### PR TITLE
fix: align release workflow pnpm version

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 9.15.4
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- align the GitHub Actions pnpm setup version with the repo's packageManager field
- unblock the pending automated release run on main

## Validation
- gh run view 22735862420 --log-failed