### PR TITLE
fix(web): terminal in session detail, output fallback, review tab fixes

### DIFF
--- a/packages/web/next-env.d.ts
+++ b/packages/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/web/src/app/api/sessions/[id]/output/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/output/route.ts
@@ -1,9 +1,221 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import { existsSync, readdirSync, readFileSync, statSync, type Dirent } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { homedir } from "node:os";
 import { getServices } from "@/lib/services";
 import { guardApiAccess } from "@/lib/auth";
 
 export const dynamic = "force-dynamic";
+
+type SessionSnapshot = {
+  filePath: string;
+  values: Record<string, string>;
+};
+
+function parseMetadataFile(content: string): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    if (key) values[key] = value;
+  }
+  return values;
+}
+
+function tailText(content: string, lines: number): string {
+  const chunks = content.split(/\r?\n/);
+  return chunks.slice(-Math.max(lines, 1)).join("\n").trimEnd();
+}
+
+function resolveHomePath(value: string): string {
+  if (value.startsWith("~/")) {
+    return resolve(homedir(), value.slice(2));
+  }
+  return resolve(value);
+}
+
+function isReadableFile(path: string): boolean {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function findSnapshotPaths(sessionId: string): string[] {
+  const conductorRoot = resolve(homedir(), ".conductor");
+  if (!existsSync(conductorRoot)) return [];
+
+  const candidates: string[] = [];
+  let roots: Dirent[];
+  try {
+    roots = readdirSync(conductorRoot, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  for (const entry of roots) {
+    if (!entry.isDirectory()) continue;
+    const sessionsDir = join(conductorRoot, entry.name, "sessions");
+    if (!existsSync(sessionsDir)) continue;
+
+    const live = join(sessionsDir, sessionId);
+    if (isReadableFile(live)) {
+      candidates.push(live);
+    }
+
+    const archiveDir = join(sessionsDir, "archive");
+    if (!existsSync(archiveDir)) continue;
+    let archiveEntries: string[];
+    try {
+      archiveEntries = readdirSync(archiveDir);
+    } catch {
+      continue;
+    }
+
+    for (const fileName of archiveEntries) {
+      if (fileName === sessionId || fileName.startsWith(`${sessionId}_`)) {
+        const path = join(archiveDir, fileName);
+        if (isReadableFile(path)) {
+          candidates.push(path);
+        }
+      }
+    }
+  }
+
+  return candidates.sort((left, right) => {
+    try {
+      return statSync(right).mtimeMs - statSync(left).mtimeMs;
+    } catch {
+      return 0;
+    }
+  });
+}
+
+function readLatestSessionSnapshot(sessionId: string): SessionSnapshot | null {
+  for (const path of findSnapshotPaths(sessionId)) {
+    try {
+      const raw = readFileSync(path, "utf8");
+      const values = parseMetadataFile(raw);
+      return { filePath: path, values };
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+function buildFallbackLogCandidates(sessionId: string, snapshot: SessionSnapshot): string[] {
+  const values = snapshot.values;
+  const tmuxName = values["tmuxName"]?.trim();
+  const worktree = values["worktree"]?.trim();
+
+  const paths = new Set<string>();
+  const addPath = (path: string | undefined): void => {
+    if (!path) return;
+    const trimmed = path.trim();
+    if (!trimmed) return;
+    paths.add(resolveHomePath(trimmed));
+  };
+
+  for (const key of [
+    "sessionLog",
+    "outputLog",
+    "terminalLog",
+    "transcript",
+    "history",
+    "historyFile",
+    "devServerLog",
+  ]) {
+    addPath(values[key]);
+  }
+
+  if (worktree) {
+    const normalizedWorktree = resolveHomePath(worktree);
+    for (const id of [sessionId, tmuxName].filter(Boolean)) {
+      addPath(join(normalizedWorktree, ".conductor", "logs", `${id}.log`));
+      addPath(join(normalizedWorktree, ".conductor", "state", `${id}.log`));
+    }
+    addPath(join(normalizedWorktree, ".conductor", "session.log"));
+    addPath(join(normalizedWorktree, ".codex", "history.jsonl"));
+    addPath(join(normalizedWorktree, ".codex", "log", "codex-tui.log"));
+    addPath(join(normalizedWorktree, ".claude", "logs", `${sessionId}.log`));
+  }
+
+  const snapshotDir = dirname(snapshot.filePath);
+  addPath(join(snapshotDir, `${sessionId}.log`));
+  if (tmuxName) {
+    addPath(join(snapshotDir, `${tmuxName}.log`));
+  }
+  if (snapshotDir.endsWith(`${join("sessions", "archive")}`)) {
+    const sessionsDir = dirname(snapshotDir);
+    addPath(join(sessionsDir, sessionId));
+    addPath(join(sessionsDir, `${sessionId}.log`));
+    if (tmuxName) {
+      addPath(join(sessionsDir, `${tmuxName}.log`));
+    }
+  }
+
+  addPath(snapshot.filePath);
+
+  return [...paths];
+}
+
+function readFallbackOutput(sessionId: string, lines: number): string | null {
+  const snapshot = readLatestSessionSnapshot(sessionId);
+  if (!snapshot) return null;
+
+  const candidates = buildFallbackLogCandidates(sessionId, snapshot);
+  const snapshotPath = resolve(snapshot.filePath);
+
+  for (const candidatePath of candidates) {
+    if (resolve(candidatePath) === snapshotPath) continue;
+    if (!isReadableFile(candidatePath)) continue;
+    try {
+      const content = readFileSync(candidatePath, "utf8");
+      if (!content.trim()) continue;
+      return tailText(content, lines);
+    } catch {
+      continue;
+    }
+  }
+
+  if (isReadableFile(snapshot.filePath)) {
+    try {
+      const content = readFileSync(snapshot.filePath, "utf8");
+      if (content.trim()) {
+        return tailText(content, lines);
+      }
+    } catch {
+      // Ignore and use synthesized output.
+    }
+  }
+
+  const status = snapshot.values["status"] ?? "unknown";
+  const summary = snapshot.values["summary"] ?? "";
+  const branch = snapshot.values["branch"] ?? "";
+  const worktree = snapshot.values["worktree"] ?? "";
+  const metadataDump = Object.entries(snapshot.values)
+    .map(([key, value]) => `${key}=${value}`)
+    .join("\n");
+
+  const fallback = [
+    `[session output fallback] Runtime output unavailable for ${sessionId}.`,
+    `status=${status}`,
+    branch ? `branch=${branch}` : "",
+    worktree ? `worktree=${worktree}` : "",
+    summary ? `summary=${summary}` : "",
+    "",
+    metadataDump,
+  ].filter(Boolean).join("\n");
+
+  return tailText(fallback, lines);
+}
 
 export async function GET(
   request: NextRequest,
@@ -31,8 +243,17 @@ export async function GET(
 
   try {
     const { sessionManager } = await getServices();
-    const output = await sessionManager.getOutput(sessionId, lines);
-    return NextResponse.json({ output });
+    try {
+      const output = await sessionManager.getOutput(sessionId, lines);
+      return NextResponse.json({ output });
+    } catch (runtimeErr) {
+      const fallbackOutput = readFallbackOutput(sessionId, lines);
+      if (fallbackOutput !== null) {
+        return NextResponse.json({ output: fallbackOutput, source: "fallback-log" });
+      }
+
+      throw runtimeErr;
+    }
   } catch (err) {
     const message = err instanceof Error ? err.message : "Failed to load output";
     const status = message.toLowerCase().includes("not found") ? 404 : 500;

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback, useRef } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import type { DashboardSession } from "@/lib/types";
 import { getAttentionLevel } from "@/lib/types";
 import { TerminalView } from "@/components/TerminalView";
@@ -46,7 +46,7 @@ interface DiffUIState {
   selectedFilePath: string | null;
   search: string;
   wrapLines: boolean;
-  activePanel: "overview" | "diff";
+  activePanel: "overview" | "diff" | "terminal";
 }
 
 type AgentCatalogEntry = {
@@ -73,8 +73,10 @@ function normalizeAgentName(value: string): string {
 export default function SessionDetailPage() {
   const params = useParams<{ id: string }>();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const sessionId = params.id;
   const { theme, toggleTheme } = useTheme();
+  const initialPanel = searchParams.get("tab") === "terminal" ? "terminal" : "overview";
 
   const [session, setSession] = useState<DashboardSession | null>(null);
   const [loading, setLoading] = useState(true);
@@ -85,6 +87,7 @@ export default function SessionDetailPage() {
   const [reviewSending, setReviewSending] = useState(false);
   const [killInProgress, setKillInProgress] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [copiedField, setCopiedField] = useState<string | null>(null);
   const [agentDirectory, setAgentDirectory] = useState<AgentDirectory>({});
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const [diffState, setDiffState] = useState<DiffUIState>({
@@ -98,7 +101,7 @@ export default function SessionDetailPage() {
     selectedFilePath: null,
     search: "",
     wrapLines: false,
-    activePanel: "overview",
+    activePanel: initialPanel,
   });
 
   const fetchSession = useCallback(async () => {
@@ -194,6 +197,13 @@ export default function SessionDetailPage() {
     };
   }, [fetchSession, fetchAgentDirectory, fetchDiff]);
 
+  useEffect(() => {
+    const tab = searchParams.get("tab");
+    if (tab === "terminal") {
+      setDiffState((prev) => (prev.activePanel === "terminal" ? prev : { ...prev, activePanel: "terminal" }));
+    }
+  }, [searchParams]);
+
   const handleSend = async () => {
     const msg = messageInput.trim();
     if (!msg) return;
@@ -254,6 +264,18 @@ export default function SessionDetailPage() {
       // ignore
     }
   };
+
+  const handleCopyField = useCallback(async (label: string, value: string | null | undefined) => {
+    const text = value?.trim();
+    if (!text || typeof navigator === "undefined" || !navigator.clipboard) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedField(label);
+      setTimeout(() => setCopiedField((current) => (current === label ? null : current)), 1500);
+    } catch {
+      // ignore
+    }
+  }, []);
 
   const isTerminal =
     session?.status === "merged" ||
@@ -448,35 +470,48 @@ export default function SessionDetailPage() {
         </div>
       )}
 
-      {/* Main content: Terminal + Metadata sidebar */}
-      <div className="flex flex-1 min-h-0 overflow-hidden">
-        {/* Terminal area */}
-        <div className="flex-1 min-w-0">
-          <TerminalView sessionId={sessionId} />
-        </div>
-
-        {/* Metadata sidebar */}
-        {session && (
-        <aside className="w-full border-t border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] overflow-hidden flex flex-col lg:w-72 lg:shrink-0 lg:border-t-0 lg:border-l">
-          <div className="flex items-center justify-between border-b border-[var(--color-border-subtle)] px-4 py-2">
-            <div className="flex items-center gap-1 rounded-md bg-[var(--color-bg-base)] p-0.5">
-              <button
-                onClick={() =>
-                  setDiffState((prev) => ({ ...prev, activePanel: "overview" }))
-                }
-                className={`rounded-md px-2.5 py-1 text-[11px] font-medium ${diffState.activePanel === "overview" ? "bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)]" : "text-[var(--color-text-muted)]"}`}
-              >
-                Overview
-              </button>
-              <button
-                onClick={() =>
-                  setDiffState((prev) => ({ ...prev, activePanel: "diff" }))
-                }
-                className={`rounded-md px-2.5 py-1 text-[11px] font-medium ${diffState.activePanel === "diff" ? "bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)]" : "text-[var(--color-text-muted)]"}`}
-              >
-                Diff
-              </button>
-            </div>
+      {/* Main content */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div className="flex items-center justify-between border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] px-4 py-2">
+          <div className="flex items-center gap-1 rounded-md bg-[var(--color-bg-base)] p-0.5">
+            <button
+              onClick={() =>
+                setDiffState((prev) => ({ ...prev, activePanel: "overview" }))
+              }
+              className={`rounded-md px-2.5 py-1 text-[11px] font-medium ${
+                diffState.activePanel === "overview"
+                  ? "bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)]"
+                  : "text-[var(--color-text-muted)]"
+              }`}
+            >
+              Overview
+            </button>
+            <button
+              onClick={() =>
+                setDiffState((prev) => ({ ...prev, activePanel: "diff" }))
+              }
+              className={`rounded-md px-2.5 py-1 text-[11px] font-medium ${
+                diffState.activePanel === "diff"
+                  ? "bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)]"
+                  : "text-[var(--color-text-muted)]"
+              }`}
+            >
+              Diff
+            </button>
+            <button
+              onClick={() =>
+                setDiffState((prev) => ({ ...prev, activePanel: "terminal" }))
+              }
+              className={`rounded-md px-2.5 py-1 text-[11px] font-medium ${
+                diffState.activePanel === "terminal"
+                  ? "bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)]"
+                  : "text-[var(--color-text-muted)]"
+              }`}
+            >
+              Terminal
+            </button>
+          </div>
+          {diffState.activePanel === "diff" && (
             <button
               onClick={() => void fetchDiff()}
               disabled={diffState.loading}
@@ -484,387 +519,322 @@ export default function SessionDetailPage() {
             >
               {diffState.loading ? "Refreshing..." : "Refresh diff"}
             </button>
-          </div>
+          )}
+        </div>
 
-          <div className="px-4 py-2 text-[10px] text-[var(--color-text-muted)]">
-            {diffState.loading && "Pulling latest code changes..."}
-            {diffState.generatedAt && !diffState.loading ? `Updated ${formatTimestamp(new Date(diffState.generatedAt))}` : ""}
+        {diffState.activePanel === "terminal" ? (
+          <div className="min-h-0 flex-1 overflow-hidden">
+            <TerminalView sessionId={sessionId} />
           </div>
-
-          <div className="px-4 py-2 pb-4 overflow-auto">
+        ) : (
+          <div className="min-h-0 flex-1 overflow-auto p-4">
             {diffState.activePanel === "overview" ? (
-              <div className="space-y-5">
-                {/* Summary */}
-                {session.summary && (
-                  <MetaSection label="Summary">
-                    <p className="text-[12px] leading-relaxed text-[var(--color-text-secondary)]">
-                      {session.summary}
-                    </p>
-                  </MetaSection>
-                )}
-
-                {/* Prompt */}
-                {meta["prompt"] && (
-                  <MetaSection label="Prompt">
-                    <p className="rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-base)] px-2 py-1.5 text-[11px] leading-relaxed text-[var(--color-text-secondary)] font-mono">
-                      {meta["prompt"]}
-                    </p>
-                  </MetaSection>
-                )}
-
-                {/* Status */}
-                <MetaSection label="Status">
-                  <div className="space-y-2">
-                    <MetaRow label="Status" value={session.status.replace(/_/g, " ")} />
-                    <MetaRow label="Activity" value={session.activity ?? "-"} />
-                    <MetaRow label="Attention" value={attentionLevel} />
-                  </div>
-                </MetaSection>
-
-                {/* Agent */}
-                <MetaSection label="Agent">
-                  {(agentName || runtimeHandle || meta["agent"]) && (
-                    <div className="mb-2 flex items-center gap-2">
-                      <AgentTileIcon
-                        seed={{
-                          label: agentDirectorySeed.label,
-                          iconUrl: agentDirectorySeed.iconUrl,
-                          homepage: agentDirectorySeed.homepage,
-                        }}
-                        className="h-3.5 w-3.5"
-                      />
-                      <span className="text-[12px] text-[var(--color-text-secondary)]">
-                        {agentDirectorySeed.label}
-                      </span>
+              <div className="grid gap-4 xl:grid-cols-2">
+                <section className="rounded-xl border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] p-4">
+                  <h2 className="mb-3 text-[12px] font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Summary</h2>
+                  <p className="whitespace-pre-wrap text-[12px] leading-relaxed text-[var(--color-text-secondary)]">
+                    {session.summary?.trim() || "No summary yet."}
+                  </p>
+                  {meta["prompt"] && (
+                    <div className="mt-4 rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-base)] p-3">
+                      <div className="mb-1 text-[10px] uppercase tracking-wide text-[var(--color-text-muted)]">Prompt</div>
+                      <p className="whitespace-pre-wrap font-mono text-[11px] leading-relaxed text-[var(--color-text-secondary)]">
+                        {meta["prompt"]}
+                      </p>
                     </div>
                   )}
-                  <MetaRow label="Type" value={meta["agent"] ?? "-"} />
-                  {meta["model"] && <MetaRow label="Model" value={meta["model"]} />}
-                  {meta["permissions"] && <MetaRow label="Permissions" value={meta["permissions"]} />}
-                </MetaSection>
+                </section>
 
-                {/* Git */}
-                {(session.branch || meta["worktree"]) && (
-                  <MetaSection label="Git">
-                    {session.branch && (
-                      <div className="text-[11px] font-mono text-[var(--color-text-secondary)] break-all">
-                        {session.branch}
-                        {session.pr ? ` ← ${session.pr.baseBranch || "main"}` : ""}
-                      </div>
-                    )}
-                    {meta["baseBranch"] && (
-                      <div className="text-[11px] font-mono text-[var(--color-text-muted)] mt-1">
-                        Base: {meta["baseBranch"]}
-                      </div>
-                    )}
-                    {meta["worktree"] && (
-                      <div className="text-[11px] font-mono text-[var(--color-text-muted)] truncate mt-1">
-                        {meta["worktree"]}
-                      </div>
-                    )}
-                  </MetaSection>
-                )}
+                <section className="rounded-xl border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] p-4">
+                  <h2 className="mb-3 text-[12px] font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Status</h2>
+                  <div className="flex flex-wrap gap-2">
+                    <InfoPill label="Status" value={session.status.replace(/_/g, " ")} tone="blue" />
+                    <InfoPill label="Activity" value={session.activity ?? "-"} tone="violet" />
+                    <InfoPill label="Attention" value={attentionLevel} tone={attentionLevel === "respond" || attentionLevel === "review" ? "amber" : "slate"} />
+                  </div>
+                </section>
 
-                {/* PR */}
+                <section className="rounded-xl border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] p-4">
+                  <h2 className="mb-3 text-[12px] font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Agent</h2>
+                  <div className="mb-3 flex items-center gap-2">
+                    <AgentTileIcon
+                      seed={{
+                        label: agentDirectorySeed.label,
+                        iconUrl: agentDirectorySeed.iconUrl,
+                        homepage: agentDirectorySeed.homepage,
+                      }}
+                      className="h-4 w-4"
+                    />
+                    <span className="text-[13px] font-medium text-[var(--color-text-primary)]">{agentDirectorySeed.label}</span>
+                  </div>
+                  <div className="space-y-1.5 text-[11px] text-[var(--color-text-secondary)]">
+                    <MetaRow label="Type" value={meta["agent"] ?? "-"} />
+                    {meta["model"] && <MetaRow label="Model" value={meta["model"]} />}
+                    {meta["permissions"] && <MetaRow label="Permissions" value={meta["permissions"]} />}
+                  </div>
+                </section>
+
                 {session.pr && (
-                  <MetaSection label="Pull Request">
+                  <section className="rounded-xl border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] p-4">
+                    <h2 className="mb-3 text-[12px] font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Pull Request</h2>
                     <a
                       href={session.pr.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-[12px] font-medium text-[var(--color-accent)] hover:underline block mb-2"
+                      className="mb-3 block text-[12px] font-medium text-[var(--color-accent)] hover:underline"
                     >
                       #{session.pr.number} — {session.pr.title}
                     </a>
-                    <div className="space-y-1.5">
-                      <MetaRow label="State" value={session.pr.state} />
-                      <ColoredMetaRow
-                        label="CI"
-                        value={session.pr.ciStatus}
-                        status={session.pr.ciStatus === "passing" ? "green" : session.pr.ciStatus === "failing" ? "red" : "amber"}
-                      />
-                      <ColoredMetaRow
-                        label="Review"
-                        value={session.pr.reviewDecision.replace(/_/g, " ")}
-                        status={session.pr.reviewDecision === "approved" ? "green" : session.pr.reviewDecision === "changes_requested" ? "red" : "amber"}
-                      />
-                      <MetaRow
-                        label="Mergeable"
-                        value={session.pr.mergeability.mergeable ? "Yes" : "No"}
-                      />
+                    <div className="grid grid-cols-2 gap-2">
+                      <InfoPill label="State" value={session.pr.state} tone="violet" />
+                      <InfoPill label="CI" value={session.pr.ciStatus} tone={session.pr.ciStatus === "failing" ? "amber" : "blue"} />
+                      <InfoPill label="Review" value={session.pr.reviewDecision.replace(/_/g, " ")} tone={session.pr.reviewDecision === "changes_requested" ? "amber" : "slate"} />
+                      <InfoPill label="Mergeable" value={session.pr.mergeability.mergeable ? "yes" : "no"} tone={session.pr.mergeability.mergeable ? "blue" : "amber"} />
                     </div>
+                  </section>
+                )}
 
-                    {/* Links */}
-                    <div className="mt-2 space-y-1">
-                      {session.pr.previewUrl && (
-                        <a
-                          href={session.pr.previewUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="flex items-center gap-1 text-[11px] text-[var(--color-accent)] hover:underline"
-                        >
-                          <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-                          Preview Deploy
-                        </a>
-                      )}
-                      <a
-                        href={`${session.pr.url}/checks`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="flex items-center gap-1 text-[11px] text-[var(--color-text-secondary)] hover:underline hover:text-[var(--color-text-primary)]"
-                      >
-                        View CI Checks ↗
-                      </a>
-                      <a
-                        href={`${session.pr.url}#pullrequestreview`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="flex items-center gap-1 text-[11px] text-[var(--color-text-secondary)] hover:underline hover:text-[var(--color-text-primary)]"
-                      >
-                        View Reviews ↗
-                      </a>
-                    </div>
-
-                    {session.pr.mergeability.blockers.length > 0 && (
-                      <div className="mt-2 rounded-md bg-[rgba(239,68,68,0.06)] border border-[rgba(239,68,68,0.15)] p-2">
-                        <div className="text-[10px] font-semibold text-[var(--color-status-error)] mb-1">Blockers</div>
-                        {session.pr.mergeability.blockers.map((b, i) => (
-                          <div key={i} className="text-[11px] text-[var(--color-text-secondary)]">
-                            {b}
-                          </div>
-                        ))}
-                      </div>
+                <section className="rounded-xl border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] p-4">
+                  <h2 className="mb-3 text-[12px] font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Git</h2>
+                  <div className="space-y-2">
+                    {session.branch && (
+                      <MonoField
+                        label="Branch"
+                        value={session.branch}
+                        copied={copiedField === "branch"}
+                        onCopy={() => void handleCopyField("branch", session.branch)}
+                      />
                     )}
-                  </MetaSection>
-                )}
-
-                {/* Cost */}
-                {cost && (
-                  <MetaSection label="Cost">
-                    <div className="space-y-1.5">
-                      {(cost.estimatedCostUsd ?? cost.totalUSD) != null && (
-                        <MetaRow
-                          label="Total"
-                          value={`$${((cost.estimatedCostUsd ?? cost.totalUSD) as number).toFixed(4)}`}
-                        />
-                      )}
-                      {cost.inputTokens != null && (
-                        <MetaRow label="Input" value={cost.inputTokens.toLocaleString()} />
-                      )}
-                      {cost.outputTokens != null && (
-                        <MetaRow label="Output" value={cost.outputTokens.toLocaleString()} />
-                      )}
-                    </div>
-                  </MetaSection>
-                )}
-
-                {/* Timing */}
-                <MetaSection label="Timing">
-                  <div className="space-y-1.5">
-                    <MetaRow label="Created" value={formatTimestamp(createdDate)} />
-                    <MetaRow label="Last Active" value={formatTimestamp(lastActivityDate)} />
-                    <MetaRow label="Duration" value={formatDuration(durationMs)} />
+                    {meta["baseBranch"] && (
+                      <MonoField
+                        label="Base"
+                        value={meta["baseBranch"]}
+                        copied={copiedField === "baseBranch"}
+                        onCopy={() => void handleCopyField("baseBranch", meta["baseBranch"])}
+                      />
+                    )}
+                    {meta["worktree"] && (
+                      <MonoField
+                        label="Worktree"
+                        value={meta["worktree"]}
+                        copied={copiedField === "worktree"}
+                        onCopy={() => void handleCopyField("worktree", meta["worktree"])}
+                      />
+                    )}
                   </div>
-                </MetaSection>
+                </section>
 
-                {/* Timeline */}
-                <MetaSection label="Timeline">
-                  <div className="relative pl-4 border-l border-[var(--color-border-default)]">
-                    <TimelineEvent
-                      label="Created"
-                      time={formatTimestamp(createdDate)}
-                      color="var(--color-accent)"
-                    />
-                    {session.pr && (
-                      <TimelineEvent
-                        label="PR opened"
-                        time={`#${session.pr.number}`}
-                        color="var(--color-accent-violet)"
-                      />
-                    )}
+                <section className="rounded-xl border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] p-4">
+                  <h2 className="mb-3 text-[12px] font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Cost + Timing</h2>
+                  <div className="grid grid-cols-2 gap-2">
+                    <MetricBox label="Total">
+                      {(cost?.estimatedCostUsd ?? cost?.totalUSD) != null
+                        ? `$${((cost?.estimatedCostUsd ?? cost?.totalUSD) as number).toFixed(4)}`
+                        : "-"}
+                    </MetricBox>
+                    <MetricBox label="Duration">{formatDuration(durationMs)}</MetricBox>
+                    <MetricBox label="Input tokens">
+                      {cost?.inputTokens != null ? cost.inputTokens.toLocaleString() : "-"}
+                    </MetricBox>
+                    <MetricBox label="Output tokens">
+                      {cost?.outputTokens != null ? cost.outputTokens.toLocaleString() : "-"}
+                    </MetricBox>
+                  </div>
+                  <div className="mt-3 space-y-1.5 text-[11px] text-[var(--color-text-secondary)]">
+                    <MetaRow label="Created" value={formatTimestamp(createdDate)} />
+                    <MetaRow label="Last active" value={formatTimestamp(lastActivityDate)} />
+                  </div>
+                </section>
+
+                <section className="rounded-xl border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] p-4">
+                  <h2 className="mb-3 text-[12px] font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Timeline</h2>
+                  <div className="relative pl-4">
+                    <div className="absolute left-0 top-0 h-full w-px bg-[var(--color-border-default)]" />
+                    <TimelineEvent label="Created" time={formatTimestamp(createdDate)} color="var(--color-accent)" />
+                    {session.pr && <TimelineEvent label="PR opened" time={`#${session.pr.number}`} color="var(--color-accent-violet)" />}
                     <TimelineEvent
                       label={session.status.replace(/_/g, " ")}
                       time={formatTimestamp(lastActivityDate)}
-                      color={
-                        isTerminal
-                          ? "var(--color-text-muted)"
-                          : "var(--color-status-working)"
-                      }
+                      color={isTerminal ? "var(--color-text-muted)" : "var(--color-status-working)"}
                       active={!isTerminal}
                     />
                   </div>
-                </MetaSection>
+                </section>
               </div>
             ) : (
-              <div className="space-y-3">
-                <div className="relative">
-                  <input
-                    value={diffState.search}
-                    onChange={(e) =>
-                      setDiffState((prev) => ({
-                        ...prev,
-                        search: e.target.value,
-                        selectedFilePath: (() => {
-                          const filteredFiles = prev.files.filter((file) =>
-                            file.path.toLowerCase().includes(e.target.value.trim().toLowerCase()),
-                          );
-
-                          return prev.selectedFilePath && filteredFiles.find((file) => file.path === prev.selectedFilePath)
-                            ? prev.selectedFilePath
-                            : filteredFiles[0]?.path ?? null;
-                        })(),
-                      }))
-                    }
-                    placeholder="Filter files..."
-                    className="w-full rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-base)] px-2.5 py-1.5 pr-16 text-[11px] text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)]"
-                  />
-                  <div className="absolute right-2 top-1/2 -translate-y-1/2 text-[9px] text-[var(--color-text-muted)]">
-                    {diffFiles.length} files
+              <div className="grid min-h-0 gap-4 xl:grid-cols-[minmax(280px,360px)_minmax(0,1fr)]">
+                <div className="space-y-3">
+                  <div className="relative">
+                    <input
+                      value={diffState.search}
+                      onChange={(e) =>
+                        setDiffState((prev) => ({
+                          ...prev,
+                          search: e.target.value,
+                          selectedFilePath: (() => {
+                            const filteredFiles = prev.files.filter((file) =>
+                              file.path.toLowerCase().includes(e.target.value.trim().toLowerCase()),
+                            );
+                            return prev.selectedFilePath && filteredFiles.find((file) => file.path === prev.selectedFilePath)
+                              ? prev.selectedFilePath
+                              : filteredFiles[0]?.path ?? null;
+                          })(),
+                        }))
+                      }
+                      placeholder="Filter files..."
+                      className="w-full rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-base)] px-2.5 py-1.5 pr-16 text-[11px] text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)]"
+                    />
+                    <div className="absolute right-2 top-1/2 -translate-y-1/2 text-[9px] text-[var(--color-text-muted)]">
+                      {diffFiles.length} files
+                    </div>
                   </div>
-                </div>
 
-                <div className="flex items-center gap-2">
-                  <button
-                    onClick={() =>
-                      setDiffState((prev) => ({ ...prev, wrapLines: !prev.wrapLines }))
-                    }
-                    className="rounded-md border border-[var(--color-border-default)] px-2 py-1 text-[10px] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
-                  >
-                    {diffState.wrapLines ? "No wrap" : "Wrap lines"}
-                  </button>
-                  <div className="text-[10px] text-[var(--color-text-muted)]">
-                    {diffState.hasDiff || diffState.untracked.length > 0 ? "Live diff" : "No local changes"}
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() =>
+                        setDiffState((prev) => ({ ...prev, wrapLines: !prev.wrapLines }))
+                      }
+                      className="rounded-md border border-[var(--color-border-default)] px-2 py-1 text-[10px] text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
+                    >
+                      {diffState.wrapLines ? "No wrap" : "Wrap lines"}
+                    </button>
+                    <div className="text-[10px] text-[var(--color-text-muted)]">
+                      {diffState.generatedAt ? `Updated ${formatTimestamp(new Date(diffState.generatedAt))}` : "Waiting for diff..."}
+                    </div>
                   </div>
-                </div>
 
-                {diffState.error && (
-                  <div className="rounded-md border border-[rgba(239,68,68,0.25)] bg-[rgba(239,68,68,0.12)] px-2.5 py-1.5 text-[10px] text-[var(--color-status-error)]">
-                    {diffState.error}
-                  </div>
-                )}
+                  {diffState.error && (
+                    <div className="rounded-md border border-[rgba(239,68,68,0.25)] bg-[rgba(239,68,68,0.12)] px-2.5 py-1.5 text-[10px] text-[var(--color-status-error)]">
+                      {diffState.error}
+                    </div>
+                  )}
 
-                <div className="grid gap-2">
-                  {diffFiles.length > 0 ? (
-                    diffFiles.map((file) => {
-                      const selected = file.path === activeDiffFile?.path;
-                      const statusColor =
-                        file.status === "added"
-                          ? "rgba(34,197,94,0.16)"
-                          : file.status === "deleted"
-                            ? "rgba(239,68,68,0.16)"
-                            : file.status === "renamed" || file.status === "copy"
-                              ? "rgba(59,130,246,0.16)"
-                              : file.status === "binary"
-                                ? "rgba(217,119,6,0.16)"
-                                : "rgba(63,63,70,0.25)";
-                      return (
-                        <button
-                          key={file.path}
-                          onClick={() =>
-                            setDiffState((prev) => ({ ...prev, selectedFilePath: file.path }))
-                          }
-                          className={`rounded-md border px-2 py-1.5 text-left transition-colors ${
-                            selected
-                              ? "border-[var(--color-accent)] bg-[rgba(59,130,246,0.12)]"
-                              : "border-[var(--color-border-subtle)] bg-[var(--color-bg-base)]"
-                          }`}
-                        >
-                          <div className="flex items-center justify-between gap-2">
-                            <div className="text-[11px] text-[var(--color-text-secondary)] truncate">
-                              {file.path}
+                  <div className="grid gap-2">
+                    {diffFiles.length > 0 ? (
+                      diffFiles.map((file) => {
+                        const selected = file.path === activeDiffFile?.path;
+                        const statusColor =
+                          file.status === "added"
+                            ? "rgba(34,197,94,0.16)"
+                            : file.status === "deleted"
+                              ? "rgba(239,68,68,0.16)"
+                              : file.status === "renamed" || file.status === "copy"
+                                ? "rgba(59,130,246,0.16)"
+                                : file.status === "binary"
+                                  ? "rgba(217,119,6,0.16)"
+                                  : "rgba(63,63,70,0.25)";
+                        return (
+                          <button
+                            key={file.path}
+                            onClick={() =>
+                              setDiffState((prev) => ({ ...prev, selectedFilePath: file.path }))
+                            }
+                            className={`rounded-md border px-2 py-1.5 text-left transition-colors ${
+                              selected
+                                ? "border-[var(--color-accent)] bg-[rgba(59,130,246,0.12)]"
+                                : "border-[var(--color-border-subtle)] bg-[var(--color-bg-base)]"
+                            }`}
+                          >
+                            <div className="flex items-center justify-between gap-2">
+                              <div className="truncate text-[11px] text-[var(--color-text-secondary)]">
+                                {file.path}
+                              </div>
+                              <span className="rounded-full px-1.5 py-0.5 text-[9px]" style={{ background: statusColor }}>
+                                {file.status}
+                              </span>
                             </div>
-                            <span className="text-[9px] px-1.5 py-0.5 rounded-full" style={{ background: statusColor }}>
-                              {file.status}
-                            </span>
-                          </div>
-                          <div className="mt-1 text-[10px] text-[var(--color-text-muted)]">
-                            +{file.additions} -{file.deletions}
-                          </div>
-                        </button>
-                      );
-                    })
+                            <div className="mt-1 text-[10px] text-[var(--color-text-muted)]">
+                              +{file.additions} -{file.deletions}
+                            </div>
+                          </button>
+                        );
+                      })
+                    ) : (
+                      <div className="rounded-md border border-[var(--color-border-subtle)] bg-[var(--color-bg-base)] px-3 py-2 text-[11px] text-[var(--color-text-muted)]">
+                        {diffState.hasDiff || diffState.untracked.length > 0
+                          ? "Diff computed, but no file hunks were returned."
+                          : "No changes yet"}
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="rounded-md border border-[var(--color-border-subtle)] bg-[var(--color-bg-base)] p-2">
+                    <textarea
+                      value={reviewDraft}
+                      onChange={(event) => setReviewDraft(event.target.value)}
+                      placeholder="Send review notes to this agent..."
+                      className="min-h-[72px] w-full rounded border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-2 text-[11px] text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)]"
+                      rows={3}
+                    />
+                    <div className="mt-2 flex items-center gap-2">
+                      <button
+                        onClick={() => void handleSendReview()}
+                        disabled={reviewSending || !reviewDraft.trim()}
+                        className="rounded-md bg-[var(--color-accent)] px-2.5 py-1 text-[10px] font-semibold text-white disabled:cursor-not-allowed disabled:opacity-40"
+                      >
+                        {reviewSending ? "Sending..." : "Send review notes"}
+                      </button>
+                      <button
+                        onClick={() => setDiffState((prev) => ({ ...prev, selectedFilePath: null }))}
+                        className="rounded-md border border-[var(--color-border-default)] px-2.5 py-1 text-[10px] text-[var(--color-text-secondary)]"
+                      >
+                        Clear selection
+                      </button>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="min-h-0 overflow-hidden rounded-xl border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)]">
+                  {activeDiffFile ? (
+                    <>
+                      <div className="border-b border-[var(--color-border-subtle)] px-3 py-2 text-[10px] text-[var(--color-text-muted)]">
+                        {activeDiffFile.path}
+                      </div>
+                      <div className="max-h-[72vh] overflow-auto">
+                        <div className="font-mono text-[11px] leading-5">
+                          {activeDiffFile.lines.map((line, idx) => (
+                            <DiffLineRow
+                              key={`${activeDiffFile.path}-${idx}`}
+                              line={line}
+                              wrapLines={diffState.wrapLines}
+                            />
+                          ))}
+                        </div>
+                      </div>
+                    </>
                   ) : (
-                    <div className="rounded-md border border-[var(--color-border-subtle)] bg-[var(--color-bg-base)] px-3 py-2 text-[11px] text-[var(--color-text-muted)]">
-                      {diffState.hasDiff || diffState.untracked.length > 0
-                        ? "Diff computed, but no file hunks were returned."
-                        : "No changes yet"}
+                    <div className="p-6 text-center text-[11px] text-[var(--color-text-muted)]">
+                      Select a file to inspect its diff.
+                    </div>
+                  )}
+
+                  {diffState.untracked.length > 0 && (
+                    <div className="border-t border-[var(--color-border-subtle)] px-3 py-2">
+                      <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">Untracked files</div>
+                      <ul className="space-y-1">
+                        {diffState.untracked.map((file) => (
+                          <li key={file} className="break-all font-mono text-[10px] text-[var(--color-text-secondary)]">
+                            {file}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+
+                  {diffState.truncated && (
+                    <div className="border-t border-[rgba(245,158,11,0.35)] bg-[rgba(245,158,11,0.1)] px-3 py-2 text-[10px] text-[var(--color-accent-orange)]">
+                      Diff output truncated for display.
                     </div>
                   )}
                 </div>
-
-                {activeDiffFile && (
-                  <div className="overflow-hidden border border-[var(--color-border-subtle)] rounded-md">
-                    <div className="px-2 py-1.5 text-[10px] text-[var(--color-text-muted)] border-b border-[var(--color-border-subtle)] truncate">
-                      {activeDiffFile.path}
-                    </div>
-                    <div className="overflow-auto max-h-72">
-                      <div className="text-[11px] leading-5 font-mono">
-                        {activeDiffFile.lines.map((line, idx) => (
-                          <DiffLineRow
-                            key={`${activeDiffFile.path}-${idx}`}
-                            line={line}
-                            wrapLines={diffState.wrapLines}
-                          />
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-                )}
-
-                <div className="rounded-md border border-[var(--color-border-subtle)] bg-[var(--color-bg-base)] p-2">
-                  <textarea
-                    value={reviewDraft}
-                    onChange={(event) => setReviewDraft(event.target.value)}
-                    placeholder="Send review notes to this agent..."
-                    className="w-full rounded border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-2 text-[11px] text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)] min-h-[72px]"
-                    rows={3}
-                  />
-                  <div className="mt-2 flex items-center gap-2">
-                    <button
-                      onClick={() => void handleSendReview()}
-                      disabled={reviewSending || !reviewDraft.trim()}
-                      className="rounded-md bg-[var(--color-accent)] px-2.5 py-1 text-[10px] font-semibold text-white disabled:opacity-40 disabled:cursor-not-allowed"
-                    >
-                      {reviewSending ? "Sending..." : "Send review notes"}
-                    </button>
-                    <button
-                      onClick={() => setDiffState((prev) => ({ ...prev, selectedFilePath: null }))}
-                      className="rounded-md border border-[var(--color-border-default)] px-2.5 py-1 text-[10px] text-[var(--color-text-secondary)]"
-                    >
-                      Clear selection
-                    </button>
-                  </div>
-                </div>
-
-                {diffState.untracked.length > 0 && (
-                  <div className="rounded-md border border-[var(--color-border-subtle)] px-2 py-2">
-                    <div className="text-[10px] font-semibold uppercase tracking-wider text-[var(--color-text-muted)] mb-1">
-                      Untracked files
-                    </div>
-                    <ul className="space-y-1">
-                      {diffState.untracked.map((file) => (
-                        <li key={file} className="text-[10px] text-[var(--color-text-secondary)] font-mono break-all">
-                          {file}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-
-                {diffState.truncated && (
-                  <div className="rounded-md border border-[rgba(245,158,11,0.35)] bg-[rgba(245,158,11,0.1)] px-2 py-1.5 text-[10px] text-[var(--color-accent-orange)]">
-                    Diff output truncated for display.
-                  </div>
-                )}
               </div>
             )}
           </div>
-        </aside>
         )}
       </div>
 
       {/* Bottom input bar */}
-      {!isTerminal && (
+      {!isTerminal && diffState.activePanel !== "terminal" && (
         <div className="border-t border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)]">
           {/* Quick action buttons */}
           <div className="flex items-center gap-1.5 px-4 pt-2 pb-1 overflow-x-auto scrollbar-none">
@@ -930,7 +900,7 @@ export default function SessionDetailPage() {
       )}
 
       {/* Terminal status footer for completed sessions */}
-      {isTerminal && (
+      {isTerminal && diffState.activePanel !== "terminal" && (
         <div
           className="border-t border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] px-4 py-2.5 flex items-center gap-2"
           style={{ paddingBottom: "max(10px, env(safe-area-inset-bottom))" }}
@@ -988,13 +958,64 @@ function DiffLineRow({ line, wrapLines }: { line: DiffLine; wrapLines: boolean }
   );
 }
 
-function MetaSection({ label, children }: { label: string; children: React.ReactNode }) {
+type InfoPillTone = "blue" | "violet" | "amber" | "slate";
+
+function InfoPill({
+  label,
+  value,
+  tone = "slate",
+}: {
+  label: string;
+  value: string;
+  tone?: InfoPillTone;
+}) {
+  const toneClasses: Record<InfoPillTone, string> = {
+    blue: "border-[rgba(59,130,246,0.3)] bg-[rgba(59,130,246,0.14)] text-[var(--color-accent)]",
+    violet: "border-[rgba(139,92,246,0.32)] bg-[rgba(139,92,246,0.14)] text-[var(--color-accent-violet)]",
+    amber: "border-[rgba(245,158,11,0.32)] bg-[rgba(245,158,11,0.14)] text-[var(--color-status-attention)]",
+    slate: "border-[var(--color-border-default)] bg-[var(--color-bg-base)] text-[var(--color-text-secondary)]",
+  };
+
   return (
-    <div>
-      <div className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
-        {label}
+    <div className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[10px] ${toneClasses[tone]}`}>
+      <span className="uppercase tracking-wide text-[9px] opacity-80">{label}</span>
+      <span className="font-medium capitalize">{value}</span>
+    </div>
+  );
+}
+
+function MetricBox({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-bg-base)] px-3 py-2">
+      <div className="mb-1 text-[10px] uppercase tracking-wide text-[var(--color-text-muted)]">{label}</div>
+      <div className="text-[12px] font-semibold text-[var(--color-text-primary)]">{children}</div>
+    </div>
+  );
+}
+
+function MonoField({
+  label,
+  value,
+  copied,
+  onCopy,
+}: {
+  label: string;
+  value: string;
+  copied: boolean;
+  onCopy: () => void;
+}) {
+  return (
+    <div className="rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-bg-base)] p-2">
+      <div className="mb-1 flex items-center justify-between gap-2">
+        <span className="text-[10px] uppercase tracking-wide text-[var(--color-text-muted)]">{label}</span>
+        <button
+          onClick={onCopy}
+          className="rounded border border-[var(--color-border-default)] px-1.5 py-0.5 text-[9px] text-[var(--color-text-muted)] transition-colors hover:text-[var(--color-text-primary)]"
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
       </div>
-      {children}
+      <div className="break-all font-mono text-[11px] text-[var(--color-text-secondary)]">{value}</div>
     </div>
   );
 }
@@ -1004,22 +1025,6 @@ function MetaRow({ label, value }: { label: string; value: string }) {
     <div className="flex items-baseline justify-between gap-2">
       <span className="text-[11px] text-[var(--color-text-muted)] shrink-0">{label}</span>
       <span className="text-[11px] text-[var(--color-text-secondary)] text-right truncate capitalize">
-        {value}
-      </span>
-    </div>
-  );
-}
-
-function ColoredMetaRow({ label, value, status }: { label: string; value: string; status: "green" | "red" | "amber" }) {
-  const colorMap = {
-    green: "var(--color-status-ready)",
-    red: "var(--color-status-error)",
-    amber: "var(--color-status-attention)",
-  };
-  return (
-    <div className="flex items-baseline justify-between gap-2">
-      <span className="text-[11px] text-[var(--color-text-muted)] shrink-0">{label}</span>
-      <span className="text-[11px] text-right truncate capitalize font-medium" style={{ color: colorMap[status] }}>
         {value}
       </span>
     </div>

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -9,6 +9,7 @@ import {
   type FormEvent,
   type ReactNode,
 } from "react";
+import { useRouter } from "next/navigation";
 import type {
   DashboardSession,
   DashboardStats,
@@ -18,7 +19,6 @@ import { getAttentionLevel } from "@/lib/types";
 import { TERMINAL_STATUSES } from "@conductor-oss/core/types";
 import { SessionCard } from "./SessionCard";
 import { EmptyState } from "./EmptyState";
-import { TerminalView } from "./TerminalView";
 import { useTheme } from "./ThemeProvider";
 
 type ConfigProject = {
@@ -38,7 +38,7 @@ type AgentInfo = {
   iconUrl: string | null;
 };
 
-type DashboardTab = "overview" | "chat" | "review" | "terminal" | "agents";
+type DashboardTab = "overview" | "chat" | "review" | "agents";
 type ReviewDiffSource = "working-tree" | "remote-pr" | "not-found";
 
 type AgentRoster = {
@@ -222,7 +222,7 @@ function getProjectFaviconUrls(repo?: string | null, iconUrl?: string | null): s
   try {
     if (!resolved) return [];
     const url = new URL(resolved);
-    const github = parseGithubRepo(repo);
+    const github = parseGithubRepo(repo ?? null);
     if (github) {
       const owner = encodeURIComponent(github.owner);
       const project = encodeURIComponent(github.name);
@@ -589,7 +589,6 @@ const TAB_DEFINITIONS: Array<{ id: DashboardTab; label: string; subtitle: string
   { id: "overview", label: "Overview", subtitle: "All sessions and controls" },
   { id: "chat", label: "Chat", subtitle: "Respond to agents in need of action" },
   { id: "review", label: "Review", subtitle: "Send review feedback quickly" },
-  { id: "terminal", label: "Terminal", subtitle: "View and switch active terminal sessions" },
   { id: "agents", label: "Agents", subtitle: "Health and launch controls" },
 ];
 
@@ -777,6 +776,7 @@ interface DashboardProps {
 }
 
 export function Dashboard({ sessions: initialSessions, stats: initialStats, configProjects: initialConfigProjects = [] }: DashboardProps) {
+  const router = useRouter();
   const [sessions, setSessions] = useState<DashboardSession[]>(initialSessions);
   const [stats, setStats] = useState<DashboardStats>(initialStats);
   const [configProjects, setConfigProjects] = useState<ConfigProject[]>(initialConfigProjects);
@@ -802,7 +802,6 @@ export function Dashboard({ sessions: initialSessions, stats: initialStats, conf
   const [agentFilter, setAgentFilter] = useState<string>("all");
   const [sortMode, setSortMode] = useState<SortMode>("recent");
   const [attentionOnly, setAttentionOnly] = useState(false);
-  const [activeTerminalSessionId, setActiveTerminalSessionId] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
   const [dashboardTab, setDashboardTab] = useState<DashboardTab>("overview");
   const [isLaunchCollapsed, setIsLaunchCollapsed] = useState(true);
@@ -1051,6 +1050,7 @@ export function Dashboard({ sessions: initialSessions, stats: initialStats, conf
         boardDir: cfg?.boardDir ?? id,
         boardFile: cfg?.boardFile,
         repo: cfg?.repo ?? null,
+        iconUrl: cfg?.iconUrl ?? null,
       };
     });
   }, [sessions, configProjects]);
@@ -1192,10 +1192,15 @@ export function Dashboard({ sessions: initialSessions, stats: initialStats, conf
     return ranked;
   }, [sessions, activeProject, statusFilter, attentionOnly, agentFilter, search, sortMode]);
 
-  const reviewSessions = useMemo(
-    () => filteredSessions.filter((session) => getAttentionLevel(session) === "review"),
-    [filteredSessions],
-  );
+  const reviewSessions = useMemo(() => {
+    return filteredSessions.filter((session) => {
+      if (session.pr && session.pr.number > 0) return true;
+      const diff = reviewDiffState[session.id];
+      if (!diff) return true;
+      if (!diff.loaded) return true;
+      return diff.hasDiff || diff.untracked.length > 0;
+    });
+  }, [filteredSessions, reviewDiffState]);
 
   const chatSessions = useMemo(
     () => filteredSessions.filter((session) => getAttentionLevel(session) === "respond"),
@@ -1446,7 +1451,7 @@ export function Dashboard({ sessions: initialSessions, stats: initialStats, conf
   }, [updateReviewDiffState]);
 
   const applyQuickMessage = useCallback(
-    (sessionId: string, kind: "chat" | "review", template: string) => {
+    (sessionId: string, kind: string, template: string) => {
       if (kind === "review") {
         setReviewMessages((prev) => {
           const current = prev[sessionId] ?? "";
@@ -1961,9 +1966,6 @@ export function Dashboard({ sessions: initialSessions, stats: initialStats, conf
   const visibleTabSessions = useMemo(() => {
     if (dashboardTab === "chat") return chatSessions;
     if (dashboardTab === "review") return reviewSessions;
-    if (dashboardTab === "terminal") {
-      return filteredSessions.filter((session) => TERMINAL_STATUSES.has(session.status));
-    }
     return filteredSessions;
   }, [chatSessions, reviewSessions, filteredSessions, dashboardTab]);
 
@@ -1988,19 +1990,12 @@ export function Dashboard({ sessions: initialSessions, stats: initialStats, conf
     [visibleAgentRoster],
   );
 
-  const activeTerminalSession = useMemo(() => {
-    if (!activeTerminalSessionId) return null;
-    return sessions.find((session) => session.id === activeTerminalSessionId) ?? null;
-  }, [activeTerminalSessionId, sessions]);
-
   const searchPlaceholder = dashboardTab === "agents"
     ? "Search agents..."
     : dashboardTab === "chat"
       ? "Search sessions needing agent response..."
       : dashboardTab === "review"
         ? "Search sessions or changed files..."
-        : dashboardTab === "terminal"
-          ? "Search terminal sessions..."
         : "Search sessions, issues, branches, agents...";
 
   const totalAgentCatalogCount = Math.max(
@@ -2021,9 +2016,8 @@ export function Dashboard({ sessions: initialSessions, stats: initialStats, conf
     : Boolean(busySessionId) || bulkBusy;
 
   const handleOpenTerminal = useCallback((sessionId: string) => {
-    setActiveTerminalSessionId(sessionId);
-    setDashboardTab("terminal");
-  }, []);
+    router.push(`/sessions/${encodeURIComponent(sessionId)}?tab=terminal`);
+  }, [router]);
 
   useEffect(() => {
     if (dashboardTab !== "chat" && dashboardTab !== "review") return;
@@ -2040,26 +2034,6 @@ export function Dashboard({ sessions: initialSessions, stats: initialStats, conf
       setSortMode("recent");
     }
   }, [agentFilter, attentionOnly, dashboardTab, sortMode, statusFilter]);
-
-  useEffect(() => {
-    if (dashboardTab === "terminal") return;
-    setActiveTerminalSessionId(null);
-  }, [dashboardTab]);
-
-  useEffect(() => {
-    if (!activeTerminalSession) return;
-    if (!TERMINAL_STATUSES.has(activeTerminalSession.status)) {
-      setActiveTerminalSessionId(null);
-    }
-  }, [activeTerminalSession]);
-
-  useEffect(() => {
-    if (!activeTerminalSessionId) return;
-    const stillExists = sessions.some((session) => session.id === activeTerminalSessionId);
-    if (!stillExists) {
-      setActiveTerminalSessionId(null);
-    }
-  }, [activeTerminalSessionId, sessions]);
 
   return (
     <div className="flex h-dvh overflow-hidden">
@@ -2755,60 +2729,7 @@ export function Dashboard({ sessions: initialSessions, stats: initialStats, conf
             </div>
           )}
 
-          {dashboardTab === "terminal" ? (
-            <div className="flex min-h-0 flex-1 flex-col gap-3">
-              <div className="rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3">
-                <div className="mb-2 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">
-                  Terminal sessions
-                </div>
-                {activeTerminalSession ? (
-                  <div className="mb-2 flex items-center gap-2 text-[11px] text-[var(--color-text-secondary)]">
-                    <span className="rounded-full bg-[var(--color-bg-subtle)] px-2 py-0.5">
-                      Active: {activeTerminalSession.id}
-                    </span>
-                    <div className="flex-1" />
-                    <button
-                      type="button"
-                      onClick={() => setActiveTerminalSessionId(null)}
-                      className="rounded-md border border-[var(--color-border-subtle)] px-2 py-1 text-[10px] text-[var(--color-text-muted)] transition-colors hover:border-[var(--color-border-strong)]"
-                    >
-                      Close terminal
-                    </button>
-                  </div>
-                ) : null}
-                {visibleTabSessions.length === 0 ? (
-                  <EmptyState />
-                ) : (
-                  <div className="flex flex-wrap gap-2">
-                    {visibleTabSessions.map((session) => (
-                      <button
-                        key={session.id}
-                        onClick={() => setActiveTerminalSessionId(session.id)}
-                        className={`rounded-md border px-2 py-1 text-[10px] transition-colors ${
-                          activeTerminalSessionId === session.id
-                            ? "border-[var(--color-accent)] bg-[var(--color-accent-subtle)] text-[var(--color-accent)]"
-                            : "border-[var(--color-border-subtle)] text-[var(--color-text-secondary)] hover:border-[var(--color-border-strong)]"
-                        }`}
-                      >
-                        <span className="font-mono text-[10px]">{session.id}</span>
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
-
-              {activeTerminalSession ? (
-                <div className="min-h-0 flex-1 overflow-hidden rounded-xl border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)]">
-                  <TerminalView sessionId={activeTerminalSession.id} />
-                </div>
-              ) : (
-                <div className="rounded-xl border border-dashed border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] px-4 py-12 text-center text-[11px] text-[var(--color-text-muted)]">
-                  Select a terminal session above to open its live output.
-                </div>
-              )}
-            </div>
-          ) : (
-            <>
+          <>
               {visibleTabSessions.length === 0 ? (
                 <EmptyState />
               ) : dashboardTab === "overview" && viewMode === "lanes" ? (
@@ -3301,8 +3222,7 @@ export function Dashboard({ sessions: initialSessions, stats: initialStats, conf
                   })}
                 </div>
               )}
-            </>
-          )}
+          </>
         </main>
 
         {commandOpen && (


### PR DESCRIPTION
## Changes

### 1. Terminal moved into Session Detail
- Removed top-level Terminal tab from main dashboard nav
- Added Terminal as 3rd tab in session detail page (alongside Overview and Diff)
- Full-height xterm.js terminal view within session context

### 2. Output API fallback for done sessions  
- `/api/sessions/[id]/output` now falls back to reading log files from state directory when tmux session is gone
- Fixes 'No runtime plugin' error for exited/done sessions

### 3. Review tab fix
- Review tab now properly shows sessions with diff data

### 4. Session detail layout improvements
- Structured Overview with status badges, agent info, git info, cost display
- Better visual hierarchy

### 5. TypeScript fixes
- `parseGithubRepo` null coercion
- `iconUrl` added to project objects  
- `applyQuickMessage` type widened

Build passes ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Terminal tab to session detail pages
  * Introduced copy-to-clipboard functionality for session details like branch and worktree

* **Bug Fixes**
  * Improved session output retrieval with automatic fallback mechanism for better reliability

* **UI/UX Improvements**
  * Redesigned session overview with clearer organized sections for summary, status, agent info, and timeline
  * Enhanced diff view with grid-based file listing and improved visual status indicators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->