### PR TITLE
docs: reorganize repository links and add cropped walkthrough media

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,6 @@ Write tasks in a kanban board — Conductor dispatches agents, manages git workt
 
 </div>
 
-## Repository Links
-
-- GitHub Repository: https://github.com/charannyk06/conductor-oss
-- Issues: https://github.com/charannyk06/conductor-oss/issues
-- Pull Requests: https://github.com/charannyk06/conductor-oss/pulls
-- CI: https://github.com/charannyk06/conductor-oss/actions/workflows/ci.yml
-- NPM Package: https://www.npmjs.com/package/conductor-oss
-
----
-
 ## What is Conductor?
 
 Conductor turns your markdown kanban board into a fully autonomous AI development pipeline. Write a task in plain English, tag it with an agent and project, drag it to **Ready to Dispatch** — and Conductor handles everything else: spawning the agent in an isolated git worktree, streaming live output to a web dashboard, opening a pull request, watching CI, and updating your board card with the result.
@@ -49,6 +39,16 @@ It runs entirely on your machine. No cloud. No database. No SaaS subscription.
 | PR lifecycle | Manual | Partial | **Full: open → CI → review → merge** |
 | Database required | — | Often | **Never — flat files only** |
 | Cost | Subscription | Subscription | **Free + your API keys** |
+
+---
+
+## Repository Links
+
+- GitHub Repository: https://github.com/charannyk06/conductor-oss
+- Issues: https://github.com/charannyk06/conductor-oss/issues
+- Pull Requests: https://github.com/charannyk06/conductor-oss/pulls
+- CI: https://github.com/charannyk06/conductor-oss/actions/workflows/ci.yml
+- NPM Package: https://www.npmjs.com/package/conductor-oss
 
 ---
 


### PR DESCRIPTION
## Summary
- Removed old Visual Dashboard Guide (Puppeteer capture) section.
- Moved Repository Links section above demo assets.
- Added new cropped demo walkthrough clips and timing annotations from the provided March 01 5:13 recording in .
- Refreshed full-demo media outputs.

## Testing / notes
- Not run (docs-only changes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with reorganized repository links section for improved accessibility.
  * Enhanced Demo section with expanded flow capture details and updated subsections.
  * Removed Visual Dashboard Guide section.
  * Minor content restructuring for improved document organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->