### PR TITLE
docs: fix full demo inline playback via jsDelivr

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Agent commits, pushes, opens a PR — board card updates with PR link.
 📹 Full demo (5 min)
 
 <p align="center">
-  <video controls width="100%" style="width: 100%; max-width: 640px; height: auto;" src="docs/demo/full-demo.mp4"></video>
+  <video controls width="100%" style="width: 100%; max-width: 640px; height: auto;" src="https://cdn.jsdelivr.net/gh/charannyk06/conductor-oss@main/docs/demo/full-demo.mp4"></video>
 </p>
 
 


### PR DESCRIPTION
Use jsDelivr-hosted mp4 URL with video src to avoid GitHub raw content-type being application/octet-stream, which caused empty/unsupported inline player.