### PR TITLE
fix: ship conductor 0.2.2 workspace config handling

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conductor-oss",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -16,7 +16,7 @@ export function registerDoctor(program: Command): void {
     .option("--json", "Output JSON report")
     .action(async (opts: DoctorOptions) => {
       try {
-        const config = await loadConfig();
+        const config = await loadConfig(opts.workspace);
         const coreModule = await import("@conductor-oss/core");
         const core = coreModule as Record<string, unknown>;
         const discoverBoards = core["discoverBoards"] as

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -25,7 +25,7 @@ export function registerStart(program: Command): void {
     .option("-w, --workspace <path>", "Obsidian workspace path")
       .action(async (opts: { dashboard?: boolean; watcher?: boolean; port?: string; workspace?: string }) => {
       try {
-        const config = await loadConfig();
+        const config = await loadConfig(opts.workspace);
         const { sessionManager, registry } = await createServices(config);
         const supportedAgents = registry.list("agent").map((agent) => agent.name);
 

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -24,7 +24,7 @@ export function registerWatch(program: Command): void {
     .option("--poll <ms>", "Polling interval in milliseconds", "5000")
       .action(async (opts: { workspace: string; poll: string }) => {
       try {
-        const config = await loadConfig();
+        const config = await loadConfig(opts.workspace);
         const { sessionManager, registry } = await createServices(config);
         const core = await import("@conductor-oss/core");
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -33,7 +33,7 @@ const program = new Command();
 program
   .name("co")
   .description("Conductor — markdown-native AI agent orchestrator")
-  .version("0.2.0");
+  .version("0.2.2");
 
 registerSpawn(program);
 registerList(program);

--- a/packages/cli/src/services.ts
+++ b/packages/cli/src/services.ts
@@ -62,12 +62,29 @@ export type { OrchestratorConfig, SessionManager };
  * Load config from the standard YAML file.
  * Imported lazily from @conductor-oss/core.
  */
-export async function loadConfig(): Promise<OrchestratorConfig> {
+export async function loadConfig(configHint?: string): Promise<OrchestratorConfig> {
   const core = await import("@conductor-oss/core");
   if (typeof core.loadConfig !== "function") {
     throw new Error("@conductor-oss/core does not export loadConfig");
   }
-  return core.loadConfig() as OrchestratorConfig;
+  const findConfigFile = core.findConfigFile as ((startDir?: string) => string | null) | undefined;
+  const { existsSync, statSync } = await import("node:fs");
+  const { resolve } = await import("node:path");
+
+  let configPath: string | undefined;
+  if (configHint) {
+    const resolvedHint = resolve(configHint);
+    if (existsSync(resolvedHint) && statSync(resolvedHint).isFile()) {
+      configPath = resolvedHint;
+    } else if (findConfigFile) {
+      configPath = findConfigFile(resolvedHint) ?? undefined;
+      if (!configPath) {
+        throw new Error(`No conductor.yaml found under ${resolvedHint}. Run \`co setup\` or \`co init\` there first.`);
+      }
+    }
+  }
+
+  return core.loadConfig(configPath) as OrchestratorConfig;
 }
 
 /**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/core",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -386,18 +386,9 @@ function applyDefaultReactions(config: OrchestratorConfig): OrchestratorConfig {
  * 4. Home directory locations
  */
 export function findConfigFile(startDir?: string): string | null {
-  // 1. Check environment variable override
-  if (process.env["CO_CONFIG_PATH"]) {
-    const envPath = resolve(process.env["CO_CONFIG_PATH"]);
-    if (existsSync(envPath)) {
-      return envPath;
-    }
-  }
+  const configFiles = ["conductor.yaml", "conductor.yml"];
 
-  // 2. Search up directory tree from CWD (like git)
   const searchUpTree = (dir: string): string | null => {
-    const configFiles = ["conductor.yaml", "conductor.yml"];
-
     for (const filename of configFiles) {
       const configPath = resolve(dir, filename);
       if (existsSync(configPath)) {
@@ -407,28 +398,32 @@ export function findConfigFile(startDir?: string): string | null {
 
     const parent = resolve(dir, "..");
     if (parent === dir) {
-      // Reached root
       return null;
     }
 
     return searchUpTree(parent);
   };
 
-  const cwd = process.cwd();
-  const foundInTree = searchUpTree(cwd);
-  if (foundInTree) {
-    return foundInTree;
+  // 1. Check environment variable override
+  if (process.env["CO_CONFIG_PATH"]) {
+    const envPath = resolve(process.env["CO_CONFIG_PATH"]);
+    if (existsSync(envPath)) {
+      return envPath;
+    }
   }
 
-  // 3. Check explicit startDir if provided
+  // 2. Search up directory tree from explicit startDir first.
   if (startDir) {
-    const files = ["conductor.yaml", "conductor.yml"];
-    for (const filename of files) {
-      const path = resolve(startDir, filename);
-      if (existsSync(path)) {
-        return path;
-      }
+    const foundFromStartDir = searchUpTree(resolve(startDir));
+    if (foundFromStartDir) {
+      return foundFromStartDir;
     }
+  }
+
+  // 3. Search up directory tree from CWD (like git)
+  const foundInTree = searchUpTree(process.cwd());
+  if (foundInTree) {
+    return foundInTree;
   }
 
   // 4. Check home directory locations

--- a/packages/plugins/agent-amp/package.json
+++ b/packages/plugins/agent-amp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-amp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-amp/src/index.ts
+++ b/packages/plugins/agent-amp/src/index.ts
@@ -148,7 +148,7 @@ export const manifest = {
   name: "amp",
   slot: "agent" as const,
   description: "Agent plugin: Amp CLI",
-  version: "0.2.0",
+  version: "0.2.2",
 };
 
 function createAgent(): Agent {

--- a/packages/plugins/agent-ccr/package.json
+++ b/packages/plugins/agent-ccr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-ccr",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-ccr/src/index.ts
+++ b/packages/plugins/agent-ccr/src/index.ts
@@ -148,7 +148,7 @@ export const manifest = {
   name: "ccr",
   slot: "agent" as const,
   description: "Agent plugin: Claude Code Router",
-  version: "0.2.0",
+  version: "0.2.2",
 };
 
 function createAgent(): Agent {

--- a/packages/plugins/agent-claude-code/package.json
+++ b/packages/plugins/agent-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-claude-code",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -192,7 +192,7 @@ export const manifest = {
   name: "claude-code",
   slot: "agent" as const,
   description: "Agent plugin: Claude Code CLI",
-  version: "0.2.0",
+  version: "0.2.2",
 };
 
 // =============================================================================

--- a/packages/plugins/agent-codex/package.json
+++ b/packages/plugins/agent-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-codex",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -85,7 +85,7 @@ export const manifest = {
   name: "codex",
   slot: "agent" as const,
   description: "Agent plugin: OpenAI Codex CLI",
-  version: "0.2.0",
+  version: "0.2.2",
 };
 
 // =============================================================================

--- a/packages/plugins/agent-cursor-cli/package.json
+++ b/packages/plugins/agent-cursor-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-cursor-cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-cursor-cli/src/index.ts
+++ b/packages/plugins/agent-cursor-cli/src/index.ts
@@ -148,7 +148,7 @@ export const manifest = {
   name: "cursor-cli",
   slot: "agent" as const,
   description: "Agent plugin: Cursor CLI",
-  version: "0.2.0",
+  version: "0.2.2",
 };
 
 function createAgent(): Agent {

--- a/packages/plugins/agent-droid/package.json
+++ b/packages/plugins/agent-droid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-droid",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-droid/src/index.ts
+++ b/packages/plugins/agent-droid/src/index.ts
@@ -148,7 +148,7 @@ export const manifest = {
   name: "droid",
   slot: "agent" as const,
   description: "Agent plugin: Factory Droid CLI",
-  version: "0.2.0",
+  version: "0.2.2",
 };
 
 function createAgent(): Agent {

--- a/packages/plugins/agent-gemini/package.json
+++ b/packages/plugins/agent-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-gemini",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/plugins/agent-gemini/src/index.ts
+++ b/packages/plugins/agent-gemini/src/index.ts
@@ -80,7 +80,7 @@ export const manifest = {
   name: "gemini",
   slot: "agent" as const,
   description: "Agent plugin: Google Gemini CLI",
-  version: "0.2.0",
+  version: "0.2.2",
 };
 
 // =============================================================================

--- a/packages/plugins/agent-github-copilot/package.json
+++ b/packages/plugins/agent-github-copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-github-copilot",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-github-copilot/src/index.ts
+++ b/packages/plugins/agent-github-copilot/src/index.ts
@@ -148,7 +148,7 @@ export const manifest = {
   name: "github-copilot",
   slot: "agent" as const,
   description: "Agent plugin: GitHub Copilot CLI",
-  version: "0.2.0",
+  version: "0.2.2",
 };
 
 function createAgent(): Agent {

--- a/packages/plugins/agent-opencode/package.json
+++ b/packages/plugins/agent-opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-opencode",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-opencode/src/index.ts
+++ b/packages/plugins/agent-opencode/src/index.ts
@@ -148,7 +148,7 @@ export const manifest = {
   name: "opencode",
   slot: "agent" as const,
   description: "Agent plugin: OpenCode CLI",
-  version: "0.2.0",
+  version: "0.2.2",
 };
 
 function createAgent(): Agent {

--- a/packages/plugins/agent-qwen-code/package.json
+++ b/packages/plugins/agent-qwen-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-qwen-code",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-qwen-code/src/index.ts
+++ b/packages/plugins/agent-qwen-code/src/index.ts
@@ -148,7 +148,7 @@ export const manifest = {
   name: "qwen-code",
   slot: "agent" as const,
   description: "Agent plugin: Qwen Code CLI",
-  version: "0.2.0",
+  version: "0.2.2",
 };
 
 function createAgent(): Agent {

--- a/packages/plugins/mcp-server/package.json
+++ b/packages/plugins/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-mcp-server",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/mcp-server/src/index.ts
+++ b/packages/plugins/mcp-server/src/index.ts
@@ -103,7 +103,7 @@ function serializeProject(id: string, p: ProjectConfig): Record<string, unknown>
 export function createMcpServer(): McpServer {
   const server = new McpServer({
     name: "conductor",
-    version: "0.2.0",
+    version: "0.2.2",
   });
 
   // -------------------------------------------------------------------------

--- a/packages/plugins/notifier-desktop/package.json
+++ b/packages/plugins/notifier-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-notifier-desktop",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-desktop/src/index.ts
+++ b/packages/plugins/notifier-desktop/src/index.ts
@@ -22,7 +22,7 @@ export const manifest = {
   name: "desktop",
   slot: "notifier" as const,
   description: "Notifier plugin: desktop notifications (macOS + Linux)",
-  version: "0.2.0",
+  version: "0.2.2",
 };
 
 const PLATFORM = platform();

--- a/packages/plugins/notifier-discord/package.json
+++ b/packages/plugins/notifier-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-notifier-discord",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-discord/src/index.ts
+++ b/packages/plugins/notifier-discord/src/index.ts
@@ -18,7 +18,7 @@ export const manifest = {
   name: "discord",
   slot: "notifier" as const,
   description: "Notifier plugin: Discord via REST API",
-  version: "0.2.0",
+  version: "0.2.2",
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/plugins/runtime-tmux/package.json
+++ b/packages/plugins/runtime-tmux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-runtime-tmux",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/runtime-tmux/src/index.ts
+++ b/packages/plugins/runtime-tmux/src/index.ts
@@ -45,7 +45,7 @@ export const manifest = {
   name: "tmux",
   slot: "runtime" as const,
   description: "Runtime plugin: tmux sessions",
-  version: "0.2.0",
+  version: "0.2.2",
 };
 
 /** Only allow safe characters in session IDs */

--- a/packages/plugins/scm-github/package.json
+++ b/packages/plugins/scm-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-scm-github",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/scm-github/src/index.ts
+++ b/packages/plugins/scm-github/src/index.ts
@@ -411,7 +411,7 @@ export const manifest = {
   name: "github",
   slot: "scm" as const,
   description: "SCM plugin: GitHub PRs, CI checks, reviews, merge readiness",
-  version: "0.2.0",
+  version: "0.2.2",
 };
 
 export function create(): SCM {

--- a/packages/plugins/terminal-web/package.json
+++ b/packages/plugins/terminal-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-terminal-web",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/terminal-web/src/index.ts
+++ b/packages/plugins/terminal-web/src/index.ts
@@ -16,7 +16,7 @@ export const manifest = {
   name: "web",
   slot: "terminal" as const,
   description: "Terminal plugin: web terminal via browser",
-  version: "0.2.0",
+  version: "0.2.2",
 };
 
 export function create(config?: Record<string, unknown>): Terminal {

--- a/packages/plugins/tracker-github/package.json
+++ b/packages/plugins/tracker-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-tracker-github",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/tracker-github/src/index.ts
+++ b/packages/plugins/tracker-github/src/index.ts
@@ -161,7 +161,7 @@ export const manifest = {
   name: "github",
   slot: "tracker" as const,
   description: "Tracker plugin: GitHub Issues",
-  version: "0.2.0",
+  version: "0.2.2",
 };
 
 export function create(): Tracker {

--- a/packages/plugins/webhook/package.json
+++ b/packages/plugins/webhook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-webhook",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/workspace-worktree/package.json
+++ b/packages/plugins/workspace-worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-workspace-worktree",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/workspace-worktree/src/index.ts
+++ b/packages/plugins/workspace-worktree/src/index.ts
@@ -41,7 +41,7 @@ export const manifest = {
   name: "worktree",
   slot: "workspace" as const,
   description: "Workspace plugin: git worktrees",
-  version: "0.2.0",
+  version: "0.2.2",
 };
 
 /** Run a git command in a given directory */

--- a/scripts/verify-cli-package.mjs
+++ b/scripts/verify-cli-package.mjs
@@ -107,6 +107,21 @@ try {
   const configContents = readFileSync(configPath, "utf8").replace(/^port:\s*4747$/m, "port: 4111");
   writeFileSync(configPath, configContents, "utf8");
 
+  execFileSync(
+    "node",
+    [
+      "node_modules/conductor-oss/dist/index.js",
+      "doctor",
+      "--workspace",
+      repoDir,
+      "--json",
+    ],
+    {
+      cwd: installDir,
+      stdio: "inherit",
+    },
+  );
+
   dashboardProcess = spawn(
     "node",
     [
@@ -122,7 +137,6 @@ try {
       cwd: installDir,
       env: {
         ...process.env,
-        CO_CONFIG_PATH: configPath,
         CONDUCTOR_WORKSPACE: repoDir,
       },
       stdio: ["ignore", "pipe", "pipe"],


### PR DESCRIPTION
## Summary
- fix packaged CLI config lookup for workspace-aware commands
- strengthen release verification with packaged doctor coverage
- version the fixed release to 0.2.2

## Validation
- pnpm typecheck
- pnpm test
- pnpm build:release
- pnpm release:verify
- full staged-install smoke (doctor, start, API mutations, spawn, kill)
- live npm smoke for conductor-oss@0.2.2