### PR TITLE
chore: refresh pnpm lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@conductor-oss/plugin-scm-github':
         specifier: workspace:*
         version: link:../plugins/scm-github
+      '@conductor-oss/plugin-terminal-web':
+        specifier: workspace:*
+        version: link:../plugins/terminal-web
       '@conductor-oss/plugin-tracker-github':
         specifier: workspace:*
         version: link:../plugins/tracker-github


### PR DESCRIPTION
## Summary
- refresh pnpm-lock.yaml after adding the terminal web plugin dependency
- unblock the automated release install step on main

## Validation
- pnpm install --lockfile-only