### PR TITLE
docs: fix demo media and PR overview GIF

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,16 +104,7 @@ Agent commits, pushes, opens a PR — board card updates with PR link.
 
 📹 Full demo (5 min)
 
-<<<<<<< HEAD
 [Watch full demo (5 min)](docs/demo/full-demo.mp4)
-=======
-<p align="center">
-  <video controls playsinline width="200" style="width: 200px; max-width: 100%; height: auto;" preload="metadata">
-    <source src="docs/demo/full-demo.mp4" type="video/mp4" />
-    Your browser does not support the video tag.
-  </video>
-</p>
->>>>>>> origin/main
 
 
 </details>


### PR DESCRIPTION
Keep README demo section media accurate: corrected PR creation GIF from real flow and replaced unreliable embedded full demo video with direct link so it is always accessible.