### PR TITLE
feat: add per-project MCP server configuration for agents

### DIFF
--- a/conductor.example.yaml
+++ b/conductor.example.yaml
@@ -6,6 +6,18 @@ port: 4747
 # URL shown in board card links (set this to your actual dashboard URL)
 # dashboardUrl: http://localhost:4747
 
+# Optional: MCP servers available to all projects by default
+# defaults:
+#   mcpServers:
+#     filesystem:
+#       command: npx
+#       args: ["-y", "@modelcontextprotocol/server-filesystem", "/"]
+#     github:
+#       command: npx
+#       args: ["-y", "@modelcontextprotocol/server-github"]
+#       env:
+#         GITHUB_TOKEN: "${GITHUB_TOKEN}"
+
 projects:
   my-app:
     path: ~/projects/my-app        # Path to your project (must be a git repo)
@@ -17,6 +29,13 @@ projects:
     workspace: worktree            # git worktree isolation per task
     runtime: tmux                  # tmux session runner
     scm: github                    # GitHub PR/CI integration
+    # Optional: MCP servers for this project (merged with defaults, project wins)
+    # mcpServers:
+    #   postgres:
+    #     command: npx
+    #     args: ["-y", "@modelcontextprotocol/server-postgres"]
+    #     env:
+    #       DATABASE_URL: "postgresql://localhost/my_app_dev"
 
   # Add more projects:
   # backend:

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -22,6 +22,14 @@ import { generateSessionPrefix } from "./paths.js";
 // ZOD SCHEMAS
 // =============================================================================
 
