### PR TITLE
fix: comprehensive mobile view improvements

### DIFF
--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { ClerkProvider } from "@clerk/nextjs";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import "./globals.css";
@@ -6,6 +6,12 @@ import "./globals.css";
 export const metadata: Metadata = {
   title: "Conductor",
   description: "Multi-agent orchestrator dashboard",
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 1,
 };
 
 function Shell({ children }: { children: React.ReactNode }) {

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -20,6 +20,7 @@ export default function SessionDetailPage() {
   const [sentFeedback, setSentFeedback] = useState<string | null>(null);
   const [killInProgress, setKillInProgress] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [metaSheetOpen, setMetaSheetOpen] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
   const fetchSession = useCallback(async () => {
@@ -157,22 +158,22 @@ export default function SessionDetailPage() {
   return (
     <div className="flex h-dvh flex-col overflow-hidden bg-[var(--color-bg-base)]">
       {/* Header bar */}
-      <header className="flex items-center gap-3 border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] px-4 py-2.5">
+      <header className="flex items-center gap-2 border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] px-3 py-2.5 min-w-0">
         <button
           onClick={() => router.push("/")}
-          className="rounded-md p-1 text-[var(--color-text-muted)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-primary)] transition-colors"
+          className="shrink-0 rounded-md p-1 text-[var(--color-text-muted)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-primary)] transition-colors"
         >
           <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
             <path d="M7.78 12.53a.75.75 0 01-1.06 0L2.47 8.28a.75.75 0 010-1.06l4.25-4.25a.75.75 0 011.06 1.06L4.81 7h7.44a.75.75 0 010 1.5H4.81l2.97 2.97a.75.75 0 010 1.06z" />
           </svg>
         </button>
 
-        <span className="font-mono text-[13px] font-semibold text-[var(--color-text-primary)]">
+        <span className="font-mono text-[13px] font-semibold text-[var(--color-text-primary)] truncate min-w-0">
           {sessionId}
         </span>
 
         {session?.metadata?.agent && (
-          <span className="rounded bg-[var(--color-accent-subtle)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--color-accent)]">
+          <span className="hidden sm:inline shrink-0 rounded bg-[var(--color-accent-subtle)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--color-accent)]">
             {session.metadata.agent}
           </span>
         )}
@@ -184,7 +185,7 @@ export default function SessionDetailPage() {
             href={session.pr.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-[11px] text-[var(--color-accent)] hover:underline"
+            className="hidden sm:block shrink-0 text-[11px] text-[var(--color-accent)] hover:underline"
           >
             PR #{session.pr.number}
           </a>
@@ -192,9 +193,21 @@ export default function SessionDetailPage() {
 
         <div className="flex-1" />
 
+        {session && (
+          <button
+            onClick={() => setMetaSheetOpen((v) => !v)}
+            className="shrink-0 rounded-md border border-[var(--color-border-default)] p-1.5 text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-secondary)] lg:hidden"
+            title="Session details"
+          >
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M0 1.75A.75.75 0 01.75 1h14.5a.75.75 0 010 1.5H.75A.75.75 0 010 1.75zm0 5A.75.75 0 01.75 6h14.5a.75.75 0 010 1.5H.75A.75.75 0 010 6.75zm0 5a.75.75 0 01.75-.75h7a.75.75 0 010 1.5h-7a.75.75 0 01-.75-.75z"/>
+            </svg>
+          </button>
+        )}
+
         <button
           onClick={toggleTheme}
-          className="rounded-md border border-[var(--color-border-default)] p-1.5 text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-secondary)]"
+          className="shrink-0 rounded-md border border-[var(--color-border-default)] p-1.5 text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-secondary)]"
           title={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
         >
           {theme === "dark" ? (
@@ -211,7 +224,7 @@ export default function SessionDetailPage() {
         <button
           onClick={() => void handleKill()}
           disabled={killInProgress}
-          className={`rounded-md border border-[rgba(239,68,68,0.3)] px-2.5 py-1 text-[11px] font-medium text-[var(--color-status-error)] transition-colors hover:bg-[rgba(239,68,68,0.08)] ${
+          className={`shrink-0 rounded-md border border-[rgba(239,68,68,0.3)] px-2.5 py-1 text-[11px] font-medium text-[var(--color-status-error)] transition-colors hover:bg-[rgba(239,68,68,0.08)] ${
             killInProgress ? "cursor-wait opacity-50" : ""
           }`}
           title={actionError ?? `${action} this session`}
@@ -226,6 +239,39 @@ export default function SessionDetailPage() {
         </div>
       )}
 
+      {/* Mobile metadata bottom sheet */}
+      {session && metaSheetOpen && (
+        <>
+          <div
+            className="fixed inset-0 z-40 bg-black/40 lg:hidden"
+            onClick={() => setMetaSheetOpen(false)}
+          />
+          <div className="fixed inset-x-0 bottom-0 z-50 max-h-[75dvh] overflow-y-auto rounded-t-2xl border-t border-[var(--color-border-default)] bg-[var(--color-bg-surface)] lg:hidden">
+            <div className="sticky top-0 flex items-center justify-between border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] px-4 py-3">
+              <span className="text-[13px] font-semibold text-[var(--color-text-primary)]">Session Details</span>
+              <button
+                onClick={() => setMetaSheetOpen(false)}
+                className="rounded-md p-1 text-[var(--color-text-muted)] hover:bg-[var(--color-bg-elevated)]"
+              >
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+                  <path d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z" />
+                </svg>
+              </button>
+            </div>
+            <MetaSidebarContent
+              session={session}
+              attentionLevel={attentionLevel}
+              meta={meta}
+              cost={cost}
+              createdDate={createdDate}
+              lastActivityDate={lastActivityDate}
+              durationMs={durationMs}
+              isTerminal={isTerminal}
+            />
+          </div>
+        </>
+      )}
+
       {/* Main content: Terminal + Metadata sidebar */}
       <div className="flex flex-1 min-h-0 overflow-hidden">
         {/* Terminal area */}
@@ -233,180 +279,19 @@ export default function SessionDetailPage() {
           <TerminalView sessionId={sessionId} />
         </div>
 
-        {/* Metadata sidebar */}
+        {/* Metadata sidebar — desktop only */}
         {session && (
           <aside className="hidden w-72 shrink-0 border-l border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] overflow-y-auto lg:block">
-            <div className="p-4 space-y-5">
-              {/* Summary */}
-              {session.summary && (
-                <MetaSection label="Summary">
-                  <p className="text-[12px] leading-relaxed text-[var(--color-text-secondary)]">
-                    {session.summary}
-                  </p>
-                </MetaSection>
-              )}
-
-              {/* Status */}
-              <MetaSection label="Status">
-                <div className="space-y-2">
-                  <MetaRow label="Status" value={session.status.replace(/_/g, " ")} />
-                  <MetaRow label="Activity" value={session.activity ?? "-"} />
-                  <MetaRow label="Attention" value={attentionLevel} />
-                </div>
-              </MetaSection>
-
-              {/* Agent */}
-              <MetaSection label="Agent">
-                <MetaRow label="Type" value={meta["agent"] ?? "-"} />
-                {meta["model"] && <MetaRow label="Model" value={meta["model"]} />}
-              </MetaSection>
-
-              {/* Git */}
-              {(session.branch || meta["worktree"]) && (
-                <MetaSection label="Git">
-                  {session.branch && (
-                    <div className="text-[11px] font-mono text-[var(--color-text-secondary)] break-all">
-                      {session.branch}
-                    </div>
-                  )}
-                  {meta["worktree"] && (
-                    <div className="text-[11px] font-mono text-[var(--color-text-muted)] truncate mt-1">
-                      {meta["worktree"]}
-                    </div>
-                  )}
-                </MetaSection>
-              )}
-
-              {/* PR */}
-              {session.pr && (
-                <MetaSection label="Pull Request">
-                  <a
-                    href={session.pr.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-[12px] font-medium text-[var(--color-accent)] hover:underline block mb-2"
-                  >
-                    #{session.pr.number} — {session.pr.title}
-                  </a>
-                  <div className="space-y-1.5">
-                    <MetaRow label="State" value={session.pr.state} />
-                    <ColoredMetaRow
-                      label="CI"
-                      value={session.pr.ciStatus}
-                      status={session.pr.ciStatus === "passing" ? "green" : session.pr.ciStatus === "failing" ? "red" : "amber"}
-                    />
-                    <ColoredMetaRow
-                      label="Review"
-                      value={session.pr.reviewDecision.replace(/_/g, " ")}
-                      status={session.pr.reviewDecision === "approved" ? "green" : session.pr.reviewDecision === "changes_requested" ? "red" : "amber"}
-                    />
-                    <MetaRow
-                      label="Mergeable"
-                      value={session.pr.mergeability.mergeable ? "Yes" : "No"}
-                    />
-                  </div>
-
-                  {/* Links */}
-                  <div className="mt-2 space-y-1">
-                    {session.pr.previewUrl && (
-                      <a
-                        href={session.pr.previewUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="flex items-center gap-1 text-[11px] text-[var(--color-accent)] hover:underline"
-                      >
-                        <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-                        Preview Deploy
-                      </a>
-                    )}
-                    <a
-                      href={`${session.pr.url}/checks`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center gap-1 text-[11px] text-[var(--color-text-secondary)] hover:underline hover:text-[var(--color-text-primary)]"
-                    >
-                      View CI Checks ↗
-                    </a>
-                    <a
-                      href={`${session.pr.url}#pullrequestreview`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center gap-1 text-[11px] text-[var(--color-text-secondary)] hover:underline hover:text-[var(--color-text-primary)]"
-                    >
-                      View Reviews ↗
-                    </a>
-                  </div>
-
-                  {session.pr.mergeability.blockers.length > 0 && (
-                    <div className="mt-2 rounded-md bg-[rgba(239,68,68,0.06)] border border-[rgba(239,68,68,0.15)] p-2">
-                      <div className="text-[10px] font-semibold text-[var(--color-status-error)] mb-1">Blockers</div>
-                      {session.pr.mergeability.blockers.map((b, i) => (
-                        <div key={i} className="text-[11px] text-[var(--color-text-secondary)]">
-                          {b}
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </MetaSection>
-              )}
-
-              {/* Cost */}
-              {cost && (
-                <MetaSection label="Cost">
-                  <div className="space-y-1.5">
-                    {(cost.estimatedCostUsd ?? cost.totalUSD) != null && (
-                      <MetaRow
-                        label="Total"
-                        value={`$${((cost.estimatedCostUsd ?? cost.totalUSD) as number).toFixed(4)}`}
-                      />
-                    )}
-                    {cost.inputTokens != null && (
-                      <MetaRow label="Input" value={cost.inputTokens.toLocaleString()} />
-                    )}
-                    {cost.outputTokens != null && (
-                      <MetaRow label="Output" value={cost.outputTokens.toLocaleString()} />
-                    )}
-                  </div>
-                </MetaSection>
-              )}
-
-              {/* Timing */}
-              <MetaSection label="Timing">
-                <div className="space-y-1.5">
-                  <MetaRow label="Created" value={formatTimestamp(createdDate)} />
-                  <MetaRow label="Last Active" value={formatTimestamp(lastActivityDate)} />
-                  <MetaRow label="Duration" value={formatDuration(durationMs)} />
-                </div>
-              </MetaSection>
-
-              {/* Timeline */}
-              <MetaSection label="Timeline">
-                <div className="relative pl-4 border-l border-[var(--color-border-default)]">
-                  <TimelineEvent
-                    label="Created"
-                    time={formatTimestamp(createdDate)}
-                    color="var(--color-accent)"
-                  />
-                  {session.pr && (
-                    <TimelineEvent
-                      label="PR opened"
-                      time={`#${session.pr.number}`}
-                      color="var(--color-accent-violet)"
-                    />
-                  )}
-                  <TimelineEvent
-                    label={session.status.replace(/_/g, " ")}
-                    time={formatTimestamp(lastActivityDate)}
-                    color={
-                      isTerminal
-                        ? "var(--color-text-muted)"
-                        : "var(--color-status-working)"
-                    }
-                    active={!isTerminal}
-                  />
-                </div>
-              </MetaSection>
-            </div>
+            <MetaSidebarContent
+              session={session}
+              attentionLevel={attentionLevel}
+              meta={meta}
+              cost={cost}
+              createdDate={createdDate}
+              lastActivityDate={lastActivityDate}
+              durationMs={durationMs}
+              isTerminal={isTerminal}
+            />
           </aside>
         )}
       </div>
@@ -489,6 +374,193 @@ export default function SessionDetailPage() {
           </span>
         </div>
       )}
+    </div>
+  );
+}
+
+interface MetaSidebarContentProps {
+  session: DashboardSession;
+  attentionLevel: string;
+  meta: Record<string, string>;
+  cost: { inputTokens?: number; outputTokens?: number; estimatedCostUsd?: number; totalUSD?: number } | null;
+  createdDate: Date;
+  lastActivityDate: Date;
+  durationMs: number;
+  isTerminal: boolean;
+}
+
+function MetaSidebarContent({ session, attentionLevel, meta, cost, createdDate, lastActivityDate, durationMs, isTerminal }: MetaSidebarContentProps) {
+  return (
+    <div className="p-4 space-y-5">
+      {/* Summary */}
+      {session.summary && (
+        <MetaSection label="Summary">
+          <p className="text-[12px] leading-relaxed text-[var(--color-text-secondary)]">
+            {session.summary}
+          </p>
+        </MetaSection>
+      )}
+
+      {/* Status */}
+      <MetaSection label="Status">
+        <div className="space-y-2">
+          <MetaRow label="Status" value={session.status.replace(/_/g, " ")} />
+          <MetaRow label="Activity" value={session.activity ?? "-"} />
+          <MetaRow label="Attention" value={attentionLevel} />
+        </div>
+      </MetaSection>
+
+      {/* Agent */}
+      <MetaSection label="Agent">
+        <MetaRow label="Type" value={meta["agent"] ?? "-"} />
+        {meta["model"] && <MetaRow label="Model" value={meta["model"]} />}
+      </MetaSection>
+
+      {/* Git */}
+      {(session.branch || meta["worktree"]) && (
+        <MetaSection label="Git">
+          {session.branch && (
+            <div className="text-[11px] font-mono text-[var(--color-text-secondary)] break-all">
+              {session.branch}
+            </div>
+          )}
+          {meta["worktree"] && (
+            <div className="text-[11px] font-mono text-[var(--color-text-muted)] truncate mt-1">
+              {meta["worktree"]}
+            </div>
+          )}
+        </MetaSection>
+      )}
+
+      {/* PR */}
+      {session.pr && (
+        <MetaSection label="Pull Request">
+          <a
+            href={session.pr.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[12px] font-medium text-[var(--color-accent)] hover:underline block mb-2"
+          >
+            #{session.pr.number} — {session.pr.title}
+          </a>
+          <div className="space-y-1.5">
+            <MetaRow label="State" value={session.pr.state} />
+            <ColoredMetaRow
+              label="CI"
+              value={session.pr.ciStatus}
+              status={session.pr.ciStatus === "passing" ? "green" : session.pr.ciStatus === "failing" ? "red" : "amber"}
+            />
+            <ColoredMetaRow
+              label="Review"
+              value={session.pr.reviewDecision.replace(/_/g, " ")}
+              status={session.pr.reviewDecision === "approved" ? "green" : session.pr.reviewDecision === "changes_requested" ? "red" : "amber"}
+            />
+            <MetaRow
+              label="Mergeable"
+              value={session.pr.mergeability.mergeable ? "Yes" : "No"}
+            />
+          </div>
+
+          {/* Links */}
+          <div className="mt-2 space-y-1">
+            {session.pr.previewUrl && (
+              <a
+                href={session.pr.previewUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1 text-[11px] text-[var(--color-accent)] hover:underline"
+              >
+                <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+                Preview Deploy
+              </a>
+            )}
+            <a
+              href={`${session.pr.url}/checks`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 text-[11px] text-[var(--color-text-secondary)] hover:underline hover:text-[var(--color-text-primary)]"
+            >
+              View CI Checks ↗
+            </a>
+            <a
+              href={`${session.pr.url}#pullrequestreview`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 text-[11px] text-[var(--color-text-secondary)] hover:underline hover:text-[var(--color-text-primary)]"
+            >
+              View Reviews ↗
+            </a>
+          </div>
+
+          {session.pr.mergeability.blockers.length > 0 && (
+            <div className="mt-2 rounded-md bg-[rgba(239,68,68,0.06)] border border-[rgba(239,68,68,0.15)] p-2">
+              <div className="text-[10px] font-semibold text-[var(--color-status-error)] mb-1">Blockers</div>
+              {session.pr.mergeability.blockers.map((b: string, i: number) => (
+                <div key={i} className="text-[11px] text-[var(--color-text-secondary)]">
+                  {b}
+                </div>
+              ))}
+            </div>
+          )}
+        </MetaSection>
+      )}
+
+      {/* Cost */}
+      {cost && (
+        <MetaSection label="Cost">
+          <div className="space-y-1.5">
+            {(cost.estimatedCostUsd ?? cost.totalUSD) != null && (
+              <MetaRow
+                label="Total"
+                value={`$${((cost.estimatedCostUsd ?? cost.totalUSD) as number).toFixed(4)}`}
+              />
+            )}
+            {cost.inputTokens != null && (
+              <MetaRow label="Input" value={cost.inputTokens.toLocaleString()} />
+            )}
+            {cost.outputTokens != null && (
+              <MetaRow label="Output" value={cost.outputTokens.toLocaleString()} />
+            )}
+          </div>
+        </MetaSection>
+      )}
+
+      {/* Timing */}
+      <MetaSection label="Timing">
+        <div className="space-y-1.5">
+          <MetaRow label="Created" value={formatTimestamp(createdDate)} />
+          <MetaRow label="Last Active" value={formatTimestamp(lastActivityDate)} />
+          <MetaRow label="Duration" value={formatDuration(durationMs)} />
+        </div>
+      </MetaSection>
+
+      {/* Timeline */}
+      <MetaSection label="Timeline">
+        <div className="relative pl-4 border-l border-[var(--color-border-default)]">
+          <TimelineEvent
+            label="Created"
+            time={formatTimestamp(createdDate)}
+            color="var(--color-accent)"
+          />
+          {session.pr && (
+            <TimelineEvent
+              label="PR opened"
+              time={`#${session.pr.number}`}
+              color="var(--color-accent-violet)"
+            />
+          )}
+          <TimelineEvent
+            label={session.status.replace(/_/g, " ")}
+            time={formatTimestamp(lastActivityDate)}
+            color={
+              isTerminal
+                ? "var(--color-text-muted)"
+                : "var(--color-status-working)"
+            }
+            active={!isTerminal}
+          />
+        </div>
+      </MetaSection>
     </div>
   );
 }

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -37,7 +37,7 @@ export function Dashboard({ sessions: initialSessions, stats: initialStats, conf
   const [configProjects, setConfigProjects] = useState<ConfigProject[]>(initialConfigProjects);
   const [connected, setConnected] = useState(false);
   const [activeProject, setActiveProject] = useState<string | null>(null);
-  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
   const [busySessionId, setBusySessionId] = useState<string | null>(null);
   const [bulkBusy, setBulkBusy] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -53,6 +53,13 @@ export function Dashboard({ sessions: initialSessions, stats: initialStats, conf
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const commandInputRef = useRef<HTMLInputElement | null>(null);
   const { theme, toggleTheme } = useTheme();
+
+  // Open sidebar by default on desktop after mount (avoids SSR hydration mismatch)
+  useEffect(() => {
+    if (window.innerWidth >= 768) {
+      setSidebarOpen(true);
+    }
+  }, []);
 
   // SSE connection for live updates
   // Fetch all configured projects for sidebar (even with 0 sessions)
@@ -517,9 +524,17 @@ export function Dashboard({ sessions: initialSessions, stats: initialStats, conf
 
   return (
     <div className="flex h-dvh overflow-hidden">
-      {/* Sidebar */}
+      {/* Mobile sidebar backdrop */}
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 z-30 bg-black/40 md:hidden"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
+
+      {/* Sidebar — overlay on mobile, push on desktop */}
       <aside
-        className={`shrink-0 border-r border-[var(--color-sidebar-border)] bg-[var(--color-sidebar-bg)] flex flex-col transition-all duration-200 ${
+        className={`flex flex-col border-r border-[var(--color-sidebar-border)] bg-[var(--color-sidebar-bg)] transition-all duration-200 z-40 max-md:fixed max-md:inset-y-0 max-md:left-0 max-md:h-full md:shrink-0 ${
           sidebarOpen ? "w-60" : "w-0 overflow-hidden border-r-0"
         }`}
       >
@@ -603,7 +618,7 @@ export function Dashboard({ sessions: initialSessions, stats: initialStats, conf
       {/* Main content */}
       <div className="flex flex-1 flex-col min-w-0">
         {/* Header */}
-        <header className="flex items-center gap-4 border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] px-6 py-3">
+        <header className="flex items-center gap-2 md:gap-4 border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] px-3 md:px-6 py-3">
           {/* Sidebar toggle */}
           <button
             onClick={() => setSidebarOpen(!sidebarOpen)}
@@ -693,12 +708,12 @@ export function Dashboard({ sessions: initialSessions, stats: initialStats, conf
           </button>
         </header>
         {actionError && (
-          <div className="mx-6 mt-3 rounded-md border border-[rgba(239,68,68,0.25)] bg-[rgba(239,68,68,0.12)] px-3 py-2 text-[11px] text-[var(--color-status-error)]">
+          <div className="mx-3 md:mx-6 mt-3 rounded-md border border-[rgba(239,68,68,0.25)] bg-[rgba(239,68,68,0.12)] px-3 py-2 text-[11px] text-[var(--color-status-error)]">
             {actionError}
           </div>
         )}
 
-        <section className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] px-6 py-3">
+        <section className="border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] px-3 md:px-6 py-3">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
             <div className="flex min-w-0 flex-1 items-center gap-2">
               <input
@@ -711,7 +726,7 @@ export function Dashboard({ sessions: initialSessions, stats: initialStats, conf
               />
             </div>
 
-            <div className="flex flex-wrap items-center gap-2">
+            <div className="flex items-center gap-2 overflow-x-auto scrollbar-none flex-nowrap pb-0.5">
               <select
                 value={statusFilter}
                 onChange={(event) => setStatusFilter(event.target.value as StatusFilter)}
@@ -781,7 +796,7 @@ export function Dashboard({ sessions: initialSessions, stats: initialStats, conf
         </section>
 
         {/* Content */}
-        <main className="flex-1 overflow-auto p-6">
+        <main className="flex-1 overflow-auto p-3 md:p-6">
           {filteredSessions.length === 0 ? (
             <EmptyState />
           ) : viewMode === "lanes" ? (


### PR DESCRIPTION
## Summary

- **Dashboard sidebar**: starts closed on mobile, opens automatically on desktop; uses fixed overlay + dimmed backdrop on mobile (push layout on desktop ≥768px)
- **Dashboard padding**: header, filter section, and main content reduce from `px-6`/`p-6` to `px-3`/`p-3` on mobile
- **Filter controls**: scroll horizontally on mobile (`flex-nowrap overflow-x-auto`) instead of wrapping awkwardly
- **Session detail header**: session ID now truncates instead of overflowing; agent badge and PR link hidden on mobile to save space
- **Session detail metadata**: new "details" icon button on mobile opens session metadata as a slide-up bottom sheet (75dvh, scrollable); desktop sidebar unchanged
- **Shared component**: extracted `MetaSidebarContent` so mobile sheet and desktop sidebar render the same data
- **Viewport meta**: added proper `width=device-width, initial-scale=1, maximum-scale=1` via Next.js `Viewport` export

## Test plan

- [ ] Open dashboard on mobile viewport (375px): sidebar should be hidden, tapping hamburger opens it as overlay with backdrop
- [ ] Open dashboard on desktop (1280px): sidebar should be open by default as push layout
- [ ] Check filter controls scroll horizontally on narrow screens
- [ ] Open a session detail page on mobile: header should not overflow
- [ ] Tap the info icon in session detail header on mobile: bottom sheet opens with full metadata
- [ ] Desktop session detail: right sidebar still visible, info button hidden

Closes #<!-- issue number if any -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)