### PR TITLE
docs: restore original centered full demo video size

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,12 @@ Agent commits, pushes, opens a PR — board card updates with PR link.
 
 📹 Full demo (5 min)
 
-<video controls width="100%" style="max-width: 800px;" preload="metadata">
-  <source src="docs/demo/full-demo.mp4" type="video/mp4" />
-  Your browser does not support the video tag.
-</video>
+<p align="center">
+  <video controls width="100%" style="max-width: 800px;" preload="metadata">
+    <source src="docs/demo/full-demo.mp4" type="video/mp4" />
+    Your browser does not support the video tag.
+  </video>
+</p>
 
 
 </details>


### PR DESCRIPTION
Reapply the original inline full-demo video block with centered layout and capped width so it renders like the initial stable README version and stays in-page.