### PR TITLE
docs: inline full demo video in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,16 +104,12 @@ Agent commits, pushes, opens a PR — board card updates with PR link.
 
 📹 Full demo (5 min)
 
-<<<<<<< HEAD
 <p align="center">
   <video controls width="200" style="max-width: 100%; height: auto;" preload="metadata">
     <source src="https://github.com/charannyk06/conductor-oss/raw/main/docs/demo/full-demo.mp4" type="video/mp4" />
     Your browser does not support the video tag.
   </video>
 </p>
-=======
-[Watch full demo (5 min)](docs/demo/full-demo.mp4)
->>>>>>> origin/main
 
 
 


### PR DESCRIPTION
Replace full demo link with inline video embed so playback stays in-place in README.