+const MCPServerConfigSchema = z.object({
+  command: z.string(),
+  args: z.array(z.string()).optional(),
+  env: z.record(z.string()).optional(),
+  cwd: z.string().optional(),
+  enabled: z.boolean().optional(),
+});
+
 const ReactionConfigSchema = z.object({
   auto: z.boolean().default(true),
   action: z.enum(["send-to-agent", "notify", "auto-merge"]).default("notify"),
@@ -77,6 +85,7 @@ const ProjectConfigSchema = z.object({
   reactions: z.record(ReactionConfigSchema.partial()).optional(),
   agentRules: z.string().optional(),
   agentRulesFile: z.string().optional(),
+  mcpServers: z.record(MCPServerConfigSchema).optional(),
 });
 
 const DefaultPluginsSchema = z.object({
@@ -84,6 +93,7 @@ const DefaultPluginsSchema = z.object({
   agent: z.string().default("claude-code"),
   workspace: z.string().default("worktree"),
   notifiers: z.array(z.string()).default(["desktop"]),
+  mcpServers: z.record(MCPServerConfigSchema).optional(),
 });
 
 const ConductorConfigSchema = z.object({

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -592,6 +592,14 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
       attachments: spawnConfig.attachments,
     });
 
+    // Merge default MCP servers with project-specific ones (project overrides defaults)
+    const mergedMcpServers = {
+      ...config.defaults.mcpServers,
+      ...project.mcpServers,
+    };
+    const resolvedMcpServers =
+      Object.keys(mergedMcpServers).length > 0 ? mergedMcpServers : undefined;
+
     // Get agent launch config and create runtime -- clean up workspace on failure
     // When agent is overridden via #agent/ tag, don't leak the project's model
     // to the wrong CLI (e.g. passing claude-opus-4-6 to codex would crash).
@@ -604,10 +612,22 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
       permissions: project.agentConfig?.permissions,
       model: spawnConfig.model ?? (agentOverridden ? undefined : project.agentConfig?.model),
       attachments: spawnConfig.attachments,
+      mcpServers: resolvedMcpServers,
+      workspacePath,
     };
 
     let handle: RuntimeHandle;
     try {
+      // Set up workspace hooks (writes MCP config files, shell wrappers, etc.)
+      // Must run before getLaunchCommand so MCP config files exist when referenced.
+      if (plugins.agent.setupWorkspaceHooks) {
+        await plugins.agent.setupWorkspaceHooks(workspacePath, {
+          dataDir: sessionsDir,
+          sessionId,
+          mcpServers: resolvedMcpServers,
+        });
+      }
+
       const launchCommand = plugins.agent.getLaunchCommand(agentLaunchConfig);
       const environment = plugins.agent.getEnvironment(agentLaunchConfig);
 
@@ -1120,13 +1140,31 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
 
     // 7. Get launch command -- try restore command first, fall back to fresh launch
     let launchCommand: string;
+    const restoreMergedMcp = {
+      ...config.defaults.mcpServers,
+      ...project.mcpServers,
+    };
+    const restoreMcpServers =
+      Object.keys(restoreMergedMcp).length > 0 ? restoreMergedMcp : undefined;
+
     const agentLaunchConfig = {
       sessionId,
       projectConfig: project,
       issueId: session.issueId ?? undefined,
       permissions: project.agentConfig?.permissions,
       model: project.agentConfig?.model,
+      mcpServers: restoreMcpServers,
+      workspacePath,
     };
+
+    // Set up workspace hooks (re-writes MCP config and shell wrappers on restore)
+    if (plugins.agent.setupWorkspaceHooks) {
+      await plugins.agent.setupWorkspaceHooks(workspacePath, {
+        dataDir: sessionsDir,
+        sessionId,
+        mcpServers: restoreMcpServers,
+      });
+    }
 
     if (plugins.agent.getRestoreCommand) {
       const restoreCmd = await plugins.agent.getRestoreCommand(session, project);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -197,11 +197,17 @@ export interface AgentLaunchConfig {
   systemPromptFile?: string;
   /** Image/file attachments from the task card. */
   attachments?: TaskAttachment[];
+  /** MCP servers to configure for this session */
+  mcpServers?: Record<string, MCPServerConfig>;
+  /** Resolved workspace path for this session */
+  workspacePath?: string;
 }
 
 export interface WorkspaceHooksConfig {
   dataDir: string;
   sessionId?: string;
+  /** MCP servers to configure for this session */
+  mcpServers?: Record<string, MCPServerConfig>;
 }
 
 export interface AgentSessionInfo {
@@ -411,11 +417,20 @@ export interface OrchestratorConfig {
   reactions: Record<string, ReactionConfig>;
 }
 
+export interface MCPServerConfig {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+  enabled?: boolean;
+}
+
 export interface DefaultPlugins {
   runtime: string;
   agent: string;
   workspace: string;
   notifiers: string[];
+  mcpServers?: Record<string, MCPServerConfig>;
 }
 
 export interface ProjectConfig {
@@ -437,6 +452,8 @@ export interface ProjectConfig {
   reactions?: Record<string, Partial<ReactionConfig>>;
   agentRules?: string;
   agentRulesFile?: string;
+  /** MCP servers available to agents in this project */
+  mcpServers?: Record<string, MCPServerConfig>;
 }
 
 export interface TrackerConfig {

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -648,6 +648,12 @@ function createClaudeCodeAgent(): Agent {
         parts.push("--append-system-prompt", shellEscape(config.systemPrompt));
       }
 
+      // MCP config file written by setupWorkspaceHooks before this is called
+      if (config.workspacePath && config.mcpServers && Object.keys(config.mcpServers).length > 0) {
+        const mcpConfigPath = join(config.workspacePath, ".claude", "mcp.json");
+        parts.push("--mcp-config", shellEscape(mcpConfigPath));
+      }
+
       // NOTE: prompt is NOT included here — it's delivered post-launch via
       // runtime.sendMessage() to keep Claude in interactive mode.
 
@@ -789,10 +795,18 @@ function createClaudeCodeAgent(): Agent {
       return parts.join(" ");
     },
 
-    async setupWorkspaceHooks(workspacePath: string, _config: WorkspaceHooksConfig): Promise<void> {
+    async setupWorkspaceHooks(workspacePath: string, config: WorkspaceHooksConfig): Promise<void> {
       await ensureClaudeConfig(workspacePath);
       const hookScriptPath = join(workspacePath, ".claude", "metadata-updater.sh");
       await setupHookInWorkspace(workspacePath, hookScriptPath);
+
+      // Write MCP config file if servers are provided
+      if (config.mcpServers && Object.keys(config.mcpServers).length > 0) {
+        const claudeDir = join(workspacePath, ".claude");
+        await mkdir(claudeDir, { recursive: true });
+        const mcpConfig = { mcpServers: config.mcpServers };
+        await writeFile(join(claudeDir, "mcp.json"), JSON.stringify(mcpConfig, null, 2), "utf-8");
+      }
     },
 
     async postLaunchSetup(session: Session): Promise<void> {

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -809,8 +809,16 @@ function createCodexAgent(): Agent {
       return parts.join(" ");
     },
 
-    async setupWorkspaceHooks(workspacePath: string, _config: WorkspaceHooksConfig): Promise<void> {
+    async setupWorkspaceHooks(workspacePath: string, config: WorkspaceHooksConfig): Promise<void> {
       await setupCodexWorkspace(workspacePath);
+
+      // Write MCP config file if servers are provided
+      if (config.mcpServers && Object.keys(config.mcpServers).length > 0) {
+        const codexDir = join(workspacePath, ".codex");
+        await mkdir(codexDir, { recursive: true });
+        const mcpConfig = { mcpServers: config.mcpServers };
+        await writeFile(join(codexDir, "mcp.json"), JSON.stringify(mcpConfig, null, 2), "utf-8");
+      }
     },
 
     async postLaunchSetup(session: Session): Promise<void> {

--- a/packages/plugins/agent-gemini/src/index.ts
+++ b/packages/plugins/agent-gemini/src/index.ts
@@ -333,8 +333,22 @@ function createGeminiAgent(): Agent {
       return parts.join(" ");
     },
 
-    async setupWorkspaceHooks(workspacePath: string, _config: WorkspaceHooksConfig): Promise<void> {
+    async setupWorkspaceHooks(workspacePath: string, config: WorkspaceHooksConfig): Promise<void> {
       await setupGeminiWorkspace(workspacePath);
+
+      // Write MCP config to .gemini/settings.json if servers are provided
+      if (config.mcpServers && Object.keys(config.mcpServers).length > 0) {
+        const geminiDir = join(workspacePath, ".gemini");
+        await mkdir(geminiDir, { recursive: true });
+        const settingsPath = join(geminiDir, "settings.json");
+        let existingSettings: Record<string, unknown> = {};
+        try {
+          const content = await readFile(settingsPath, "utf-8");
+          existingSettings = JSON.parse(content) as Record<string, unknown>;
+        } catch { /* start fresh if missing or invalid */ }
+        existingSettings["mcpServers"] = config.mcpServers;
+        await writeFile(settingsPath, JSON.stringify(existingSettings, null, 2), "utf-8");
+      }
     },
 
     async postLaunchSetup(session: Session): Promise<void> {


### PR DESCRIPTION
- Add MCPServerConfig interface and extend ProjectConfig, DefaultPlugins,
  AgentLaunchConfig, and WorkspaceHooksConfig in types.ts
- Add Zod schema for MCPServerConfig validation in config.ts
- Wire session-manager to merge defaults+project mcpServers, call
  setupWorkspaceHooks before getLaunchCommand, and pass workspacePath+
  mcpServers through AgentLaunchConfig (both spawn and restore paths)
- Claude Code: write .claude/mcp.json in setupWorkspaceHooks, pass
  --mcp-config flag in getLaunchCommand when mcpServers provided
- Codex: write .codex/mcp.json in setupWorkspaceHooks
- Gemini: write .gemini/settings.json in setupWorkspaceHooks
- Update conductor.example.yaml with commented MCP config examples

Merge order: defaults → project (project overrides defaults)
mcpServers is optional everywhere; no existing behavior is changed.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
