### PR TITLE
chore: release 0.2.1

### DIFF
--- a/.changeset/few-yaks-teach.md
+++ b/.changeset/few-yaks-teach.md
@@ -1,5 +1,0 @@
----
-"conductor-oss": patch
----
-
-Fix npm packaging so the published CLI installs as a complete product, including bundled internal runtime packages, the embedded web dashboard, and automated publish verification on pushes to `main`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conductor-oss",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-amp/package.json
+++ b/packages/plugins/agent-amp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-amp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-ccr/package.json
+++ b/packages/plugins/agent-ccr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-ccr",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-claude-code/package.json
+++ b/packages/plugins/agent-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-claude-code",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-codex/package.json
+++ b/packages/plugins/agent-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-codex",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-cursor-cli/package.json
+++ b/packages/plugins/agent-cursor-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-cursor-cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-droid/package.json
+++ b/packages/plugins/agent-droid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-droid",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-gemini/package.json
+++ b/packages/plugins/agent-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-gemini",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/plugins/agent-github-copilot/package.json
+++ b/packages/plugins/agent-github-copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-github-copilot",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-opencode/package.json
+++ b/packages/plugins/agent-opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-opencode",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-qwen-code/package.json
+++ b/packages/plugins/agent-qwen-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-qwen-code",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/mcp-server/package.json
+++ b/packages/plugins/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-mcp-server",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-desktop/package.json
+++ b/packages/plugins/notifier-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-notifier-desktop",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-discord/package.json
+++ b/packages/plugins/notifier-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-notifier-discord",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/runtime-tmux/package.json
+++ b/packages/plugins/runtime-tmux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-runtime-tmux",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/scm-github/package.json
+++ b/packages/plugins/scm-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-scm-github",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/terminal-web/package.json
+++ b/packages/plugins/terminal-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-terminal-web",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/tracker-github/package.json
+++ b/packages/plugins/tracker-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-tracker-github",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/webhook/package.json
+++ b/packages/plugins/webhook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-webhook",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/workspace-worktree/package.json
+++ b/packages/plugins/workspace-worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-workspace-worktree",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- version packages to 0.2.1 after fixing the published npm package layout
- align the repo state with the live npm release and pushed tag

## Validation
- pnpm release
- npm publish conductor-oss@0.2.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed npm packaging to ensure complete product installation with all required components.

* **Chores**
  * Version bumped to 0.2.1 across CLI, core, and all plugin packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->