### PR TITLE
fix(web): use serverExternalPackages for Next.js 16 Turbopack build

### DIFF
--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@conductor-oss/core"],
+  serverExternalPackages: ["@conductor-oss/core"],
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Problem
Dashboard returns Internal Server Error on fresh builds with Next.js 16 (Turbopack).

`transpilePackages: ["@conductor-oss/core"]` conflicts with node: imports (`node:fs`, `node:child_process`) used in API routes like `/api/sessions/[id]/diff`, `/api/sessions/[id]/checks`, etc.

## Fix
Replace `transpilePackages` with `serverExternalPackages` in `next.config.ts`. This tells Turbopack to treat `@conductor-oss/core` as an external server-side dependency, avoiding the node: import resolution failure.

## Verified
- `pnpm build` succeeds — all 19 routes compile
- Dashboard returns 200 on `:4747`
- No regressions in API routes