### PR TITLE
docs: add repository links section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Write tasks in a kanban board — Conductor dispatches agents, manages git workt
 
 </div>
 
+## Repository Links
+
+- GitHub Repository: https://github.com/charannyk06/conductor-oss
+- Issues: https://github.com/charannyk06/conductor-oss/issues
+- Pull Requests: https://github.com/charannyk06/conductor-oss/pulls
+- CI: https://github.com/charannyk06/conductor-oss/actions/workflows/ci.yml
+- NPM Package: https://www.npmjs.com/package/conductor-oss
+
 ---
 
 ## What is Conductor?


### PR DESCRIPTION
## Summary
- Adds an explicit Repository Links section to README with links to the Conductor OSS GitHub repo, issues, PRs, CI workflow, and npm package.

## Why
The README had badges and some repository references, but this makes discoverability of key Git endpoints explicit in one place.

## Verification
- Confirmed  now includes the new links section and commit is on branch .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Repository Links" section to the README with quick access to the GitHub repository, issues tracker, pull requests, CI workflow, and NPM package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->