### PR TITLE
fix: restore full-demo inline video src in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,7 @@ Agent commits, pushes, opens a PR — board card updates with PR link.
 📹 Full demo (5 min)
 
 <p align="center">
-  <video controls width="640" style="width: 100%; max-width: 640px; height: auto;" preload="metadata">
-    <source src="docs/demo/full-demo.mp4" type="video/mp4" />
-    Your browser does not support the video tag.
-  </video>
+  <video controls width="640" style="width: 100%; max-width: 640px; height: auto;" src="docs/demo/full-demo.mp4"></video>
 </p>
 
 


### PR DESCRIPTION
Restore the inline full demo player to a single video tag with src so GitHub renders it instead of an empty block.