### PR TITLE
feat: add webhook trigger system — HTTP + GitHub webhook → kanban task creation

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,8 @@
     "commander": "^13.0.0",
     "ora": "^8.1.0",
     "@conductor-oss/plugin-agent-gemini": "workspace:*",
-    "@conductor-oss/plugin-mcp-server": "workspace:*"
+    "@conductor-oss/plugin-mcp-server": "workspace:*",
+    "@conductor-oss/plugin-webhook": "workspace:*"
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -208,6 +208,33 @@ export function registerStart(program: Command): void {
           }
         }
 
+        // ---- Start webhook server (if enabled in config) ----
+        if (config.webhook?.enabled) {
+          const webhookSpinner = ora("Starting webhook server").start();
+          try {
+            const { createWebhookServer } = await import(
+              "@conductor-oss/plugin-webhook"
+            );
+            const webhookServer = createWebhookServer(config, config.webhook);
+            await webhookServer.start();
+            webhookSpinner.succeed(
+              `Webhook server running on port ${config.webhook.port}`,
+            );
+
+            // Add to shutdown
+            const prevSIGINT2 = process.listeners("SIGINT");
+            process.removeAllListeners("SIGINT");
+            process.on("SIGINT", () => {
+              webhookServer.stop();
+              for (const listener of prevSIGINT2) {
+                (listener as () => void)();
+              }
+            });
+          } catch (err) {
+            webhookSpinner.warn(`Webhook server failed to start: ${err}`);
+          }
+        }
+
         // ---- Summary ----
         console.log();
         console.log(chalk.bold.green("Conductor is running."));
@@ -217,6 +244,13 @@ export function registerStart(program: Command): void {
         }
         if (opts.watcher !== false) {
           console.log(chalk.dim("  Watcher:   Obsidian CONDUCTOR.md boards"));
+        }
+        if (config.webhook?.enabled) {
+          console.log(
+            chalk.dim(
+              `  Webhook:   http://localhost:${config.webhook.port}/api/webhook`,
+            ),
+          );
         }
         console.log(chalk.dim("  Press Ctrl-C to stop.\n"));
 

