### PR TITLE
fix(web): show sidebar project icons always visible with brand colors

### DIFF
--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -1680,16 +1680,16 @@ export function Dashboard({ sessions: initialSessions, stats: initialStats, conf
                     {project.count}
                   </span>
                 </button>
-                {/* Quick-action icons shown on hover */}
-                <div className="absolute right-2 top-1/2 -translate-y-1/2 hidden flex items-center gap-1.5 opacity-0 transition-opacity group-hover:flex group-hover:opacity-100">
+                {/* Quick-action icons — always visible */}
+                <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1">
                   <a href={obsidianUrl} title="Open board in Obsidian" onClick={(e) => e.stopPropagation()}
-                     className="rounded-full border border-transparent bg-[rgba(74,222,128,0.14)] p-1 text-[var(--color-text-primary)] transition-all hover:border-[var(--color-border-default)] hover:bg-[rgba(74,222,128,0.28)] hover:text-[#6D9B6D]">
-                    <ObsidianLogo className="h-3 w-3" />
+                     className="inline-flex items-center justify-center rounded-md p-1 text-[#7C3AED] transition-colors hover:bg-[rgba(124,58,237,0.15)]">
+                    <ObsidianLogo className="h-[18px] w-[18px]" />
                   </a>
                   {githubUrl && (
                     <a href={githubUrl} target="_blank" rel="noopener noreferrer" title="Open repo on GitHub" onClick={(e) => e.stopPropagation()}
-                       className="rounded-full border border-transparent bg-[rgba(15,23,42,0.2)] p-1 text-[var(--color-text-primary)] transition-all hover:border-[var(--color-border-default)] hover:bg-[rgba(15,23,42,0.4)] hover:text-[#181717]">
-                    <GitHubLogo className="h-3 w-3" />
+                       className="inline-flex items-center justify-center rounded-md p-1 text-[#181717] dark:text-[#e6edf3] transition-colors hover:bg-[rgba(0,0,0,0.1)] dark:hover:bg-[rgba(255,255,255,0.1)]">
+                      <GitHubLogo className="h-[18px] w-[18px]" />
                     </a>
                   )}
                 </div>
@@ -2816,9 +2816,12 @@ function GitHubLogo({ className = "h-4 w-4" }: LogoIconProps) {
     <svg
       viewBox="0 0 24 24"
       fill="currentColor"
-      className={className}
+      role="img"
       aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
     >
+      <title>GitHub</title>
       <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
     </svg>
   );
@@ -2829,9 +2832,12 @@ function ObsidianLogo({ className = "h-4 w-4" }: LogoIconProps) {
     <svg
       viewBox="0 0 24 24"
       fill="currentColor"
-      className={className}
+      role="img"
       aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
     >
+      <title>Obsidian</title>
       <path d="M19.355 18.538a68.967 68.959 0 0 0 1.858-2.954.81.81 0 0 0-.062-.9c-.516-.685-1.504-2.075-2.042-3.362-.553-1.321-.636-3.375-.64-4.377a1.707 1.707 0 0 0-.358-1.05l-3.198-4.064a3.744 3.744 0 0 1-.076.543c-.106.503-.307 1.004-.536 1.5-.134.29-.29.6-.446.914l-.31.626c-.516 1.068-.997 2.227-1.132 3.59-.124 1.26.046 2.73.815 4.481.128.011.257.025.386.044a6.363 6.363 0 0 1 3.326 1.505c.916.79 1.744 1.922 2.415 3.5zM8.199 22.569c.073.012.146.02.22.02.78.024 2.095.092 3.16.29.87.16 2.593.64 4.01 1.055 1.083.316 2.198-.548 2.355-1.664.114-.814.33-1.735.725-2.58l-.01.005c-.67-1.87-1.522-3.078-2.416-3.849a5.295 5.295 0 0 0-2.778-1.257c-1.54-.216-2.952.19-3.84.45.532 2.218.368 4.829-1.425 7.531zM5.533 9.938c-.023.1-.056.197-.098.29L2.82 16.059a1.602 1.602 0 0 0 .313 1.772l4.116 4.24c2.103-3.101 1.796-6.02.836-8.3-.728-1.73-1.832-3.081-2.55-3.831zM9.32 14.01c.615-.183 1.606-.465 2.745-.534-.683-1.725-.848-3.233-.716-4.577.154-1.552.7-2.847 1.235-3.95.113-.235.223-.454.328-.664.149-.297.288-.577.419-.86.217-.47.379-.885.46-1.27.08-.38.08-.72-.014-1.043-.095-.325-.297-.675-.68-1.06a1.6 1.6 0 0 0-1.475.36l-4.95 4.452a1.602 1.602 0 0 0-.513.952l-.427 2.83c.672.59 2.328 2.316 3.335 4.711.09.21.175.43.253.653z" />
     </svg>
   );


### PR DESCRIPTION
## Problem
Obsidian and GitHub icons in the project sidebar were only visible on hover, too small, and lacked proper brand colors.

## Fix
- **Obsidian icon**: Always visible, purple (#7C3AED)
- **GitHub icon**: Always visible, black (#181717) with dark mode support
- Icons sized at 18px for readability
- Removed hidden/hover-only visibility
- Cleaner hover states

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Quick-action icons (Obsidian and GitHub) in the Project row are now always visible instead of appearing only on hover.
  * Improved accessibility with enhanced icon labeling and sizing adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->