### PR TITLE
docs: keep README Demo section expanded by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ It runs entirely on your machine. No cloud. No database. No SaaS subscription.
 
 ## Demo
 
-<details>
+<details open>
 <summary><strong>Watch the 5-minute end-to-end demo</strong> — task → agent → PR → board update</summary>
 
 <br>


### PR DESCRIPTION
## Summary
- Make the README Demo section always expanded by default for immediate visibility.

## Change
- Updated `README.md` `<details>` tag to `<details open>` in the Demo section.

## Notes
- Keeps all existing GIF links and video link intact.