--- a/packages/cli/src/commands/webhook.ts
+++ b/packages/cli/src/commands/webhook.ts
@@ -1,0 +1,74 @@
+/**
+ * `co webhook`
+ *
+ * Starts the webhook server standalone — useful for testing without the full
+ * lifecycle manager and board watcher.
+ *
+ * Usage:
+ *   co webhook [--port 4748]
+ */
+
+import chalk from "chalk";
+import type { Command } from "commander";
+import { loadConfig } from "../services.js";
+
+export function registerWebhook(program: Command): void {
+  program
+    .command("webhook")
+    .description("Start webhook server standalone (HTTP + GitHub webhook → kanban task creation)")
+    .option("-p, --port <port>", "Port to listen on (default: 4748)")
+    .action(async (opts: { port?: string }) => {
+      try {
+        const config = await loadConfig();
+        const port = opts.port
+          ? parseInt(opts.port, 10)
+          : (config.webhook?.port ?? 4748);
+
+        const { createWebhookServer } = await import(
+          "@conductor-oss/plugin-webhook"
+        );
+
+        const webhookConfig = {
+          enabled: true,
+          port,
+          secret: config.webhook?.secret,
+        };
+
+        const server = createWebhookServer(config, webhookConfig);
+        await server.start();
+
+        const line = "=".repeat(50);
+        console.log(chalk.dim(line));
+        console.log(chalk.bold.cyan("  Conductor Webhook Server"));
+        console.log(chalk.dim(line));
+        console.log();
+        console.log(
+          chalk.bold.green(`Webhook server running on http://localhost:${port}`),
+        );
+        console.log();
+        console.log(
+          chalk.dim("  POST /api/webhook/task   — create task from any source"),
+        );
+        console.log(
+          chalk.dim("  POST /api/webhook/github — handle GitHub webhook events"),
+        );
+        console.log(chalk.dim("  GET  /api/webhook/health — health check"));
+        console.log(chalk.dim("  GET  /api/webhook/status — stats"));
+        console.log();
+        console.log(chalk.dim("  Press Ctrl-C to stop.\n"));
+
+        const shutdown = (): void => {
+          server.stop();
+          process.exit(0);
+        };
+        process.on("SIGINT", shutdown);
+        process.on("SIGTERM", shutdown);
+
+        // Keep process alive
+        setInterval(() => {}, 60_000);
+      } catch (err) {
+        console.error(chalk.red(`Failed to start webhook server: ${err}`));
+        process.exit(1);
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,6 +21,7 @@ import { registerStart } from "./commands/start.js";
 import { registerWatch } from "./commands/watch.js";
 import { registerInit } from "./commands/init.js";
 import { registerMcpServer } from "./commands/mcp-server.js";
+import { registerWebhook } from "./commands/webhook.js";
 
 const program = new Command();
 
@@ -42,5 +43,6 @@ registerStart(program);
 registerWatch(program);
 registerInit(program);
 registerMcpServer(program);
+registerWebhook(program);
 
 program.parse();

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -96,6 +96,12 @@ const DefaultPluginsSchema = z.object({
   mcpServers: z.record(MCPServerConfigSchema).optional(),
 });
 
+const WebhookConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  port: z.number().default(4748),
+  secret: z.string().optional(),
+});
+
 const ConductorConfigSchema = z.object({
   port: z.number().default(4747),
   terminalPort: z.number().optional(),
@@ -112,6 +118,7 @@ const ConductorConfigSchema = z.object({
     info: ["desktop"],
   }),
   reactions: z.record(ReactionConfigSchema).default({}),
+  webhook: WebhookConfigSchema.optional(),
 });
 
 // =============================================================================

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -403,6 +403,12 @@ export interface ReactionResult {
 
 // === CONFIGURATION ===
 
+export interface WebhookConfig {
+  enabled: boolean;
+  port: number;
+  secret?: string;
+}
+
 export interface OrchestratorConfig {
   configPath: string;
   port?: number;
@@ -415,6 +421,7 @@ export interface OrchestratorConfig {
   notifiers: Record<string, NotifierConfig>;
   notificationRouting: Record<EventPriority, string[]>;
   reactions: Record<string, ReactionConfig>;
+  webhook?: WebhookConfig;
 }
 
 export interface MCPServerConfig {

--- a/packages/plugins/webhook/package.json
+++ b/packages/plugins/webhook/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@conductor-oss/plugin-webhook",
+  "version": "0.1.0",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@conductor-oss/core": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/packages/plugins/webhook/src/index.ts
+++ b/packages/plugins/webhook/src/index.ts
@@ -1,0 +1,368 @@
+/**
+ * Conductor Webhook Plugin
+ *
+ * HTTP server that listens for external events and creates tasks on
+ * Obsidian CONDUCTOR.md kanban boards automatically.
+ *
+ * Endpoints:
+ *   POST /api/webhook/task   — Create a task from any source
+ *   POST /api/webhook/github — Handle GitHub webhook events
+ *   GET  /api/webhook/health — Health check
+ *   GET  /api/webhook/status — Stats (tasks created, uptime)
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { createHmac } from "node:crypto";
+import { readFileSync, writeFileSync, appendFileSync, existsSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import type { OrchestratorConfig } from "@conductor-oss/core";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface WebhookConfig {
+  enabled: boolean;
+  port: number;
+  secret?: string;
+}
+
+export interface WebhookServer {
+  start(): Promise<void>;
+  stop(): void;
+  getStats(): { tasksCreated: number; startedAt: Date };
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+    req.on("error", reject);
+  });
+}
+
+/** Constant-time HMAC-SHA256 signature verification for GitHub webhooks. */
+function verifyGitHubSignature(
+  body: string,
+  signature: string | undefined,
+  secret: string,
+): boolean {
+  if (!signature) return false;
+  const expected =
+    "sha256=" + createHmac("sha256", secret).update(body).digest("hex");
+  if (expected.length !== signature.length) return false;
+  let diff = 0;
+  for (let i = 0; i < expected.length; i++) {
+    diff |= expected.charCodeAt(i) ^ signature.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+/** Resolve the default workspace path. */
+function defaultWorkspacePath(): string {
+  return (
+    process.env["CONDUCTOR_WORKSPACE"] ??
+    join(process.env["HOME"] ?? "~", ".conductor", "workspace")
+  );
+}
+
+/**
+ * Find the best CONDUCTOR.md board path for a given project key.
+ * Falls back to the first available board, then the default workspace board.
+ */
+function findBoardPath(
+  config: OrchestratorConfig,
+  projectKey?: string,
+): string | null {
+  const workspacePath = defaultWorkspacePath();
+
+  if (projectKey) {
+    const project = config.projects[projectKey];
+    if (project) {
+      const boardDir = project.boardDir ?? projectKey;
+      const candidate = join(workspacePath, boardDir, "CONDUCTOR.md");
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+
+  // First available project board
+  for (const [key, project] of Object.entries(config.projects)) {
+    const boardDir = project.boardDir ?? key;
+    const candidate = join(workspacePath, boardDir, "CONDUCTOR.md");
+    if (existsSync(candidate)) return candidate;
+  }
+
+  // Top-level workspace board
+  const defaultBoard = join(workspacePath, "CONDUCTOR.md");
+  if (existsSync(defaultBoard)) return defaultBoard;
+
+  return null;
+}
+
+/**
+ * Insert a task line into the Inbox section of a CONDUCTOR.md board.
+ * If no "## Inbox" heading exists, one is appended.
+ */
+function addTaskToInbox(boardPath: string, task: string): void {
+  const content = readFileSync(boardPath, "utf-8");
+  const inboxIdx = content.indexOf("## Inbox");
+
+  if (inboxIdx === -1) {
+    writeFileSync(boardPath, content + `\n## Inbox\n\n- ${task}\n`);
+    return;
+  }
+
+  // Insert immediately after the "## Inbox\n" line
+  const insertAt = content.indexOf("\n", inboxIdx) + 1;
+  const newContent =
+    content.slice(0, insertAt) + `- ${task}\n` + content.slice(insertAt);
+  writeFileSync(boardPath, newContent);
+}
+
+/** Append a line to conductor.log and echo to stdout. */
+function logWebhook(message: string): void {
+  const logDir = join(process.env["HOME"] ?? ".", ".conductor");
+  const logPath = join(logDir, "conductor.log");
+  const timestamp = new Date().toISOString();
+  try {
+    mkdirSync(logDir, { recursive: true });
+    appendFileSync(logPath, `[${timestamp}] [webhook] ${message}\n`);
+  } catch {
+    /* ignore log write failures */
+  }
+  console.log(`[webhook] ${message}`);
+}
+
+function sendJson(res: ServerResponse, status: number, data: unknown): void {
+  const body = JSON.stringify(data);
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(body);
+}
+
+/** Find a project key whose repo name matches the GitHub repository name. */
+function matchProject(
+  config: OrchestratorConfig,
+  repoName: string,
+): string | undefined {
+  for (const [key, proj] of Object.entries(config.projects)) {
+    if (
+      proj.repo === repoName ||
+      proj.repo.endsWith(`/${repoName}`)
+    ) {
+      return key;
+    }
+  }
+  return undefined;
+}
+
+// =============================================================================
+// Server factory
+// =============================================================================
+
+export function createWebhookServer(
+  config: OrchestratorConfig,
+  webhookConfig: WebhookConfig,
+): WebhookServer {
+  let tasksCreated = 0;
+  const startedAt = new Date();
+
+  const server = createServer(
+    async (req: IncomingMessage, res: ServerResponse) => {
+      const url = req.url ?? "/";
+      const method = req.method ?? "GET";
+
+      try {
+        // ------------------------------------------------------------------
+        // GET /api/webhook/health
+        // ------------------------------------------------------------------
+        if (method === "GET" && url === "/api/webhook/health") {
+          sendJson(res, 200, { ok: true });
+          return;
+        }
+
+        // ------------------------------------------------------------------
+        // GET /api/webhook/status
+        // ------------------------------------------------------------------
+        if (method === "GET" && url === "/api/webhook/status") {
+          sendJson(res, 200, {
+            ok: true,
+            tasksCreated,
+            uptime: Math.floor((Date.now() - startedAt.getTime()) / 1000),
+            startedAt: startedAt.toISOString(),
+          });
+          return;
+        }
+
+        // ------------------------------------------------------------------
+        // POST /api/webhook/task — generic task creation
+        // ------------------------------------------------------------------
+        if (method === "POST" && url === "/api/webhook/task") {
+          const raw = await readBody(req);
+          let payload: {
+            task?: string;
+            project?: string;
+            agent?: string;
+            priority?: string;
+            board?: string;
+          };
+          try {
+            payload = JSON.parse(raw) as typeof payload;
+          } catch {
+            sendJson(res, 400, { ok: false, error: "Invalid JSON body" });
+            return;
+          }
+
+          if (!payload.task) {
+            sendJson(res, 400, { ok: false, error: "task field is required" });
+            return;
+          }
+
+          let taskLine = payload.task;
+          if (payload.agent) taskLine += ` #agent/${payload.agent}`;
+          if (payload.project) taskLine += ` #project/${payload.project}`;
+          if (payload.priority) taskLine += ` #priority/${payload.priority}`;
+
+          const boardPath = payload.board ?? findBoardPath(config, payload.project);
+          if (!boardPath) {
+            sendJson(res, 500, {
+              ok: false,
+              error: "No CONDUCTOR.md board found",
+            });
+            return;
+          }
+
+          addTaskToInbox(boardPath, taskLine);
+          tasksCreated++;
+          logWebhook(`Task created: "${taskLine}" -> ${boardPath}`);
+          sendJson(res, 200, { ok: true, task: taskLine, board: boardPath });
+          return;
+        }
+
+        // ------------------------------------------------------------------
+        // POST /api/webhook/github — GitHub webhook events
+        // ------------------------------------------------------------------
+        if (method === "POST" && url === "/api/webhook/github") {
+          const raw = await readBody(req);
+
+          // Verify HMAC signature when a secret is configured
+          if (webhookConfig.secret) {
+            const sig = req.headers["x-hub-signature-256"] as string | undefined;
+            if (!verifyGitHubSignature(raw, sig, webhookConfig.secret)) {
+              sendJson(res, 401, { ok: false, error: "Invalid signature" });
+              return;
+            }
+          }
+
+          const event = req.headers["x-github-event"] as string | undefined;
+          let payload: Record<string, unknown>;
+          try {
+            payload = JSON.parse(raw) as Record<string, unknown>;
+          } catch {
+            sendJson(res, 400, { ok: false, error: "Invalid JSON body" });
+            return;
+          }
+
+          const action = payload["action"] as string | undefined;
+          let taskLine: string | null = null;
+          let projectKey: string | undefined;
+
+          const repoObj = payload["repository"] as Record<string, unknown> | undefined;
+          const repoName = (repoObj?.["name"] as string | undefined) ?? "";
+          if (repoName) {
+            projectKey = matchProject(config, repoName);
+          }
+          const projectTag = projectKey ? ` #project/${projectKey}` : "";
+
+          // ---- issues.opened ----
+          if (event === "issues" && action === "opened") {
+            const issue = payload["issue"] as Record<string, unknown> | undefined;
+            const issueNum = issue?.["number"] as number | undefined;
+            const title = (issue?.["title"] as string | undefined) ?? "New issue";
+            const body = (issue?.["body"] as string | undefined) ?? "";
+
+            const issueTag = issueNum ? ` #issue/${issueNum}` : "";
+            taskLine = `${title}${issueTag}${projectTag}`;
+            if (body.trim()) {
+              const preview = body.slice(0, 200).replace(/\n+/g, " ").trim();
+              taskLine += ` — ${preview}`;
+            }
+          }
+
+          // ---- issue_comment.created with /conductor command ----
+          if (event === "issue_comment" && action === "created") {
+            const comment = payload["comment"] as Record<string, unknown> | undefined;
+            const commentBody = (comment?.["body"] as string | undefined) ?? "";
+            if (commentBody.trim().startsWith("/conductor")) {
+              const taskText = commentBody
+                .replace(/^\/conductor\s*/m, "")
+                .trim();
+              if (taskText) {
+                taskLine = `${taskText}${projectTag}`;
+              }
+            }
+          }
+
+          // ---- pull_request_review with changes_requested ----
+          if (event === "pull_request_review" && action === "submitted") {
+            const review = payload["review"] as Record<string, unknown> | undefined;
+            const state = (review?.["state"] as string | undefined)?.toLowerCase();
+            if (state === "changes_requested") {
+              const pr = payload["pull_request"] as Record<string, unknown> | undefined;
+              const prNum = pr?.["number"] as number | undefined;
+              taskLine = `Address PR review for #${prNum}${projectTag}`;
+            }
+          }
+
+          if (!taskLine) {
+            sendJson(res, 200, { ok: true, skipped: true, event, action });
+            return;
+          }
+
+          const boardPath = findBoardPath(config, projectKey);
+          if (!boardPath) {
+            sendJson(res, 500, { ok: false, error: "No CONDUCTOR.md board found" });
+            return;
+          }
+
+          addTaskToInbox(boardPath, taskLine);
+          tasksCreated++;
+          logWebhook(`GitHub ${event}/${action}: "${taskLine}" -> ${boardPath}`);
+          sendJson(res, 200, { ok: true, task: taskLine, board: boardPath });
+          return;
+        }
+
+        // 404
+        sendJson(res, 404, { ok: false, error: "Not found" });
+      } catch (err) {
+        console.error("[webhook] Unhandled error:", err);
+        sendJson(res, 500, { ok: false, error: String(err) });
+      }
+    },
+  );
+
+  return {
+    start(): Promise<void> {
+      return new Promise((resolve, reject) => {
+        server.listen(webhookConfig.port, () => {
+          logWebhook(`Listening on port ${webhookConfig.port}`);
+          resolve();
+        });
+        server.on("error", reject);
+      });
+    },
+
+    stop(): void {
+      server.close();
+      logWebhook("Server stopped");
+    },
+
+    getStats() {
+      return { tasksCreated, startedAt };
+    },
+  };
+}

--- a/packages/plugins/webhook/tsconfig.json
+++ b/packages/plugins/webhook/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@conductor-oss/plugin-tracker-github':
         specifier: workspace:*
         version: link:../plugins/tracker-github
+      '@conductor-oss/plugin-webhook':
+        specifier: workspace:*
+        version: link:../plugins/webhook
       '@conductor-oss/plugin-workspace-worktree':
         specifier: workspace:*
         version: link:../plugins/workspace-worktree
@@ -207,6 +210,19 @@ importers:
         version: 5.9.3
 
   packages/plugins/tracker-github:
+    dependencies:
+      '@conductor-oss/core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.13
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
+  packages/plugins/webhook:
     dependencies:
       '@conductor-oss/core':
         specifier: workspace:*


### PR DESCRIPTION
- Add packages/plugins/webhook (@conductor-oss/plugin-webhook) with a vanilla
  Node.js HTTP server (no Express) that exposes:
    POST /api/webhook/task   — create a task from any source
    POST /api/webhook/github — handle GitHub webhook events (issues.opened,
                               issue_comment /conductor command,
                               pull_request_review changes_requested)
    GET  /api/webhook/health — health check
    GET  /api/webhook/status — tasks created + uptime

- GitHub webhook verification uses HMAC-SHA256 (constant-time compare)
  when a secret is configured; signature is optional otherwise.

- Task creation finds the right CONDUCTOR.md board via project key → boardDir
  mapping, inserts a line into the Inbox column, and logs to conductor.log.

- Add webhook config schema to @conductor-oss/core (types + Zod):
    webhook:
      enabled: true
      port: 4748
      secret: "optional-github-webhook-secret"

- co start now starts the webhook server alongside the lifecycle manager
  and board watcher when webhook.enabled is true.

- Add standalone co webhook [--port] command for isolated testing.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added webhook server with support for GitHub events and generic webhook task creation.
  * Webhook server can be enabled in configuration with customizable port and optional secret authentication.
  * New standalone webhook CLI command for running the webhook server independently.
  * Includes health check and status monitoring endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->