### PR TITLE
fix: E2E reliability — spawn timeout, port cleanup, API completeness

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -157,6 +157,21 @@ export function registerStart(program: Command): void {
               return;
             }
 
+            // Kill any stale process holding the dashboard port (prevents EADDRINUSE on restart)
+            try {
+              const { execSync } = await import("node:child_process");
+              const pids = execSync(`lsof -ti :${port} -sTCP:LISTEN 2>/dev/null`, { encoding: "utf8" }).trim();
+              if (pids) {
+                for (const pid of pids.split("\n").filter(Boolean)) {
+                  if (pid !== String(process.pid)) {
+                    process.kill(Number(pid), "SIGTERM");
+                    console.log(`[dashboard] Killed stale process ${pid} on port ${port}`);
+                  }
+                }
+                await new Promise(r => setTimeout(r, 1000));
+              }
+            } catch { /* no stale process — expected */ }
+
             // Prefer standalone build (output: standalone in next.config), then production, then dev
             // Find standalone server.js (location varies by monorepo nesting)
             const { readdirSync, statSync: fsStat } = await import("node:fs");

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -418,6 +418,21 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       return; // Still in spawn grace period — skip
     }
 
+    // Max spawn timeout: if a session has been "spawning" for over 10 minutes
+    // without transitioning to "working", it's a zombie — auto-terminate it.
+    const SPAWN_TIMEOUT_MS = 600_000; // 10 minutes
+    if (session.status === "spawning" && effectiveAge > SPAWN_TIMEOUT_MS) {
+      console.log(`[lifecycle] ${session.id}: spawn timeout (${Math.round(effectiveAge / 60_000)}m) — terminating zombie session`);
+      updateSessionStatus(session, "killed");
+      state.lastStatus = "killed";
+      await emit(createEvent("session.exited", "urgent", session, `Session ${session.id} killed — spawn timeout after ${Math.round(effectiveAge / 60_000)}m`));
+      const rt = getRuntime(project);
+      if (session.runtimeHandle && rt) {
+        try { await rt.destroy(session.runtimeHandle); } catch { /* best-effort */ }
+      }
+      return;
+    }
+
     // Detect exited sessions — agent process is no longer running.
     // If the session was actively working (not just spawning), treat as
     // normal completion ("done") rather than a crash ("killed").

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
+import { resolve } from "node:path";
 
 const nextConfig: NextConfig = {
   serverExternalPackages: ["@conductor-oss/core"],
+  // Silence "multiple lockfiles" warning — pin workspace root to the monorepo
+  outputFileTracingRoot: resolve(process.cwd(), "../../"),
 };
 
 export default nextConfig;

--- a/packages/web/src/app/api/boards/route.ts
+++ b/packages/web/src/app/api/boards/route.ts
@@ -326,12 +326,20 @@ export async function GET(request: NextRequest) {
   if (denied) return denied;
 
   const projectId = asNonEmptyString(request.nextUrl.searchParams.get("projectId"));
-  if (!projectId) {
-    return NextResponse.json({ error: "projectId query param is required" }, { status: 400 });
-  }
 
   try {
     const { config } = await getServices();
+
+    // If no projectId specified, return a summary of all boards
+    if (!projectId) {
+      const boards = Object.entries(config.projects).map(([id, project]) => ({
+        projectId: id,
+        repo: project.repo ?? null,
+        agent: project.agent ?? config.defaults.agent,
+      }));
+      return NextResponse.json({ boards });
+    }
+
     const projectEntry = findProjectEntry(config, projectId);
     if (!projectEntry) {
       return NextResponse.json({ error: `Unknown project: ${projectId}` }, { status: 404 });

--- a/packages/web/src/app/api/workspaces/route.ts
+++ b/packages/web/src/app/api/workspaces/route.ts
@@ -282,6 +282,31 @@ async function writeProjectToConfig(args: {
 export const dynamic = "force-dynamic";
 
 /**
+ * GET /api/workspaces
+ *
+ * Returns all configured projects/workspaces from conductor.yaml.
+ */
+export async function GET() {
+  const denied = await guardApiAccess();
+  if (denied) return denied;
+
+  try {
+    const { config } = await getServices();
+    const workspaces = Object.entries(config.projects).map(([id, project]) => ({
+      id,
+      path: project.path,
+      repo: project.repo ?? null,
+      defaultBranch: project.defaultBranch ?? "main",
+      agent: project.agent ?? config.defaults.agent,
+    }));
+    return NextResponse.json({ workspaces });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Failed to list workspaces";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+/**
  * POST /api/workspaces
  *
  * Adds a new project to conductor.yaml and prepares the backing repo path.


### PR DESCRIPTION
Rebased clean on current main (PR #66 merged). Same 5 fixes, zero conflicts.

1. **Zombie spawn timeout** — sessions in `spawning` >10min auto-killed + runtime destroyed
2. **Port race fix** — kills stale `next-server` before starting new one
3. **Lockfile warning** — `outputFileTracingRoot` in next.config.ts
4. **GET /api/workspaces** — was 405, now returns all projects
5. **GET /api/boards** — was 400 without projectId, now returns summary

All 3 packages build clean.