### PR TITLE
docs: keep inline full-demo video compact

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Agent commits, pushes, opens a PR — board card updates with PR link.
 📹 Full demo (5 min)
 
 <p align="center">
-  <video controls width="640" style="width: 100%; max-width: 640px; height: auto;" src="docs/demo/full-demo.mp4"></video>
+  <video controls width="100%" style="width: 100%; max-width: 640px; height: auto;" src="docs/demo/full-demo.mp4"></video>
 </p>
 
 


### PR DESCRIPTION
Keep full demo video embedded inline with direct src and use responsive width to avoid oversized rendering in README.