### PR TITLE
chore: release 0.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ It runs entirely on your machine. No cloud. No database. No SaaS subscription.
 ## Quick Start
 
 ```bash
-# 1. From any terminal, run the guided setup for a repo
-npx conductor-oss@latest setup --path /path/to/your-repo
+# 1. From any terminal, launch Conductor
+npx conductor-oss@latest
 
-# 2. Optional: pin explicit defaults and skip the prompts
+# 2. Optional: preseed a specific repo and install supported tools first
 npx conductor-oss@latest setup --yes \
   --path /path/to/your-repo \
   --project-id my-app \
@@ -113,9 +113,10 @@ npx conductor-oss@latest start
 
 Then in the dashboard:
 
-1. First run opens **Confirm your preferences** (agent, IDE, markdown editor, notifications).
-2. Open **Settings → Repositories** for the exact one-line bootstrap command and repository defaults.
-3. Click **Add Workspace** in the left sidebar if you want to connect more repos from the UI.
+1. `npx conductor-oss@latest` launches Conductor locally and opens the dashboard in your browser.
+2. First run opens the **Setup** wizard for preferences.
+3. If no project exists yet, Conductor immediately opens **Add Workspace** so the user can connect a repo or local folder.
+4. Adding a project writes `CONDUCTOR.md` and a repo-local `conductor.yaml`, then keeps that YAML in sync when dashboard settings or agent selections change.
 
 Open `CONDUCTOR.md` in your editor (or Obsidian), write a task in **Ready to Dispatch**, save — done.
 
@@ -169,13 +170,23 @@ This mirrors the practical part of Vibe Kanban's remote workflow: tunnel the UI,
 
 ### Guided setup behavior
 
-`co setup` is the default onboarding path for product and design teams:
+`npx conductor-oss@latest` is the default onboarding path for product and design teams:
 
-- checks whether `git`, `tmux`, `gh`, your chosen agent CLI, and selected apps are already available
-- installs supported missing tools automatically when possible
-- opens GitHub CLI browser auth when a repo connection is needed
+- starts Conductor in a clean home workspace and opens the dashboard immediately
+- shows the product-facing preferences flow first, without requiring repo flags up front
+- opens **Add Workspace** right after preferences when there are no configured projects
+- writes `CONDUCTOR.md` and repo-local `conductor.yaml` when a project is added
+- keeps repo-local YAML synced when preferences, repository settings, or dashboard agent selections change
+
+`co setup` remains available as the repo-preseed path:
+
+- uses the terminal only as a launcher, then opens the real onboarding flow in the dashboard
 - writes `CONDUCTOR.md` and `conductor.yaml` into the selected repository
-- starts Conductor in that repository automatically
+- starts Conductor in that repository automatically and opens the browser to the setup wizard
+- lets the user choose preferences and review repository defaults in the dashboard
+- checks `git`, `tmux`, `gh`, your chosen agent CLI, and selected apps
+- installs supported missing tools automatically when `--yes` is used
+- opens GitHub CLI browser auth when a repo connection is needed and `--yes` is used
 
 Today the smoothest auto-install path is macOS with Homebrew. On other systems, Conductor still guides the user but may leave a few tools as manual installs.
 
@@ -454,9 +465,9 @@ When running the standalone webhook command, the listener defaults to port `4748
 ## CLI Reference
 
 ```bash
-co setup [--path <repo>] [--yes] [--agent <agent>] [--ide <editor>] [--markdown-editor <app>] # Guided setup with readiness checks + installs
+co setup [--path <repo>] [--yes] [--agent <agent>] [--ide <editor>] [--markdown-editor <app>] # Scaffold repo, launch dashboard, open setup wizard
 co init [--project-id <id>] [--repo <owner/repo>] [--agent <agent>] # Scaffold CONDUCTOR.md + conductor.yaml with repo-aware defaults
-co start [--no-dashboard] [--no-watcher] [--port <port>] [--workspace <path>] # Start orchestrator
+co start [--no-dashboard] [--no-watcher] [--open] [--port <port>] [--workspace <path>] # Start orchestrator
 co watch                               # Run board watcher only
 co doctor                              # Diagnose board parsing/dispatch issues
 co list [--all] [--json] [project]     # List all sessions

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,9 +1,10 @@
 {
   "name": "conductor-oss",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "MIT",
   "type": "module",
   "bin": {
+    "conductor-oss": "dist/index.js",
     "conductor": "dist/index.js",
     "co": "dist/index.js"
   },

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -10,6 +10,7 @@ import { writeFileSync, existsSync, statSync } from "node:fs";
 import { basename, resolve } from "node:path";
 import chalk from "chalk";
 import type { Command } from "commander";
+import { buildConductorBoard, buildConductorYaml } from "@conductor-oss/core";
 
 export type InitOptions = {
   force?: boolean;
@@ -37,38 +38,6 @@ export type InitProjectConfig = {
   defaultWorkingDirectory: string | null;
   dashboardUrl: string | null;
 };
-
-export function buildConductorBoard(projectId: string, displayName: string): string {
-  return `# ${displayName}
-
-> 🤖 Conductor — AI agent orchestrator. Write tasks here, agents do the work.
-> Tags: \`#agent/claude-code\` · \`#agent/codex\` · \`#agent/gemini\` · \`#agent/amp\` · \`#agent/cursor-cli\` · \`#agent/opencode\` · \`#agent/droid\` · \`#agent/qwen-code\` · \`#agent/ccr\` · \`#agent/github-copilot\` · \`#project/${projectId}\` · \`#type/feature\` · \`#priority/high\`
-
-## Inbox
-
-> Drop rough ideas here. Conductor auto-tags them within 20s.
-
-## Ready to Dispatch
-
-> Move tagged tasks here to dispatch an agent.
-
-## Dispatching
-
-## In Progress
-
-## Review
-
-> Agent finished — review the PR, then move to Done.
-
-## Done
-
-## Blocked
-`;
-}
-
-function yamlString(value: string): string {
-  return JSON.stringify(value);
-}
 
 function slugifyProjectId(value: string): string {
   const normalized = value
@@ -114,68 +83,6 @@ function detectDefaultBranch(repoPath: string): string | null {
   }
 
   return runGit(repoPath, ["branch", "--show-current"]);
-}
-
-export function buildConductorYaml(config: InitProjectConfig): string {
-  const lines = [
-    "# Conductor Configuration",
-    "# Docs: https://github.com/charannyk06/conductor-oss",
-    "",
-    "port: 4747",
-    "",
-    "preferences:",
-    "  onboardingAcknowledged: false",
-    `  codingAgent: ${yamlString(config.agent)}`,
-    `  ide: ${yamlString(config.ide)}`,
-    `  markdownEditor: ${yamlString(config.markdownEditor)}`,
-    "  notifications:",
-    "    soundEnabled: true",
-    "    soundFile: abstract-sound-4",
-  ];
-
-  if (config.dashboardUrl) {
-    lines.push("", `dashboardUrl: ${yamlString(config.dashboardUrl)}`);
-  }
-
-  lines.push(
-    "",
-    "projects:",
-    `  ${config.projectId}:`,
-    `    name: ${yamlString(config.displayName)}`,
-    `    path: ${yamlString(config.path)}`,
-    `    repo: ${yamlString(config.repo)}`,
-    `    agent: ${yamlString(config.agent)}`,
-    `    defaultBranch: ${yamlString(config.defaultBranch)}`,
-    "    agentConfig:",
-    '      model: "claude-sonnet-4-6"',
-    '      permissions: "skip"',
-  );
-
-  if (config.defaultWorkingDirectory) {
-    lines.push(`    defaultWorkingDirectory: ${yamlString(config.defaultWorkingDirectory)}`);
-  }
-
-  lines.push(
-    '    workspace: "worktree"',
-    '    runtime: "tmux"',
-    '    scm: "github"',
-    "",
-    "# Add more projects below:",
-    "# another-project:",
-    '#   path: "~/projects/another"',
-    '#   repo: "your-org/another"',
-    '#   agent: "codex"',
-    "#   agentConfig:",
-    '#     model: "o4-mini"',
-    "",
-    "# Optional: Discord notifications",
-    "# plugins:",
-    "#   discord:",
-    '#     channelId: "YOUR_CHANNEL_ID"',
-    '#     tokenEnvVar: "DISCORD_BOT_TOKEN"',
-  );
-
-  return `${lines.join("\n")}\n`;
 }
 
 export function resolveInitProjectConfig(cwd: string, options: InitOptions): InitProjectConfig {
@@ -232,7 +139,16 @@ export function runInitScaffold(cwd: string, opts: InitOptions): {
   }
 
   if (!existsSync(configPath) || opts.force) {
-    writeFileSync(configPath, buildConductorYaml(project), "utf-8");
+    writeFileSync(configPath, buildConductorYaml({
+      dashboardUrl: project.dashboardUrl,
+      preferences: {
+        onboardingAcknowledged: false,
+        codingAgent: project.agent,
+        ide: project.ide,
+        markdownEditor: project.markdownEditor,
+      },
+      projects: [project],
+    }), "utf-8");
     console.log(chalk.green("✔") + "  Created conductor.yaml");
     created++;
   } else {

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -1,5 +1,4 @@
 import { execFileSync, spawnSync } from "node:child_process";
-import { createInterface } from "node:readline/promises";
 import { homedir } from "node:os";
 import process from "node:process";
 import chalk from "chalk";
@@ -28,40 +27,6 @@ type SetupCheck = {
   install?: InstallCommand;
   authCommand?: InstallCommand;
 };
-
-type SelectOption = {
-  value: string;
-  label: string;
-};
-
-const AGENT_OPTIONS: SelectOption[] = [
-  { value: "claude-code", label: "Claude Code" },
-  { value: "codex", label: "OpenAI Codex" },
-  { value: "gemini", label: "Gemini CLI" },
-  { value: "github-copilot", label: "GitHub Copilot" },
-  { value: "cursor-cli", label: "Cursor Agent" },
-  { value: "amp", label: "Amp" },
-  { value: "opencode", label: "OpenCode" },
-  { value: "droid", label: "Droid" },
-  { value: "qwen-code", label: "Qwen Code" },
-  { value: "ccr", label: "CCR" },
-];
-
-const IDE_OPTIONS: SelectOption[] = [
-  { value: "vscode", label: "VS Code" },
-  { value: "vscode-insiders", label: "VS Code Insiders" },
-  { value: "cursor", label: "Cursor" },
-  { value: "zed", label: "Zed" },
-  { value: "custom", label: "I already have something else" },
-];
-
-const MARKDOWN_EDITOR_OPTIONS: SelectOption[] = [
-  { value: "obsidian", label: "Obsidian" },
-  { value: "notion", label: "Notion" },
-  { value: "logseq", label: "Logseq" },
-  { value: "typora", label: "Typora" },
-  { value: "custom", label: "I already have something else" },
-];
 
 function commandExists(command: string): boolean {
   const result = spawnSync("sh", ["-lc", `command -v ${command}`], { stdio: "ignore" });
@@ -308,32 +273,6 @@ function buildBaseChecks(agent: string, ide: string, markdownEditor: string): Se
   return checks;
 }
 
-async function askYesNo(question: string, defaultValue = true): Promise<boolean> {
-  const rl = createInterface({ input: process.stdin, output: process.stdout });
-  const suffix = defaultValue ? "[Y/n]" : "[y/N]";
-  const answer = (await rl.question(`${question} ${suffix} `)).trim().toLowerCase();
-  rl.close();
-  if (!answer) return defaultValue;
-  return answer === "y" || answer === "yes";
-}
-
-async function selectOption(question: string, options: SelectOption[], fallback: string): Promise<string> {
-  const rl = createInterface({ input: process.stdin, output: process.stdout });
-  console.log();
-  console.log(chalk.bold(question));
-  options.forEach((option, index) => {
-    const isDefault = option.value === fallback;
-    console.log(`  ${index + 1}. ${option.label}${isDefault ? chalk.dim(" (recommended)") : ""}`);
-  });
-  const answer = (await rl.question("Choose a number and press Enter: ")).trim();
-  rl.close();
-  const selected = Number.parseInt(answer, 10);
-  if (Number.isFinite(selected) && selected >= 1 && selected <= options.length) {
-    return options[selected - 1]?.value ?? fallback;
-  }
-  return fallback;
-}
-
 function printChecks(checks: SetupCheck[]): void {
   console.log();
   console.log(chalk.bold("Machine readiness"));
@@ -352,15 +291,15 @@ function startConductor(projectPath: string, configPath: string): void {
   const cliEntrypoint = process.argv[1];
   if (!cliEntrypoint || cliEntrypoint.endsWith(".ts")) {
     console.log();
-    console.log(chalk.yellow("Setup finished. Run `co start` to launch Conductor."));
+    console.log(chalk.yellow("Setup finished. Run `co start --open` to launch Conductor."));
     return;
   }
 
   console.log();
-  console.log(chalk.bold("Launching Conductor..."));
+  console.log(chalk.bold("Opening Conductor in your browser..."));
   execFileSync(
     process.execPath,
-    [cliEntrypoint, "start", "--workspace", projectPath],
+    [cliEntrypoint, "start", "--workspace", projectPath, "--open"],
     {
       cwd: projectPath,
       stdio: "inherit",
@@ -393,41 +332,33 @@ export function registerSetup(program: Command): void {
     .action(async (opts: SetupOptions) => {
       try {
         const cwd = process.cwd();
-        const agent = opts.agent?.trim() || await selectOption("Which AI assistant should Conductor use by default?", AGENT_OPTIONS, "claude-code");
-        const ide = opts.ide?.trim() || await selectOption("Which code editor should open when someone reviews work?", IDE_OPTIONS, "vscode");
-        const markdownEditor = opts.markdownEditor?.trim() || await selectOption("Which notes app should Conductor expect for docs and context?", MARKDOWN_EDITOR_OPTIONS, "obsidian");
+        const agent = opts.agent?.trim() || "claude-code";
+        const ide = opts.ide?.trim() || "vscode";
+        const markdownEditor = opts.markdownEditor?.trim() || "obsidian";
 
         console.log();
         console.log(chalk.bold("Conductor Setup"));
-        console.log(chalk.dim("We’ll check your machine, install what is missing, scaffold the workspace, and start Conductor."));
+        console.log(chalk.dim("We’ll scaffold this repo, launch the dashboard, and let the browser finish the guided setup."));
 
         let checks = rerunChecks(agent, ide, markdownEditor);
         printChecks(checks);
 
-        const installableChecks = checks.filter((check) => !check.installed && check.install);
-        if (installableChecks.length > 0) {
-          const shouldInstall = opts.yes || await askYesNo("Install the missing tools automatically?", true);
-          if (shouldInstall) {
-            for (const check of installableChecks) {
-              if (!check.install) continue;
-              console.log();
-              console.log(chalk.bold(check.install.label));
-              runCommand(check.install);
-            }
+        if (opts.yes) {
+          const installableChecks = checks.filter((check) => !check.installed && check.install);
+          for (const check of installableChecks) {
+            if (!check.install) continue;
+            console.log();
+            console.log(chalk.bold(check.install.label));
+            runCommand(check.install);
           }
-        }
 
-        checks = rerunChecks(agent, ide, markdownEditor);
-        const pendingAuth = checks.filter((check) => !check.installed && check.authCommand);
-        if (pendingAuth.length > 0) {
-          const shouldConnect = opts.yes || await askYesNo("Connect GitHub in your browser now?", true);
-          if (shouldConnect) {
-            for (const check of pendingAuth) {
-              if (!check.authCommand) continue;
-              console.log();
-              console.log(chalk.bold(check.authCommand.label));
-              runCommand(check.authCommand);
-            }
+          checks = rerunChecks(agent, ide, markdownEditor);
+          const pendingAuth = checks.filter((check) => !check.installed && check.authCommand);
+          for (const check of pendingAuth) {
+            if (!check.authCommand) continue;
+            console.log();
+            console.log(chalk.bold(check.authCommand.label));
+            runCommand(check.authCommand);
           }
         }
 
@@ -441,6 +372,7 @@ export function registerSetup(program: Command): void {
           for (const check of remainingManual) {
             console.log(`  - ${check.label}: ${check.detail}`);
           }
+          console.log(chalk.dim("You can keep going. Finish the product-facing setup in the dashboard after it opens."));
         }
 
         console.log();
@@ -461,7 +393,11 @@ export function registerSetup(program: Command): void {
 
         if (opts.start !== false) {
           startConductor(project.path, configPath);
+          return;
         }
+
+        console.log();
+        console.log(chalk.dim(`Next step: co start --workspace ${project.path} --open`));
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         console.error(chalk.red(`Setup failed: ${message}`));

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -10,10 +10,71 @@
  */
 
 import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import chalk from "chalk";
 import ora from "ora";
 import type { Command } from "commander";
+import { buildConductorBoard, buildConductorYaml } from "@conductor-oss/core";
 import { createServices, loadConfig } from "../services.js";
+
+function openDashboardInBrowser(url: string): void {
+  const opener = process.platform === "darwin" ? "open" : "xdg-open";
+  const child = spawn(opener, [url], { stdio: "ignore", detached: true });
+  child.unref();
+  child.on("error", () => {
+    console.log(chalk.yellow(`Could not open browser automatically. Open ${url} manually.`));
+  });
+}
+
+async function waitForDashboard(url: string, timeoutMs = 15_000): Promise<boolean> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return true;
+      }
+    } catch {
+      // Dashboard is still starting.
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  return false;
+}
+
+function getDefaultLauncherWorkspace(): string {
+  return resolve(homedir(), ".openclaw", "workspace");
+}
+
+function ensureDashboardBootstrapWorkspace(): { workspacePath: string; configPath: string } {
+  const workspacePath = getDefaultLauncherWorkspace();
+  const configPath = join(workspacePath, "conductor.yaml");
+  const boardPath = join(workspacePath, "CONDUCTOR.md");
+
+  mkdirSync(workspacePath, { recursive: true });
+
+  if (!existsSync(configPath)) {
+    writeFileSync(configPath, buildConductorYaml({
+      preferences: {
+        onboardingAcknowledged: false,
+        codingAgent: "claude-code",
+        ide: "vscode",
+        markdownEditor: "obsidian",
+      },
+      projects: [],
+    }), "utf8");
+  }
+
+  if (!existsSync(boardPath)) {
+    writeFileSync(boardPath, buildConductorBoard("home", "Conductor Home"), "utf8");
+  }
+
+  return { workspacePath, configPath };
+}
 
 export function registerStart(program: Command): void {
   program
@@ -21,20 +82,47 @@ export function registerStart(program: Command): void {
     .description("Start lifecycle manager + board watcher + web dashboard (foreground)")
     .option("--no-dashboard", "Skip starting the web dashboard")
     .option("--no-watcher", "Skip starting the board watcher")
+    .option("--open", "Open the dashboard in your default browser")
     .option("-p, --port <port>", "Dashboard port override")
     .option("-w, --workspace <path>", "Obsidian workspace path")
-      .action(async (opts: { dashboard?: boolean; watcher?: boolean; port?: string; workspace?: string }) => {
+      .action(async (opts: { dashboard?: boolean; watcher?: boolean; open?: boolean; port?: string; workspace?: string }) => {
       try {
-        const config = await loadConfig(opts.workspace);
+        const explicitWorkspaceHint = opts.workspace ?? process.env["CONDUCTOR_WORKSPACE"];
+        let config;
+        if (explicitWorkspaceHint) {
+          config = await loadConfig(explicitWorkspaceHint);
+        } else {
+          try {
+            config = await loadConfig();
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            if (!/No conductor\.ya?ml found/i.test(message)) {
+              throw err;
+            }
+
+            const bootstrap = ensureDashboardBootstrapWorkspace();
+            process.env["CONDUCTOR_WORKSPACE"] = bootstrap.workspacePath;
+            process.env["CO_CONFIG_PATH"] = bootstrap.configPath;
+            config = await loadConfig(bootstrap.workspacePath);
+          }
+        }
+
+        const workspacePath = opts.workspace
+          ?? process.env["CONDUCTOR_WORKSPACE"]
+          ?? (config.configPath ? dirname(config.configPath) : `${process.env["HOME"]}/.conductor/workspace`);
+        if (!process.env["CONDUCTOR_WORKSPACE"]) {
+          process.env["CONDUCTOR_WORKSPACE"] = workspacePath;
+        }
+        if (!process.env["CO_CONFIG_PATH"] && config.configPath) {
+          process.env["CO_CONFIG_PATH"] = config.configPath;
+        }
+
         const { sessionManager, registry } = await createServices(config);
         const supportedAgents = registry.list("agent").map((agent) => agent.name);
 
         // Mutable ref — set after boardWatcher is created, used by lifecycle callback
         let boardWatcherRef: { updateNow(): void } | null = null;
         const port = opts.port ? parseInt(opts.port, 10) : (config.port ?? 3000);
-        const workspacePath = opts.workspace
-          ?? process.env["CONDUCTOR_WORKSPACE"]
-          ?? `${process.env["HOME"]}/.conductor/workspace`;
         const shutdownTasks: Array<() => void | Promise<void>> = [];
         let isShuttingDown = false;
 
@@ -129,8 +217,8 @@ export function registerStart(program: Command): void {
 
           try {
             const cliDir = new URL(".", import.meta.url).pathname;
-            const { join, resolve } = await import("node:path");
-            const { existsSync } = await import("node:fs");
+            const { dirname, join, resolve } = await import("node:path");
+            const { cpSync, existsSync, mkdirSync } = await import("node:fs");
 
             // Search order:
             // 1. Standalone build inside CLI package (npm install -g)
@@ -204,6 +292,14 @@ export function registerStart(program: Command): void {
             let dashboardCwd = webDir;
 
             if (standaloneServer) {
+              const standaloneAppDir = dirname(standaloneServer);
+              const standaloneStaticDir = join(standaloneAppDir, ".next", "static");
+              const sourceStaticDir = join(webDir, ".next", "static");
+              if (!existsSync(standaloneStaticDir) && existsSync(sourceStaticDir)) {
+                mkdirSync(join(standaloneAppDir, ".next"), { recursive: true });
+                cpSync(sourceStaticDir, standaloneStaticDir, { recursive: true });
+              }
+
               cmd = process.execPath;
               args = [standaloneServer];
               dashboardCwd = standaloneDir;
@@ -247,7 +343,18 @@ export function registerStart(program: Command): void {
               dashSpinner.warn("Dashboard failed to start. Try: cd packages/web && pnpm build");
             });
 
-            dashSpinner.succeed(`Web dashboard starting on http://localhost:${port}`);
+            const dashboardUrl = `http://localhost:${port}`;
+            dashSpinner.succeed(`Web dashboard starting on ${dashboardUrl}`);
+            if (opts.open) {
+              void waitForDashboard(`${dashboardUrl}/api/config`).then((ready) => {
+                if (ready) {
+                  openDashboardInBrowser(dashboardUrl);
+                  return;
+                }
+
+                console.log(chalk.yellow(`Dashboard is still starting. Open ${dashboardUrl} manually if it does not open shortly.`));
+              });
+            }
           } catch {
             dashSpinner.warn("Could not start dashboard.");
           }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -33,7 +33,7 @@ const program = new Command();
 program
   .name("co")
   .description("Conductor — markdown-native AI agent orchestrator")
-  .version("0.2.2");
+  .version("0.2.3");
 
 registerSpawn(program);
 registerList(program);
@@ -54,5 +54,9 @@ registerDoctor(program);
 registerRetry(program);
 registerTask(program);
 registerFeedback(program);
+
+if (process.argv.slice(2).length === 0) {
+  process.argv.push("start", "--open");
+}
 
 program.parse();

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/core",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,18 @@ export {
   findConfigFile,
 } from "./config.js";
 
+// Scaffolding helpers
+export {
+  buildConductorBoard,
+  buildConductorYaml,
+  buildProjectConfigRecord,
+} from "./scaffold.js";
+export type {
+  ConductorYamlScaffoldConfig,
+  ScaffoldPreferencesConfig,
+  ScaffoldProjectConfig,
+} from "./scaffold.js";
+
 // Plugin registry
 export { createPluginRegistry } from "./plugin-registry.js";
 

--- a/packages/core/src/scaffold.ts
+++ b/packages/core/src/scaffold.ts
@@ -1,0 +1,151 @@
+import { basename } from "node:path";
+import { stringify } from "yaml";
+import { generateSessionPrefix } from "./paths.js";
+
+export type ScaffoldNotificationPreferences = {
+  soundEnabled?: boolean;
+  soundFile?: string | null;
+};
+
+export type ScaffoldPreferencesConfig = {
+  onboardingAcknowledged?: boolean;
+  codingAgent?: string;
+  ide?: string;
+  remoteSshHost?: string | null;
+  remoteSshUser?: string | null;
+  markdownEditor?: string;
+  notifications?: ScaffoldNotificationPreferences;
+};
+
+export type ScaffoldProjectConfig = {
+  projectId: string;
+  displayName?: string;
+  repo: string;
+  path: string;
+  agent: string;
+  defaultBranch: string;
+  defaultWorkingDirectory?: string | null;
+  sessionPrefix?: string | null;
+  workspace?: string | null;
+  runtime?: string | null;
+  scm?: string | null;
+  boardDir?: string | null;
+  agentModel?: string | null;
+  agentPermissions?: "skip" | "default";
+};
+
+export type ConductorYamlScaffoldConfig = {
+  port?: number;
+  dashboardUrl?: string | null;
+  preferences?: ScaffoldPreferencesConfig;
+  projects?: ScaffoldProjectConfig[];
+};
+
+function normalizeProjectDisplayName(project: ScaffoldProjectConfig): string {
+  const explicit = project.displayName?.trim();
+  if (explicit) return explicit;
+  const fallback = basename(project.path).trim();
+  return fallback.length > 0 ? fallback : project.projectId;
+}
+
+export function buildConductorBoard(projectId: string, displayName: string): string {
+  return `# ${displayName}
+
+> Conductor AI agent orchestrator. Tags: \`#project/${projectId}\` \`#agent/claude-code\` \`#agent/codex\` \`#agent/gemini\`
+
+## Inbox
+
+> Drop rough ideas here.
+
+## Ready to Dispatch
+
+> Move tagged tasks here to dispatch an agent.
+
+## Dispatching
+
+## In Progress
+
+## Review
+
+## Done
+
+## Blocked
+`;
+}
+
+export function buildProjectConfigRecord(project: ScaffoldProjectConfig): Record<string, unknown> {
+  const nextProject: Record<string, unknown> = {
+    name: normalizeProjectDisplayName(project),
+    path: project.path,
+    repo: project.repo,
+    agent: project.agent,
+    defaultBranch: project.defaultBranch,
+    sessionPrefix: project.sessionPrefix?.trim() || generateSessionPrefix(basename(project.path)),
+    workspace: project.workspace?.trim() || "worktree",
+    runtime: project.runtime?.trim() || "tmux",
+    agentConfig: {
+      permissions: project.agentPermissions ?? "skip",
+    },
+  };
+
+  if (project.scm?.trim()) {
+    nextProject["scm"] = project.scm.trim();
+  } else if (project.repo.includes("/")) {
+    nextProject["scm"] = "github";
+  }
+
+  if (project.boardDir?.trim()) {
+    nextProject["boardDir"] = project.boardDir.trim();
+  }
+
+  if (project.defaultWorkingDirectory?.trim()) {
+    nextProject["defaultWorkingDirectory"] = project.defaultWorkingDirectory.trim();
+  }
+
+  if (project.agentModel?.trim()) {
+    nextProject["agentConfig"] = {
+      ...(nextProject["agentConfig"] as Record<string, unknown>),
+      model: project.agentModel.trim(),
+    };
+  }
+
+  return nextProject;
+}
+
+export function buildConductorYaml(config: ConductorYamlScaffoldConfig = {}): string {
+  const preferences = config.preferences ?? {};
+  const root: Record<string, unknown> = {
+    port: config.port ?? 4747,
+    preferences: {
+      onboardingAcknowledged: preferences.onboardingAcknowledged === true,
+      codingAgent: preferences.codingAgent?.trim() || "claude-code",
+      ide: preferences.ide?.trim() || "vscode",
+      markdownEditor: preferences.markdownEditor?.trim() || "obsidian",
+      notifications: {
+        soundEnabled: preferences.notifications?.soundEnabled !== false,
+        soundFile: preferences.notifications?.soundFile === null
+          ? null
+          : preferences.notifications?.soundFile?.trim() || "abstract-sound-4",
+      },
+    },
+    projects: {},
+  };
+
+  if (preferences.remoteSshHost?.trim()) {
+    (root["preferences"] as Record<string, unknown>)["remoteSshHost"] = preferences.remoteSshHost.trim();
+  }
+  if (preferences.remoteSshUser?.trim()) {
+    (root["preferences"] as Record<string, unknown>)["remoteSshUser"] = preferences.remoteSshUser.trim();
+  }
+  if (config.dashboardUrl?.trim()) {
+    root["dashboardUrl"] = config.dashboardUrl.trim();
+  }
+
+  const projects = config.projects ?? [];
+  const projectMap = root["projects"] as Record<string, unknown>;
+  for (const project of projects) {
+    projectMap[project.projectId] = buildProjectConfigRecord(project);
+  }
+
+  return stringify(root, { lineWidth: 0 });
+}

--- a/packages/plugins/agent-amp/package.json
+++ b/packages/plugins/agent-amp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-amp",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-amp/src/index.ts
+++ b/packages/plugins/agent-amp/src/index.ts
@@ -148,7 +148,7 @@ export const manifest = {
   name: "amp",
   slot: "agent" as const,
   description: "Agent plugin: Amp CLI",
-  version: "0.2.2",
+  version: "0.2.3",
 };
 
 function createAgent(): Agent {

--- a/packages/plugins/agent-ccr/package.json
+++ b/packages/plugins/agent-ccr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-ccr",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-ccr/src/index.ts
+++ b/packages/plugins/agent-ccr/src/index.ts
@@ -148,7 +148,7 @@ export const manifest = {
   name: "ccr",
   slot: "agent" as const,
   description: "Agent plugin: Claude Code Router",
-  version: "0.2.2",
+  version: "0.2.3",
 };
 
 function createAgent(): Agent {

--- a/packages/plugins/agent-claude-code/package.json
+++ b/packages/plugins/agent-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-claude-code",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -192,7 +192,7 @@ export const manifest = {
   name: "claude-code",
   slot: "agent" as const,
   description: "Agent plugin: Claude Code CLI",
-  version: "0.2.2",
+  version: "0.2.3",
 };
 
 // =============================================================================

--- a/packages/plugins/agent-codex/package.json
+++ b/packages/plugins/agent-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-codex",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -85,7 +85,7 @@ export const manifest = {
   name: "codex",
   slot: "agent" as const,
   description: "Agent plugin: OpenAI Codex CLI",
-  version: "0.2.2",
+  version: "0.2.3",
 };
 
 // =============================================================================

--- a/packages/plugins/agent-cursor-cli/package.json
+++ b/packages/plugins/agent-cursor-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-cursor-cli",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-cursor-cli/src/index.ts
+++ b/packages/plugins/agent-cursor-cli/src/index.ts
@@ -148,7 +148,7 @@ export const manifest = {
   name: "cursor-cli",
   slot: "agent" as const,
   description: "Agent plugin: Cursor CLI",
-  version: "0.2.2",
+  version: "0.2.3",
 };
 
 function createAgent(): Agent {

--- a/packages/plugins/agent-droid/package.json
+++ b/packages/plugins/agent-droid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-droid",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-droid/src/index.ts
+++ b/packages/plugins/agent-droid/src/index.ts
@@ -148,7 +148,7 @@ export const manifest = {
   name: "droid",
   slot: "agent" as const,
   description: "Agent plugin: Factory Droid CLI",
-  version: "0.2.2",
+  version: "0.2.3",
 };
 
 function createAgent(): Agent {

--- a/packages/plugins/agent-gemini/package.json
+++ b/packages/plugins/agent-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-gemini",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/plugins/agent-gemini/src/index.ts
+++ b/packages/plugins/agent-gemini/src/index.ts
@@ -80,7 +80,7 @@ export const manifest = {
   name: "gemini",
   slot: "agent" as const,
   description: "Agent plugin: Google Gemini CLI",
-  version: "0.2.2",
+  version: "0.2.3",
 };
 
 // =============================================================================

--- a/packages/plugins/agent-github-copilot/package.json
+++ b/packages/plugins/agent-github-copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-github-copilot",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-github-copilot/src/index.ts
+++ b/packages/plugins/agent-github-copilot/src/index.ts
@@ -148,7 +148,7 @@ export const manifest = {
   name: "github-copilot",
   slot: "agent" as const,
   description: "Agent plugin: GitHub Copilot CLI",
-  version: "0.2.2",
+  version: "0.2.3",
 };
 
 function createAgent(): Agent {

--- a/packages/plugins/agent-opencode/package.json
+++ b/packages/plugins/agent-opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-opencode",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-opencode/src/index.ts
+++ b/packages/plugins/agent-opencode/src/index.ts
@@ -148,7 +148,7 @@ export const manifest = {
   name: "opencode",
   slot: "agent" as const,
   description: "Agent plugin: OpenCode CLI",
-  version: "0.2.2",
+  version: "0.2.3",
 };
 
 function createAgent(): Agent {

--- a/packages/plugins/agent-qwen-code/package.json
+++ b/packages/plugins/agent-qwen-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-qwen-code",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-qwen-code/src/index.ts
+++ b/packages/plugins/agent-qwen-code/src/index.ts
@@ -148,7 +148,7 @@ export const manifest = {
   name: "qwen-code",
   slot: "agent" as const,
   description: "Agent plugin: Qwen Code CLI",
-  version: "0.2.2",
+  version: "0.2.3",
 };
 
 function createAgent(): Agent {

--- a/packages/plugins/mcp-server/package.json
+++ b/packages/plugins/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-mcp-server",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/mcp-server/src/index.ts
+++ b/packages/plugins/mcp-server/src/index.ts
@@ -103,7 +103,7 @@ function serializeProject(id: string, p: ProjectConfig): Record<string, unknown>
 export function createMcpServer(): McpServer {
   const server = new McpServer({
     name: "conductor",
-    version: "0.2.2",
+    version: "0.2.3",
   });
 
   // -------------------------------------------------------------------------

--- a/packages/plugins/notifier-desktop/package.json
+++ b/packages/plugins/notifier-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-notifier-desktop",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-desktop/src/index.ts
+++ b/packages/plugins/notifier-desktop/src/index.ts
@@ -22,7 +22,7 @@ export const manifest = {
   name: "desktop",
   slot: "notifier" as const,
   description: "Notifier plugin: desktop notifications (macOS + Linux)",
-  version: "0.2.2",
+  version: "0.2.3",
 };
 
 const PLATFORM = platform();

--- a/packages/plugins/notifier-discord/package.json
+++ b/packages/plugins/notifier-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-notifier-discord",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-discord/src/index.ts
+++ b/packages/plugins/notifier-discord/src/index.ts
@@ -18,7 +18,7 @@ export const manifest = {
   name: "discord",
   slot: "notifier" as const,
   description: "Notifier plugin: Discord via REST API",
-  version: "0.2.2",
+  version: "0.2.3",
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/plugins/runtime-tmux/package.json
+++ b/packages/plugins/runtime-tmux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-runtime-tmux",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/runtime-tmux/src/index.ts
+++ b/packages/plugins/runtime-tmux/src/index.ts
@@ -45,7 +45,7 @@ export const manifest = {
   name: "tmux",
   slot: "runtime" as const,
   description: "Runtime plugin: tmux sessions",
-  version: "0.2.2",
+  version: "0.2.3",
 };
 
 /** Only allow safe characters in session IDs */

--- a/packages/plugins/scm-github/package.json
+++ b/packages/plugins/scm-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-scm-github",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/scm-github/src/index.ts
+++ b/packages/plugins/scm-github/src/index.ts
@@ -411,7 +411,7 @@ export const manifest = {
   name: "github",
   slot: "scm" as const,
   description: "SCM plugin: GitHub PRs, CI checks, reviews, merge readiness",
-  version: "0.2.2",
+  version: "0.2.3",
 };
 
 export function create(): SCM {

--- a/packages/plugins/terminal-web/package.json
+++ b/packages/plugins/terminal-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-terminal-web",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/terminal-web/src/index.ts
+++ b/packages/plugins/terminal-web/src/index.ts
@@ -16,7 +16,7 @@ export const manifest = {
   name: "web",
   slot: "terminal" as const,
   description: "Terminal plugin: web terminal via browser",
-  version: "0.2.2",
+  version: "0.2.3",
 };
 
 export function create(config?: Record<string, unknown>): Terminal {

--- a/packages/plugins/tracker-github/package.json
+++ b/packages/plugins/tracker-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-tracker-github",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/tracker-github/src/index.ts
+++ b/packages/plugins/tracker-github/src/index.ts
@@ -161,7 +161,7 @@ export const manifest = {
   name: "github",
   slot: "tracker" as const,
   description: "Tracker plugin: GitHub Issues",
-  version: "0.2.2",
+  version: "0.2.3",
 };
 
 export function create(): Tracker {

--- a/packages/plugins/webhook/package.json
+++ b/packages/plugins/webhook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-webhook",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/workspace-worktree/package.json
+++ b/packages/plugins/workspace-worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-workspace-worktree",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/workspace-worktree/src/index.ts
+++ b/packages/plugins/workspace-worktree/src/index.ts
@@ -41,7 +41,7 @@ export const manifest = {
   name: "worktree",
   slot: "workspace" as const,
   description: "Workspace plugin: git worktrees",
-  version: "0.2.2",
+  version: "0.2.3",
 };
 
 /** Run a git command in a given directory */

--- a/packages/web/src/app/api/preferences/route.ts
+++ b/packages/web/src/app/api/preferences/route.ts
@@ -4,6 +4,7 @@ import { parse, stringify } from "yaml";
 import type { UserPreferences } from "@conductor-oss/core";
 import { getServices, invalidateServicesCache } from "@/lib/services";
 import { guardApiAccess, guardApiActionAccess } from "@/lib/auth";
+import { syncAllProjectLocalConfigs } from "@/lib/projectConfigSync";
 
 export const dynamic = "force-dynamic";
 
@@ -166,7 +167,8 @@ export async function PUT(request: NextRequest) {
 
     try {
       invalidateServicesCache("preferences updated");
-      await getServices();
+      const { config: refreshedConfig } = await getServices();
+      await syncAllProjectLocalConfigs(refreshedConfig as unknown as Record<string, unknown>);
     } catch (err) {
       await writeFile(configPath, originalConfigRaw, "utf8");
       invalidateServicesCache("preferences update rollback");

--- a/packages/web/src/app/api/repositories/route.ts
+++ b/packages/web/src/app/api/repositories/route.ts
@@ -8,6 +8,7 @@ import { homedir } from "node:os";
 import { parse, stringify } from "yaml";
 import { getServices, invalidateServicesCache } from "@/lib/services";
 import { guardApiAccess, guardApiActionAccess } from "@/lib/auth";
+import { syncProjectLocalConfig } from "@/lib/projectConfigSync";
 
 export const dynamic = "force-dynamic";
 
@@ -375,7 +376,8 @@ export async function PUT(request: NextRequest) {
 
     try {
       invalidateServicesCache("repository settings updated");
-      await getServices();
+      const { config: refreshedConfig } = await getServices();
+      await syncProjectLocalConfig(refreshedConfig as unknown as Record<string, unknown>, id);
     } catch (err) {
       await writeFile(configPath, originalConfigRaw, "utf8");
       invalidateServicesCache("repository settings update rollback");

--- a/packages/web/src/app/api/spawn/route.ts
+++ b/packages/web/src/app/api/spawn/route.ts
@@ -1,9 +1,58 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { getServices } from "@/lib/services";
+import { readFile, writeFile } from "node:fs/promises";
+import { parse, stringify } from "yaml";
+import { getServices, invalidateServicesCache } from "@/lib/services";
 import { guardApiAccess, guardApiActionAccess } from "@/lib/auth";
 import { sessionToDashboard } from "@/lib/serialize";
+import { syncProjectLocalConfig } from "@/lib/projectConfigSync";
 
 /** POST /api/spawn -- Spawn a new agent session. */
+
+type MutableConfig = Record<string, unknown>;
+
+function toObject(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return { ...(value as Record<string, unknown>) };
+}
+
+async function persistSpawnAgentSelection(configPath: string, projectId: string, agent: string): Promise<void> {
+  const originalConfigRaw = await readFile(configPath, "utf8");
+  const parsed = (parse(originalConfigRaw) ?? {}) as MutableConfig;
+  const nextRoot: MutableConfig =
+    parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? { ...parsed }
+      : {};
+
+  const nextProjects = toObject(nextRoot["projects"]);
+  const existingProject = toObject(nextProjects[projectId]);
+  nextProjects[projectId] = {
+    ...existingProject,
+    agent,
+  };
+  nextRoot["projects"] = nextProjects;
+
+  const nextPreferences = toObject(nextRoot["preferences"]);
+  nextRoot["preferences"] = {
+    ...nextPreferences,
+    codingAgent: agent,
+  };
+
+  const updatedYaml = stringify(nextRoot, { lineWidth: 0 });
+  await writeFile(configPath, updatedYaml, "utf8");
+
+  try {
+    invalidateServicesCache("spawn agent selection updated");
+    const { config: refreshedConfig } = await getServices();
+    await syncProjectLocalConfig(refreshedConfig as unknown as Record<string, unknown>, projectId);
+  } catch (err) {
+    await writeFile(configPath, originalConfigRaw, "utf8");
+    invalidateServicesCache("spawn agent selection rollback");
+    throw err;
+  }
+}
+
 export async function POST(request: NextRequest) {
   const denied = await guardApiAccess();
   if (denied) return denied;
@@ -116,6 +165,14 @@ export async function POST(request: NextRequest) {
         { error: "Either prompt or issueId is required to create a workspace" },
         { status: 400 },
       );
+    }
+
+    if (normalizedAgent && config.configPath) {
+      const currentProjectAgent = config.projects[normalizedProjectId]?.agent;
+      const currentPreferredAgent = config.preferences?.codingAgent;
+      if (normalizedAgent !== currentProjectAgent || normalizedAgent !== currentPreferredAgent) {
+        await persistSpawnAgentSelection(config.configPath, normalizedProjectId, normalizedAgent);
+      }
     }
 
     const session = await sessionManager.spawn({

--- a/packages/web/src/app/api/workspaces/route.ts
+++ b/packages/web/src/app/api/workspaces/route.ts
@@ -5,9 +5,10 @@ import { homedir } from "node:os";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { parse, stringify } from "yaml";
-import { generateSessionPrefix } from "@conductor-oss/core";
+import { buildConductorBoard, buildProjectConfigRecord, generateSessionPrefix } from "@conductor-oss/core";
 import { getServices, invalidateServicesCache } from "@/lib/services";
 import { guardApiAccess, guardApiActionAccess } from "@/lib/auth";
+import { syncProjectLocalConfig } from "@/lib/projectConfigSync";
 
 const execFileAsync = promisify(execFile);
 
@@ -198,7 +199,16 @@ function toProjectMap(value: unknown): Record<string, unknown> {
   return { ...(value as Record<string, unknown>) };
 }
 
+function deriveDisplayName(projectId: string): string {
+  const humanized = projectId
+    .replace(/[-_]+/g, " ")
+    .trim();
+  if (humanized.length === 0) return projectId;
+  return humanized.replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
 function buildProjectPayload(args: {
+  projectId: string;
   path: string;
   repo: string;
   defaultBranch: string;
@@ -206,7 +216,9 @@ function buildProjectPayload(args: {
   sessionPrefix: string;
   useWorktree: boolean;
 }): Record<string, unknown> {
-  return {
+  return buildProjectConfigRecord({
+    projectId: args.projectId,
+    displayName: deriveDisplayName(args.projectId),
     path: args.path,
     repo: args.repo,
     defaultBranch: args.defaultBranch,
@@ -214,7 +226,8 @@ function buildProjectPayload(args: {
     sessionPrefix: args.sessionPrefix,
     workspace: args.useWorktree ? "worktree" : "local",
     runtime: "tmux",
-  };
+    scm: args.repo.includes("/") ? "github" : null,
+  });
 }
 
 function getExistingPathBasenames(existingPaths: string[]): Set<string> {
@@ -279,6 +292,20 @@ async function writeProjectToConfig(args: {
     invalidateServicesCache("workspace add rollback");
     throw err;
   }
+}
+
+async function ensureProjectBoard(args: {
+  path: string;
+  projectId: string;
+  displayName: string;
+}): Promise<void> {
+  const boardPath = resolve(args.path, "CONDUCTOR.md");
+  const boardStats = await stat(boardPath).catch(() => null);
+  if (boardStats?.isFile()) {
+    return;
+  }
+
+  await writeFile(boardPath, buildConductorBoard(args.projectId, args.displayName), "utf8");
 }
 
 export const dynamic = "force-dynamic";
@@ -409,6 +436,7 @@ export async function POST(request: NextRequest) {
         configPath,
         projectId,
         projectData: buildProjectPayload({
+          projectId,
           path: targetPath,
           repo: repoValue,
           defaultBranch,
@@ -417,6 +445,15 @@ export async function POST(request: NextRequest) {
           useWorktree,
         }),
       });
+      await ensureProjectBoard({
+        path: targetPath,
+        projectId,
+        displayName: deriveDisplayName(projectId),
+      });
+      {
+        const { config: refreshedConfig } = await getServices();
+        await syncProjectLocalConfig(refreshedConfig as unknown as Record<string, unknown>, projectId);
+      }
 
       return NextResponse.json(
         {
@@ -485,6 +522,7 @@ export async function POST(request: NextRequest) {
       configPath,
       projectId,
       projectData: buildProjectPayload({
+        projectId,
         path: localPath,
         repo: repoValue,
         defaultBranch,
@@ -493,6 +531,15 @@ export async function POST(request: NextRequest) {
         useWorktree,
       }),
     });
+    await ensureProjectBoard({
+      path: localPath,
+      projectId,
+      displayName: deriveDisplayName(projectId),
+    });
+    {
+      const { config: refreshedConfig } = await getServices();
+      await syncProjectLocalConfig(refreshedConfig as unknown as Record<string, unknown>, projectId);
+    }
 
     return NextResponse.json(
       {

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -154,12 +154,14 @@ type SettingsTabId =
   | "mcp"
   | "preferences";
 
-const SETTINGS_TABS: Array<{
+type SettingsTab = {
   id: SettingsTabId;
   label: string;
   icon: LucideIcon;
   implemented: boolean;
-}> = [
+};
+
+const SETTINGS_TABS: SettingsTab[] = [
   { id: "general", label: "General", icon: Settings2, implemented: false },
   { id: "repositories", label: "Repositories", icon: FolderGit2, implemented: true },
   { id: "organization", label: "Organization Settings", icon: Building2, implemented: false },
@@ -167,6 +169,11 @@ const SETTINGS_TABS: Array<{
   { id: "agents", label: "Agents", icon: Bot, implemented: false },
   { id: "mcp", label: "MCP Servers", icon: PlugZap, implemented: false },
   { id: "preferences", label: "Preferences", icon: SlidersHorizontal, implemented: true },
+];
+
+const ONBOARDING_TABS: SettingsTab[] = [
+  { id: "preferences", label: "Preferences", icon: SlidersHorizontal, implemented: true },
+  { id: "repositories", label: "Repository", icon: FolderGit2, implemented: true },
 ];
 
 const IDE_OPTIONS = [
@@ -357,6 +364,7 @@ export default function Home() {
   const [preferencesSaving, setPreferencesSaving] = useState(false);
   const [preferencesError, setPreferencesError] = useState<string | null>(null);
   const [preferencesDialogOpen, setPreferencesDialogOpen] = useState(false);
+  const [pendingWorkspaceSetup, setPendingWorkspaceSetup] = useState(false);
 
   const dashboardSessions = sessions as unknown as DashboardSession[];
   const workspaceError = createError ?? configError ?? sessionsError ?? preferencesError;
@@ -469,7 +477,10 @@ export default function Home() {
     }
   }, [agentOptions, selectedAgent]);
 
-  async function handleSavePreferences(next: PreferencesPayload) {
+  async function handleSavePreferences(
+    next: PreferencesPayload,
+    options?: { closeDialog?: boolean },
+  ) {
     setPreferencesSaving(true);
     setPreferencesError(null);
     try {
@@ -487,7 +498,9 @@ export default function Home() {
       const normalized = normalizePreferences(data?.preferences, next.codingAgent || "qwen-code");
       setPreferences(normalized);
       setSelectedAgent(normalized.codingAgent);
-      setPreferencesDialogOpen(false);
+      if (options?.closeDialog !== false) {
+        setPreferencesDialogOpen(false);
+      }
     } catch (err) {
       setPreferencesError(err instanceof Error ? err.message : "Failed to save preferences");
       throw err;
@@ -517,6 +530,12 @@ export default function Home() {
     setNewWorkspaceOpen(true);
     syncSidebarForViewport();
   };
+
+  useEffect(() => {
+    if (!pendingWorkspaceSetup || preferencesDialogOpen) return;
+    setPendingWorkspaceSetup(false);
+    openWorkspaceDialog();
+  }, [pendingWorkspaceSetup, preferencesDialogOpen]);
 
   async function handleCreateSession() {
     const trimmedPrompt = prompt.trim();
@@ -720,6 +739,11 @@ export default function Home() {
         current={resolvedPreferences}
         agentOptions={agentOptions}
         onRepositoriesChanged={refreshConfig}
+        onOnboardingComplete={({ needsProject }) => {
+          if (needsProject) {
+            setPendingWorkspaceSetup(true);
+          }
+        }}
         onClose={() => {
           if (preferencesSaving || onboardingRequired) return;
           setPreferencesDialogOpen(false);
@@ -1674,6 +1698,7 @@ function SettingsDialog({
   current,
   agentOptions,
   onRepositoriesChanged,
+  onOnboardingComplete,
   onClose,
   onSave,
 }: {
@@ -1684,8 +1709,9 @@ function SettingsDialog({
   current: PreferencesPayload;
   agentOptions: string[];
   onRepositoriesChanged?: () => Promise<void>;
+  onOnboardingComplete?: (result: { needsProject: boolean }) => void;
   onClose: () => void;
-  onSave: (next: PreferencesPayload) => Promise<void>;
+  onSave: (next: PreferencesPayload, options?: { closeDialog?: boolean }) => Promise<void>;
 }) {
   const [activeTab, setActiveTab] = useState<SettingsTabId>("preferences");
   const [codingAgent, setCodingAgent] = useState(current.codingAgent);
@@ -1798,9 +1824,9 @@ function SettingsDialog({
     }
   }
 
-  async function handleSaveRepository(): Promise<void> {
-    if (!repositoryDraft || repositoriesSaving) return;
-    if (repositoryDraft.repo.trim().length === 0 || repositoryDraft.path.trim().length === 0) return;
+  async function handleSaveRepository(): Promise<boolean> {
+    if (!repositoryDraft || repositoriesSaving) return false;
+    if (repositoryDraft.repo.trim().length === 0 || repositoryDraft.path.trim().length === 0) return false;
 
     setRepositoriesSaving(true);
     setRepositoriesError(null);
@@ -1847,8 +1873,10 @@ function SettingsDialog({
       if (onRepositoriesChanged) {
         await onRepositoriesChanged();
       }
+      return true;
     } catch (err) {
       setRepositoriesError(err instanceof Error ? err.message : "Failed to save repository settings");
+      return false;
     } finally {
       setRepositoriesSaving(false);
     }
@@ -1866,16 +1894,16 @@ function SettingsDialog({
     setSoundFile(current.notifications.soundFile);
     setRepositoryBranchOptions([]);
     setRepositoryBranchesError(null);
-  }, [current, open]);
+  }, [open]);
 
   useEffect(() => {
-    if (!open || mode !== "settings") return;
+    if (!open) return;
     void loadRepositories();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, mode]);
+  }, [open]);
 
   useEffect(() => {
-    if (!open || mode !== "settings") return;
+    if (!open) return;
     if (!selectedRepositoryId) {
       setRepositoryDraft(null);
       return;
@@ -1889,18 +1917,26 @@ function SettingsDialog({
       void detectRepositoryBranches(selected.path, selected.defaultBranch);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, mode, repositories, selectedRepositoryId]);
+  }, [open, repositories, selectedRepositoryId]);
+
+  const onboardingShouldShowRepositoryStep = mode === "onboarding"
+    && (repositoriesLoading || repositories.length > 0);
 
   const visibleTabs = useMemo(() => {
     if (mode === "onboarding") {
-      return SETTINGS_TABS.filter((tab) => tab.id === "preferences");
+      return onboardingShouldShowRepositoryStep
+        ? ONBOARDING_TABS
+        : ONBOARDING_TABS.filter((tab) => tab.id === "preferences");
     }
     return SETTINGS_TABS;
-  }, [mode]);
+  }, [mode, onboardingShouldShowRepositoryStep]);
 
   const activeTabItem = visibleTabs.find((tab) => tab.id === activeTab) ?? visibleTabs[0] ?? SETTINGS_TABS[0];
+  const isOnboarding = mode === "onboarding";
   const isPreferencesTab = activeTabItem.id === "preferences";
   const isRepositoriesTab = activeTabItem.id === "repositories";
+  const onboardingStepIndex = visibleTabs.findIndex((tab) => tab.id === activeTabItem.id) + 1;
+  const onboardingHasRepositoryStep = visibleTabs.some((tab) => tab.id === "repositories");
 
   const orderedAgentOptions = useMemo(() => {
     const opts = new Set(agentOptions);
@@ -1936,14 +1972,13 @@ function SettingsDialog({
       })
     : "";
 
-  async function handleSubmitPreferences() {
-    if (!canSubmitPreferences || creating) return;
+  function buildNextPreferences(acknowledgeOnboarding: boolean): PreferencesPayload {
     const resolvedSoundFile = soundEnabled
       ? soundFile ?? NOTIFICATION_SOUND_OPTIONS[0]?.id ?? "abstract-sound-4"
       : null;
 
-    await onSave({
-      onboardingAcknowledged: mode === "onboarding" ? true : current.onboardingAcknowledged,
+    return {
+      onboardingAcknowledged: acknowledgeOnboarding ? true : current.onboardingAcknowledged,
       codingAgent: codingAgent.trim(),
       ide: ide.trim(),
       remoteSshHost: remoteSshHost.trim(),
@@ -1953,7 +1988,37 @@ function SettingsDialog({
         soundEnabled,
         soundFile: resolvedSoundFile,
       },
-    });
+    };
+  }
+
+  async function handleSubmitPreferences(
+    acknowledgeOnboarding: boolean,
+    options?: { closeDialog?: boolean },
+  ) {
+    if (!canSubmitPreferences || creating) return;
+    await onSave(buildNextPreferences(acknowledgeOnboarding), options);
+  }
+
+  async function handleOnboardingContinue() {
+    if (repositoriesLoading) return;
+    if (!onboardingHasRepositoryStep) {
+      await handleSubmitPreferences(true, { closeDialog: true });
+      onOnboardingComplete?.({ needsProject: repositories.length === 0 });
+      return;
+    }
+
+    await handleSubmitPreferences(false, { closeDialog: false });
+    setActiveTab("repositories");
+  }
+
+  async function handleFinishOnboarding() {
+    if (isRepositoriesTab) {
+      const saved = await handleSaveRepository();
+      if (!saved) return;
+    }
+
+    await handleSubmitPreferences(true, { closeDialog: true });
+    onOnboardingComplete?.({ needsProject: false });
   }
 
   return (
@@ -1972,7 +2037,9 @@ function SettingsDialog({
         >
           <aside className="flex w-full shrink-0 flex-col border-b border-[var(--vk-border)] bg-[rgba(28,28,28,0.8)] sm:w-[224px] sm:border-b-0 sm:border-r">
             <header className="border-b border-[var(--vk-border)] px-4 py-3 sm:py-4">
-              <h2 className="text-[22px] leading-[24px] text-[var(--vk-text-strong)] sm:text-[27px] sm:leading-[27px]">Settings</h2>
+              <h2 className="text-[22px] leading-[24px] text-[var(--vk-text-strong)] sm:text-[27px] sm:leading-[27px]">
+                {isOnboarding ? "Setup" : "Settings"}
+              </h2>
             </header>
             <nav className="flex gap-1 overflow-x-auto p-2 sm:block sm:space-y-1 sm:overflow-auto">
               {visibleTabs.map((tab) => {
@@ -2000,9 +2067,20 @@ function SettingsDialog({
 
           <div className="flex min-w-0 flex-1 flex-col">
             <header className="flex items-center justify-between border-b border-[var(--vk-border)] px-4 py-3 sm:py-4">
-              <h3 className="text-[20px] leading-[24px] text-[var(--vk-text-strong)] sm:text-[27px] sm:leading-[27px]">
-                {mode === "onboarding" && isPreferencesTab ? "2. Confirm your preferences" : activeTabItem.label}
-              </h3>
+              <div>
+                <h3 className="text-[20px] leading-[24px] text-[var(--vk-text-strong)] sm:text-[27px] sm:leading-[27px]">
+                  {isOnboarding
+                    ? isPreferencesTab
+                      ? "Choose your preferences"
+                      : "Review repository defaults"
+                    : activeTabItem.label}
+                </h3>
+                {isOnboarding && (
+                  <p className="mt-1 text-[12px] text-[var(--vk-text-muted)]">
+                    Step {onboardingStepIndex} of {visibleTabs.length}
+                  </p>
+                )}
+              </div>
               <button
                 type="button"
                 onClick={onClose}
@@ -2017,6 +2095,15 @@ function SettingsDialog({
             <div className="min-h-0 flex-1 overflow-auto px-4 py-3 sm:px-6 sm:py-4">
               {isPreferencesTab ? (
                 <div className="space-y-5">
+                  {isOnboarding && (
+                    <section className="rounded-[6px] border border-[var(--vk-border)] bg-[rgba(234,122,42,0.08)] px-4 py-3">
+                      <p className="text-[13px] leading-5 text-[var(--vk-text-normal)]">
+                        Conductor is already running locally. Finish setup here in the dashboard, then you can start using
+                        chat and boards immediately.
+                      </p>
+                    </section>
+                  )}
+
                   <section className="space-y-2">
                     <h4 className="text-[15px] font-medium text-[var(--vk-text-strong)]">Choose Your Coding Agent</h4>
                     <p className="text-[12px] text-[var(--vk-text-muted)]">Select the default coding agent configuration.</p>
@@ -2179,45 +2266,63 @@ function SettingsDialog({
               ) : isRepositoriesTab ? (
                 <div className="space-y-5">
                   <section className="space-y-1">
-                    <h4 className="text-[24px] leading-[24px] text-[var(--vk-text-strong)]">Repository Configuration</h4>
+                    <h4 className="text-[24px] leading-[24px] text-[var(--vk-text-strong)]">
+                      {isOnboarding ? "Repository Defaults" : "Repository Configuration"}
+                    </h4>
                     <p className="text-[14px] text-[var(--vk-text-muted)]">
-                      Configure scripts and defaults used whenever this repository is selected for workspaces.
+                      {isOnboarding
+                        ? "Review the repository Conductor will use for this workspace. You can edit advanced scripts later from Settings."
+                        : "Configure scripts and defaults used whenever this repository is selected for workspaces."}
                     </p>
                   </section>
 
-                  <section className="space-y-2">
+                  {(mode === "settings" || repositories.length > 1) && (
+                    <section className="space-y-2">
+                      <label className="block">
+                        <span className="mb-1.5 block text-[12px] font-medium text-[var(--vk-text-normal)]">Select Repository</span>
+                        <select
+                          value={selectedRepositoryId}
+                          onChange={(event) => setSelectedRepositoryId(event.target.value)}
+                          disabled={repositoriesLoading || repositories.length === 0 || isBusy}
+                          className="h-9 w-full rounded-[4px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] px-2 text-[13px] text-[var(--vk-text-normal)] outline-none focus:border-[var(--vk-orange)] disabled:opacity-60"
+                        >
+                          {repositories.length === 0 && <option value="">No repositories configured</option>}
+                          {repositories.map((repository) => (
+                            <option key={repository.id} value={repository.id}>
+                              {repository.displayName}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                      <p className="text-[12px] text-[var(--vk-text-muted)]">
+                        Select a repository to view and edit its configuration.
+                      </p>
+                      {repositoriesLoading && (
+                        <p className="text-[12px] text-[var(--vk-text-muted)]">Loading repositories...</p>
+                      )}
+                    </section>
+                  )}
+
+                  {isOnboarding && repositories.length === 1 && repositoryDraft && (
                     <label className="block">
-                      <span className="mb-1.5 block text-[12px] font-medium text-[var(--vk-text-normal)]">Select Repository</span>
-                      <select
-                        value={selectedRepositoryId}
-                        onChange={(event) => setSelectedRepositoryId(event.target.value)}
-                        disabled={repositoriesLoading || repositories.length === 0 || isBusy}
-                        className="h-9 w-full rounded-[4px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] px-2 text-[13px] text-[var(--vk-text-normal)] outline-none focus:border-[var(--vk-orange)] disabled:opacity-60"
-                      >
-                        {repositories.length === 0 && <option value="">No repositories configured</option>}
-                        {repositories.map((repository) => (
-                          <option key={repository.id} value={repository.id}>
-                            {repository.displayName}
-                          </option>
-                        ))}
-                      </select>
+                      <span className="mb-1.5 block text-[12px] font-medium text-[var(--vk-text-normal)]">Detected Repository</span>
+                      <div className="rounded-[4px] border border-[var(--vk-border)] bg-[rgba(15,15,15,0.52)] px-3 py-3 text-[13px] text-[var(--vk-text-normal)]">
+                        {repositoryDraft.displayName}
+                        <span className="ml-2 text-[var(--vk-text-muted)]">{repositoryDraft.path}</span>
+                      </div>
                     </label>
-                    <p className="text-[12px] text-[var(--vk-text-muted)]">
-                      Select a repository to view and edit its configuration.
-                    </p>
-                    {repositoriesLoading && (
-                      <p className="text-[12px] text-[var(--vk-text-muted)]">Loading repositories...</p>
-                    )}
-                  </section>
+                  )}
 
                   {repositoryDraft && (
                     <>
-                      <section className="space-y-3 border-t border-[var(--vk-border)] pt-4">
+                      {mode === "settings" && (
+                        <section className="space-y-3 border-t border-[var(--vk-border)] pt-4">
                         <div className="space-y-1">
-                          <h5 className="text-[22px] leading-[22px] text-[var(--vk-text-strong)]">One-Line Bootstrap</h5>
+                          <h5 className="text-[22px] leading-[22px] text-[var(--vk-text-strong)]">Repo-Preseed Bootstrap</h5>
                           <p className="text-[13px] text-[var(--vk-text-muted)]">
-                            Run this from any terminal to launch a PM-friendly guided setup. It checks the machine,
-                            installs supported tools, connects GitHub, writes the repo defaults below, and starts Conductor.
+                            Use this when you already know the target repository and want one command to prefill it. The
+                            default first-run path is still `npx conductor-oss@latest`, which opens the dashboard and lets
+                            the user choose preferences before adding a project.
                           </p>
                         </div>
 
@@ -2241,11 +2346,13 @@ function SettingsDialog({
 
                         <div className="flex flex-wrap items-center justify-between gap-2">
                           <p className="text-[12px] text-[var(--vk-text-muted)]">
-                            This command uses your selected agent, editor, and notes app. Best on macOS with Homebrew. GitHub sign-in still opens a browser so the user can approve access.
+                            This command uses your selected agent, editor, and notes app. Best on macOS with Homebrew.
+                            GitHub sign-in still opens a browser so the user can approve access.
                           </p>
                           <CopySnippetButton value={repositoryBootstrapCommand} idleLabel="Copy Setup Command" />
                         </div>
-                      </section>
+                        </section>
+                      )}
 
                       <section className="space-y-3 border-t border-[var(--vk-border)] pt-4">
                         <h5 className="text-[22px] leading-[22px] text-[var(--vk-text-strong)]">General Settings</h5>
@@ -2397,7 +2504,8 @@ function SettingsDialog({
                         </label>
                       </section>
 
-                      <section className="space-y-3 border-t border-[var(--vk-border)] pt-4">
+                      {mode === "settings" && (
+                        <section className="space-y-3 border-t border-[var(--vk-border)] pt-4">
                         <h5 className="text-[22px] leading-[22px] text-[var(--vk-text-strong)]">Scripts & Configuration</h5>
                         <p className="text-[13px] text-[var(--vk-text-muted)]">
                           Configure dev server, setup, cleanup, archive, and file-copy behavior for this repository.
@@ -2473,7 +2581,8 @@ function SettingsDialog({
                             Comma-separated relative file paths or glob patterns copied from the repo to each worktree.
                           </p>
                         </label>
-                      </section>
+                        </section>
+                      )}
                     </>
                   )}
                 </div>
@@ -2503,19 +2612,21 @@ function SettingsDialog({
                 )}
                 {!error && !repositoriesError && isPreferencesTab && (
                   <p className="text-[11px] text-[var(--vk-text-muted)]">
-                    {mode === "onboarding"
-                      ? "These preferences can be changed any time from Settings."
+                    {isOnboarding
+                      ? "Finish setup once here. You can change these preferences any time from Settings."
                       : "Preferences are saved to your conductor config and applied immediately."}
                   </p>
                 )}
                 {!error && !repositoriesError && isRepositoriesTab && (
                   <p className="text-[11px] text-[var(--vk-text-muted)]">
-                    Repository settings are saved to your conductor config and used for future workspaces.
+                    {isOnboarding
+                      ? "These defaults will be used the first time workspaces and tasks are created for this repo."
+                      : "Repository settings are saved to your conductor config and used for future workspaces."}
                   </p>
                 )}
               </div>
               <div className="flex w-full flex-wrap items-center justify-end gap-2 sm:w-auto">
-                {mode === "settings" && (
+                {!isOnboarding && (
                   <button
                     type="button"
                     onClick={onClose}
@@ -2525,10 +2636,22 @@ function SettingsDialog({
                     Close
                   </button>
                 )}
-                {isPreferencesTab && (
+                {isOnboarding && isRepositoriesTab && (
                   <button
                     type="button"
-                    onClick={handleSubmitPreferences}
+                    onClick={() => setActiveTab("preferences")}
+                    disabled={isBusy}
+                    className="inline-flex h-9 items-center rounded-[4px] border border-[var(--vk-border)] px-3 text-[13px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-50"
+                  >
+                    Back
+                  </button>
+                )}
+                {isPreferencesTab && !isOnboarding && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      void handleSubmitPreferences(current.onboardingAcknowledged, { closeDialog: true });
+                    }}
                     disabled={!canSubmitPreferences || creating}
                     className="inline-flex h-9 items-center rounded-[4px] bg-[var(--vk-bg-active)] px-3 text-[13px] text-[var(--vk-text-strong)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-50"
                   >
@@ -2537,10 +2660,10 @@ function SettingsDialog({
                         <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
                         Saving...
                       </>
-                    ) : mode === "onboarding" ? "Continue" : "Save"}
+                    ) : "Save"}
                   </button>
                 )}
-                {isRepositoriesTab && mode === "settings" && (
+                {isRepositoriesTab && !isOnboarding && (
                   <button
                     type="button"
                     onClick={() => {
@@ -2555,6 +2678,31 @@ function SettingsDialog({
                         Saving...
                       </>
                     ) : "Save Repository"}
+                  </button>
+                )}
+                {isOnboarding && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      void (isPreferencesTab ? handleOnboardingContinue() : handleFinishOnboarding());
+                    }}
+                    disabled={
+                      isPreferencesTab
+                        ? !canSubmitPreferences || creating || repositoriesLoading
+                        : !canSaveRepository || isBusy
+                    }
+                    className="inline-flex h-9 items-center rounded-[4px] bg-[var(--vk-bg-active)] px-3 text-[13px] text-[var(--vk-text-strong)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-50"
+                  >
+                    {isBusy || (isPreferencesTab && repositoriesLoading) ? (
+                      <>
+                        <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                        {isPreferencesTab && repositoriesLoading ? "Loading..." : "Saving..."}
+                      </>
+                    ) : isPreferencesTab ? (
+                      onboardingHasRepositoryStep ? "Continue" : "Finish Setup"
+                    ) : (
+                      "Finish Setup"
+                    )}
                   </button>
                 )}
               </div>

--- a/packages/web/src/lib/projectConfigSync.ts
+++ b/packages/web/src/lib/projectConfigSync.ts
@@ -1,0 +1,92 @@
+import { join, resolve } from "node:path";
+import { writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { buildConductorYaml, type ScaffoldProjectConfig } from "@conductor-oss/core";
+
+type MutableConfig = Record<string, unknown>;
+
+function asNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function toObject(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return { ...(value as Record<string, unknown>) };
+}
+
+function expandHome(value: string): string {
+  if (value.startsWith("~/")) {
+    return resolve(homedir(), value.slice(2));
+  }
+  return resolve(value);
+}
+
+function normalizePreferences(value: unknown) {
+  const root = toObject(value);
+  const notifications = toObject(root["notifications"]);
+
+  return {
+    onboardingAcknowledged: root["onboardingAcknowledged"] === true,
+    codingAgent: asNonEmptyString(root["codingAgent"]) ?? "claude-code",
+    ide: asNonEmptyString(root["ide"]) ?? "vscode",
+    remoteSshHost: asNonEmptyString(root["remoteSshHost"]),
+    remoteSshUser: asNonEmptyString(root["remoteSshUser"]),
+    markdownEditor: asNonEmptyString(root["markdownEditor"]) ?? "obsidian",
+    notifications: {
+      soundEnabled: notifications["soundEnabled"] !== false,
+      soundFile: notifications["soundFile"] === null
+        ? null
+        : asNonEmptyString(notifications["soundFile"]) ?? "abstract-sound-4",
+    },
+  };
+}
+
+function buildProjectScaffold(projectId: string, project: Record<string, unknown>): ScaffoldProjectConfig {
+  const agentConfig = toObject(project["agentConfig"]);
+
+  return {
+    projectId,
+    displayName: asNonEmptyString(project["name"]) ?? projectId,
+    repo: asNonEmptyString(project["repo"]) ?? `local-${projectId}`,
+    path: expandHome(asNonEmptyString(project["path"]) ?? projectId),
+    agent: asNonEmptyString(project["agent"]) ?? "claude-code",
+    defaultBranch: asNonEmptyString(project["defaultBranch"]) ?? "main",
+    defaultWorkingDirectory: asNonEmptyString(project["defaultWorkingDirectory"]),
+    sessionPrefix: asNonEmptyString(project["sessionPrefix"]),
+    workspace: asNonEmptyString(project["workspace"]),
+    runtime: asNonEmptyString(project["runtime"]),
+    scm: asNonEmptyString(project["scm"]),
+    boardDir: asNonEmptyString(project["boardDir"]),
+    agentModel: asNonEmptyString(agentConfig["model"]),
+    agentPermissions: agentConfig["permissions"] === "default" ? "default" : "skip",
+  };
+}
+
+export async function syncProjectLocalConfig(rootConfig: MutableConfig, projectId: string): Promise<void> {
+  const projects = toObject(rootConfig["projects"]);
+  const project = toObject(projects[projectId]);
+  const projectPath = asNonEmptyString(project["path"]);
+  if (!projectPath) {
+    return;
+  }
+
+  const yaml = buildConductorYaml({
+    port: typeof rootConfig["port"] === "number" ? rootConfig["port"] : 4747,
+    dashboardUrl: asNonEmptyString(rootConfig["dashboardUrl"]),
+    preferences: normalizePreferences(rootConfig["preferences"]),
+    projects: [buildProjectScaffold(projectId, project)],
+  });
+
+  await writeFile(join(expandHome(projectPath), "conductor.yaml"), yaml, "utf8");
+}
+
+export async function syncAllProjectLocalConfigs(rootConfig: MutableConfig): Promise<void> {
+  const projects = toObject(rootConfig["projects"]);
+  for (const projectId of Object.keys(projects)) {
+    await syncProjectLocalConfig(rootConfig, projectId);
+  }
+}

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -208,7 +208,10 @@ function findConfigFromWorkspace(workspace?: string): string | undefined {
 function getConfigStateFromEnv(): { path: string | undefined } {
   const envConfigPath = normalizeConfigPath(process.env["CO_CONFIG_PATH"]);
   const workspaceConfigPath = findConfigFromWorkspace(process.env["CONDUCTOR_WORKSPACE"]);
-  const homeWorkspaceConfig = normalizeConfigPath(`${homedir()}/.openclaw/workspace/conductor.yaml`);
+  const homeWorkspaceConfigCandidate = normalizeConfigPath(`${homedir()}/.openclaw/workspace/conductor.yaml`);
+  const homeWorkspaceConfig = homeWorkspaceConfigCandidate && existsSync(homeWorkspaceConfigCandidate)
+    ? homeWorkspaceConfigCandidate
+    : undefined;
 
   return {
     path: envConfigPath ||

--- a/scripts/cli-release-stage.mjs
+++ b/scripts/cli-release-stage.mjs
@@ -52,6 +52,22 @@ function copyOptionalFile(sourcePath, destinationPath) {
   }
 }
 
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
+function copyDirectoryResolvingSymlinks(sourcePath, destinationPath) {
+  mkdirSync(destinationPath, { recursive: true });
+  execFileSync(
+    "sh",
+    [
+      "-lc",
+      `tar -chf - -C ${shellQuote(sourcePath)} . | tar -xf - -C ${shellQuote(destinationPath)}`,
+    ],
+    { stdio: "inherit" },
+  );
+}
+
 function sanitizePublishedPackage(pkg, dependencies) {
   const sanitized = {
     name: pkg.name,
@@ -174,11 +190,13 @@ export function createCliReleaseStage({ rootDir = process.cwd(), stageDir } = {}
   copyOptionalFile(resolve(resolvedRootDir, "LICENSE"), join(outputDir, "LICENSE"));
 
   const webOutputDir = join(outputDir, "web");
-  cpSync(webBundle.standaloneDir, join(webOutputDir, ".next", "standalone"), {
-    recursive: true,
-    dereference: true,
-  });
+  copyDirectoryResolvingSymlinks(webBundle.standaloneDir, join(webOutputDir, ".next", "standalone"));
   cpSync(webBundle.staticDir, join(webOutputDir, ".next", "static"), { recursive: true });
+  cpSync(
+    webBundle.staticDir,
+    join(webOutputDir, ".next", "standalone", "packages", "web", ".next", "static"),
+    { recursive: true },
+  );
   if (existsSync(webBundle.publicDir)) {
     cpSync(webBundle.publicDir, join(webOutputDir, "public"), { recursive: true });
   }

--- a/scripts/verify-cli-package.mjs
+++ b/scripts/verify-cli-package.mjs
@@ -6,8 +6,63 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { packCliReleasePackage } from "./cli-release-stage.mjs";
 
 function fail(message) {
-  console.error(`release preflight failed: ${message}`);
-  process.exit(1);
+  throw new Error(`release preflight failed: ${message}`);
+}
+
+function createTempDir(prefix, tempDirs) {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function getInstalledCliEntry(installDir) {
+  return join(installDir, "node_modules", "conductor-oss", "dist", "index.js");
+}
+
+function readTextFile(path) {
+  return readFileSync(path, "utf8");
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function yamlContainsProject(content, projectId) {
+  return new RegExp(`(^|\\n)  ${escapeRegExp(projectId)}:`, "m").test(content);
+}
+
+function spawnInstalledCli(installDir, args, options = {}) {
+  const cliEntry = getInstalledCliEntry(installDir);
+  const child = spawn("node", [cliEntry, ...args], {
+    cwd: installDir,
+    stdio: ["ignore", "pipe", "pipe"],
+    ...options,
+  });
+
+  let bufferedStdout = "";
+  let bufferedStderr = "";
+  child.stdout?.on("data", (chunk) => {
+    bufferedStdout += chunk.toString();
+  });
+  child.stderr?.on("data", (chunk) => {
+    bufferedStderr += chunk.toString();
+  });
+
+  return {
+    child,
+    getLogs() {
+      return `${bufferedStdout}\n${bufferedStderr}`.trim();
+    },
+  };
+}
+
+async function stopProcess(child) {
+  if (!child || child.exitCode !== null) return;
+  child.kill("SIGTERM");
+  await sleep(1000);
+  if (child.exitCode === null) {
+    child.kill("SIGKILL");
+  }
 }
 
 async function waitForDashboard(url, timeoutMs) {
@@ -27,11 +82,563 @@ async function waitForDashboard(url, timeoutMs) {
   throw new Error(`Timed out waiting for ${url}`);
 }
 
+async function waitForCondition(description, check, timeoutMs = 20_000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      if (await check()) {
+        return;
+      }
+    } catch {
+      // Condition is not ready yet.
+    }
+    await sleep(500);
+  }
+
+  throw new Error(`Timed out waiting for ${description}`);
+}
+
+async function fetchJson(url, init) {
+  const response = await fetch(url, init);
+  const payload = await response.json().catch(() => null);
+  return { response, payload };
+}
+
+async function verifyDashboardAssets(baseUrl) {
+  const response = await fetch(baseUrl);
+  if (!response.ok) {
+    throw new Error(`dashboard home page returned ${response.status}`);
+  }
+
+  const html = await response.text();
+  const assetPaths = [...html.matchAll(/(?:href|src)=\"(\/_next\/static\/[^\"]+)\"/g)]
+    .map((match) => match[1])
+    .filter(Boolean);
+
+  if (assetPaths.length === 0) {
+    throw new Error("dashboard home page did not reference any static assets");
+  }
+
+  for (const assetPath of assetPaths.slice(0, 5)) {
+    await waitForCondition(`dashboard asset ${assetPath}`, async () => {
+      const assetResponse = await fetch(new URL(assetPath, baseUrl));
+      return assetResponse.ok;
+    }, 10_000);
+  }
+}
+
+async function withBrowser(run) {
+  const { default: puppeteer } = await import("puppeteer");
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+  });
+
+  try {
+    return await run(browser);
+  } finally {
+    await browser.close();
+  }
+}
+
+async function clickButtonByText(page, label) {
+  await page.evaluate((expectedLabel) => {
+    const button = [...document.querySelectorAll("button")].find((candidate) => {
+      return candidate.textContent?.trim() === expectedLabel && !candidate.disabled;
+    });
+
+    if (!button) {
+      throw new Error(`Button not found: ${expectedLabel}`);
+    }
+
+    button.click();
+  }, label);
+}
+
+async function fillInput(page, selector, value) {
+  const isMac = process.platform === "darwin";
+  await page.click(selector, { clickCount: 3 });
+  await page.keyboard.down(isMac ? "Meta" : "Control");
+  await page.keyboard.press("A");
+  await page.keyboard.up(isMac ? "Meta" : "Control");
+  await page.keyboard.press("Backspace");
+  if (String(value).length > 0) {
+    await page.type(selector, String(value));
+  }
+}
+
+async function clickOnboardingPrimaryAction(page) {
+  await page.waitForFunction(
+    () => [...document.querySelectorAll("button")].some((candidate) => {
+      const label = candidate.textContent?.trim();
+      return (label === "Continue" || label === "Finish Setup") && !candidate.disabled;
+    }),
+    { timeout: 20_000 },
+  );
+
+  await page.evaluate(() => {
+    const button = [...document.querySelectorAll("button")].find((candidate) => {
+      const label = candidate.textContent?.trim();
+      return (label === "Continue" || label === "Finish Setup") && !candidate.disabled;
+    });
+
+    if (!button) {
+      throw new Error("Onboarding action button not found");
+    }
+
+    button.click();
+  });
+}
+
+async function verifyFirstRunOnboarding(baseUrl) {
+  await withBrowser(async (browser) => {
+    const page = await browser.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (error) => {
+      pageErrors.push(error.message);
+    });
+
+    await page.goto(baseUrl, { waitUntil: "domcontentloaded" });
+    await page.waitForFunction(
+      () => document.body?.innerText?.includes("Choose your preferences"),
+      { timeout: 20_000 },
+    );
+
+    await clickButtonByText(page, "Claude Code");
+    await clickButtonByText(page, "Cursor");
+    await clickButtonByText(page, "Notion");
+    await clickButtonByText(page, "No sound");
+    await fillInput(page, 'input[placeholder="e.g., conductor-dev or 203.0.113.10"]', "conductor-dev");
+    await fillInput(page, 'input[placeholder="e.g., ubuntu"]', "pm");
+    await clickOnboardingPrimaryAction(page);
+
+    await page.waitForFunction(
+      () => document.body?.innerText?.includes("Add Workspace"),
+      { timeout: 20_000 },
+    );
+    await page.waitForFunction(
+      () => document.body?.innerText?.includes("Local Folder")
+        && document.body?.innerText?.includes("Git Repository"),
+      { timeout: 10_000 },
+    );
+
+    if (pageErrors.length > 0) {
+      throw new Error(`browser onboarding triggered runtime errors: ${pageErrors.join("; ")}`);
+    }
+  });
+}
+
+async function verifyConfiguredWorkspaceOnboarding(baseUrl) {
+  await withBrowser(async (browser) => {
+    const page = await browser.newPage();
+    const pageErrors = [];
+    page.on("pageerror", (error) => {
+      pageErrors.push(error.message);
+    });
+
+    await page.goto(baseUrl, { waitUntil: "domcontentloaded" });
+    await page.waitForFunction(
+      () => document.body?.innerText?.includes("Choose your preferences"),
+      { timeout: 20_000 },
+    );
+    await page.waitForFunction(
+      () => document.body?.innerText?.includes("Step 1 of 2"),
+      { timeout: 10_000 },
+    );
+
+    await clickButtonByText(page, "Cursor");
+    await clickButtonByText(page, "Notion");
+    await clickButtonByText(page, "No sound");
+    await fillInput(page, 'input[placeholder="e.g., conductor-dev or 203.0.113.10"]', "conductor-dev");
+    await fillInput(page, 'input[placeholder="e.g., ubuntu"]', "pm");
+    await clickButtonByText(page, "Continue");
+
+    await page.waitForFunction(
+      () => document.body?.innerText?.includes("Review repository defaults"),
+      { timeout: 20_000 },
+    );
+    await page.waitForFunction(
+      () => document.body?.innerText?.includes("Step 2 of 2"),
+      { timeout: 10_000 },
+    );
+
+    await fillInput(page, 'input[placeholder="e.g., your-org/your-repo"]', "example/release-smoke-onboarded");
+    await clickButtonByText(page, "Finish Setup");
+
+    await page.waitForFunction(
+      () => !document.body?.innerText?.includes("Review repository defaults")
+        && !document.body?.innerText?.includes("Finish Setup"),
+      { timeout: 20_000 },
+    );
+    await page.waitForFunction(
+      () => document.body?.innerText?.includes("What would you like to work on?"),
+      { timeout: 20_000 },
+    );
+
+    if (pageErrors.length > 0) {
+      throw new Error(`browser onboarding triggered runtime errors: ${pageErrors.join("; ")}`);
+    }
+  });
+}
+
+async function verifyDashboardReadyState(baseUrl) {
+  await withBrowser(async (browser) => {
+    const page = await browser.newPage();
+    await page.goto(baseUrl, { waitUntil: "domcontentloaded" });
+    await page.waitForFunction(
+      () => document.body?.innerText?.includes("What would you like to work on?"),
+      { timeout: 20_000 },
+    );
+    await page.waitForFunction(
+      () => !document.body?.innerText?.includes("Choose your preferences"),
+      { timeout: 10_000 },
+    );
+  });
+}
+
+async function verifyBrowserFirstLauncherFlow(installDir, tempDirs) {
+  const homeDir = createTempDir("conductor-cli-home-", tempDirs);
+  const projectDir = createTempDir("conductor-cli-project-", tempDirs);
+  const baseUrl = "http://127.0.0.1:4747";
+
+  const launcher = spawnInstalledCli(installDir, [], {
+    env: {
+      ...process.env,
+      HOME: homeDir,
+    },
+  });
+
+  try {
+    await waitForDashboard(`${baseUrl}/api/config`, 25_000);
+    await verifyDashboardAssets(baseUrl);
+    await verifyFirstRunOnboarding(baseUrl);
+
+    const bootstrapWorkspace = join(homeDir, ".openclaw", "workspace");
+    const bootstrapConfigPath = join(bootstrapWorkspace, "conductor.yaml");
+    const bootstrapBoardPath = join(bootstrapWorkspace, "CONDUCTOR.md");
+
+    if (!existsSync(bootstrapConfigPath)) {
+      throw new Error("bare launcher did not create ~/.openclaw/workspace/conductor.yaml");
+    }
+    if (!existsSync(bootstrapBoardPath)) {
+      throw new Error("bare launcher did not create ~/.openclaw/workspace/CONDUCTOR.md");
+    }
+
+    await waitForCondition("first-run preferences to persist", async () => {
+      const { response, payload } = await fetchJson(`${baseUrl}/api/preferences`);
+      if (!response.ok) return false;
+
+      const preferences = payload?.preferences;
+      return preferences?.onboardingAcknowledged === true
+        && preferences?.codingAgent === "claude-code"
+        && preferences?.ide === "cursor"
+        && preferences?.markdownEditor === "notion"
+        && preferences?.notifications?.soundEnabled === false
+        && preferences?.remoteSshHost === "conductor-dev"
+        && preferences?.remoteSshUser === "pm";
+    });
+
+    const createWorkspaceResult = await fetchJson(`${baseUrl}/api/workspaces`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        mode: "local",
+        path: projectDir,
+        defaultBranch: "main",
+        agent: "claude-code",
+        initializeGit: true,
+        useWorktree: true,
+      }),
+    });
+
+    if (!createWorkspaceResult.response.ok) {
+      throw new Error(
+        `browser-first project creation failed (${createWorkspaceResult.response.status}): ${createWorkspaceResult.payload?.error ?? "unknown error"}`,
+      );
+    }
+
+    const createdProjectId = createWorkspaceResult.payload?.project?.id;
+    if (typeof createdProjectId !== "string" || createdProjectId.trim().length === 0) {
+      throw new Error("browser-first project creation did not return a project id");
+    }
+
+    const projectBoardPath = join(projectDir, "CONDUCTOR.md");
+    const projectConfigPath = join(projectDir, "conductor.yaml");
+
+    await waitForCondition("project scaffolding to be written", async () => {
+      return existsSync(projectBoardPath) && existsSync(projectConfigPath);
+    });
+
+    const boardContents = readFileSync(projectBoardPath, "utf8");
+    if (!boardContents.includes(`#project/${createdProjectId}`)) {
+      throw new Error("generated CONDUCTOR.md is missing the project tag");
+    }
+
+    await waitForCondition("repo-local config to reflect onboarding preferences", async () => {
+      const projectYaml = readTextFile(projectConfigPath);
+      return yamlContainsProject(projectYaml, createdProjectId)
+        && projectYaml.includes("codingAgent: claude-code")
+        && projectYaml.includes("ide: cursor")
+        && projectYaml.includes("markdownEditor: notion")
+        && projectYaml.includes("soundEnabled: false")
+        && projectYaml.includes("remoteSshHost: conductor-dev")
+        && projectYaml.includes("remoteSshUser: pm")
+        && projectYaml.includes(`path: ${projectDir}`)
+        && projectYaml.includes("agent: claude-code");
+    });
+
+    const repositoriesResult = await fetchJson(`${baseUrl}/api/repositories`);
+    if (!repositoriesResult.response.ok) {
+      throw new Error(`failed to load repositories after first-run setup (${repositoriesResult.response.status})`);
+    }
+
+    const repository = repositoriesResult.payload?.repositories?.find((item) => item.id === createdProjectId);
+    if (!repository) {
+      throw new Error("new project was not exposed through /api/repositories");
+    }
+
+    const updateRepositoryResult = await fetchJson(`${baseUrl}/api/repositories`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: repository.id,
+        displayName: repository.displayName,
+        repo: "example/browser-first-smoke",
+        path: repository.path,
+        agent: repository.agent,
+        defaultWorkingDirectory: "app",
+        defaultBranch: repository.defaultBranch,
+        devServerScript: repository.devServerScript,
+        setupScript: repository.setupScript,
+        runSetupInParallel: repository.runSetupInParallel,
+        cleanupScript: repository.cleanupScript,
+        archiveScript: repository.archiveScript,
+        copyFiles: repository.copyFiles,
+      }),
+    });
+
+    if (!updateRepositoryResult.response.ok) {
+      throw new Error(
+        `repository settings update failed (${updateRepositoryResult.response.status}): ${updateRepositoryResult.payload?.error ?? "unknown error"}`,
+      );
+    }
+
+    await waitForCondition("repo-local config to reflect repository settings", async () => {
+      const projectYaml = readTextFile(projectConfigPath);
+      return yamlContainsProject(projectYaml, createdProjectId)
+        && projectYaml.includes("repo: example/browser-first-smoke")
+        && projectYaml.includes("defaultWorkingDirectory: app");
+    });
+
+    const updatePreferencesResult = await fetchJson(`${baseUrl}/api/preferences`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        onboardingAcknowledged: true,
+        codingAgent: "claude-code",
+        ide: "vscode",
+        remoteSshHost: "conductor-prod",
+        remoteSshUser: "pm-team",
+        markdownEditor: "obsidian",
+        notifications: {
+          soundEnabled: true,
+          soundFile: "abstract-sound-4",
+        },
+      }),
+    });
+
+    if (!updatePreferencesResult.response.ok) {
+      throw new Error(
+        `preferences update failed (${updatePreferencesResult.response.status}): ${updatePreferencesResult.payload?.error ?? "unknown error"}`,
+      );
+    }
+
+    await waitForCondition("repo-local config to reflect preferences updates", async () => {
+      const projectYaml = readTextFile(projectConfigPath);
+      return projectYaml.includes("codingAgent: claude-code")
+        && projectYaml.includes("ide: vscode")
+        && projectYaml.includes("markdownEditor: obsidian")
+        && projectYaml.includes("soundEnabled: true")
+        && projectYaml.includes("soundFile: abstract-sound-4")
+        && projectYaml.includes("remoteSshHost: conductor-prod")
+        && projectYaml.includes("remoteSshUser: pm-team");
+    });
+
+    const spawnResult = await fetchJson(`${baseUrl}/api/spawn`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        projectId: createdProjectId,
+        prompt: "Smoke test the agent launcher",
+        agent: "codex",
+      }),
+    });
+
+    if (spawnResult.response.status === 404 || spawnResult.response.status === 400) {
+      throw new Error(
+        `spawn endpoint rejected dashboard launch inputs (${spawnResult.response.status}): ${spawnResult.payload?.error ?? "unknown error"}`,
+      );
+    }
+
+    await waitForCondition("repo-local config to reflect spawn agent selection", async () => {
+      const projectYaml = readTextFile(projectConfigPath);
+      return projectYaml.includes("codingAgent: codex")
+        && yamlContainsProject(projectYaml, createdProjectId)
+        && projectYaml.includes("agent: codex");
+    });
+
+    const createdSessionId = spawnResult.payload?.session?.id;
+    if (typeof createdSessionId === "string" && createdSessionId.length > 0) {
+      await fetch(`${baseUrl}/api/sessions/${createdSessionId}/kill`, {
+        method: "POST",
+      }).catch(() => {
+        // Best-effort cleanup.
+      });
+    }
+
+    const bootstrapConfig = readTextFile(bootstrapConfigPath);
+    if (!yamlContainsProject(bootstrapConfig, createdProjectId) || !bootstrapConfig.includes(`path: ${projectDir}`)) {
+      throw new Error("home workspace config did not retain the created project");
+    }
+
+    await verifyDashboardReadyState(baseUrl);
+
+    if (launcher.child.exitCode !== null && launcher.child.exitCode !== 0) {
+      throw new Error(`bare launcher exited early with code ${launcher.child.exitCode}\n${launcher.getLogs()}`);
+    }
+  } finally {
+    await stopProcess(launcher.child);
+  }
+}
+
+async function verifyConfiguredWorkspaceFlow(installDir, tempDirs) {
+  const repoDir = createTempDir("conductor-cli-repo-", tempDirs);
+  const baseUrl = "http://127.0.0.1:4111";
+
+  execFileSync("git", ["init", "-b", "main", repoDir], {
+    cwd: installDir,
+    stdio: "ignore",
+  });
+
+  execFileSync(
+    "node",
+    [
+      getInstalledCliEntry(installDir),
+      "init",
+      "--path",
+      repoDir,
+      "--project-id",
+      "release-smoke",
+      "--display-name",
+      "Release Smoke",
+      "--repo",
+      "example/release-smoke",
+      "--default-branch",
+      "main",
+    ],
+    {
+      cwd: installDir,
+      stdio: "inherit",
+    },
+  );
+
+  const configPath = join(repoDir, "conductor.yaml");
+  const configContents = readFileSync(configPath, "utf8").replace(/^port:\s*4747$/m, "port: 4111");
+  writeFileSync(configPath, configContents, "utf8");
+
+  execFileSync(
+    "node",
+    [
+      getInstalledCliEntry(installDir),
+      "doctor",
+      "--workspace",
+      repoDir,
+      "--json",
+    ],
+    {
+      cwd: installDir,
+      stdio: "inherit",
+    },
+  );
+
+  const dashboard = spawnInstalledCli(installDir, [
+    "start",
+    "--no-watcher",
+    "--port",
+    "4111",
+    "--workspace",
+    repoDir,
+  ], {
+    env: {
+      ...process.env,
+      CONDUCTOR_WORKSPACE: repoDir,
+      CO_CONFIG_PATH: configPath,
+    },
+  });
+
+  try {
+    await waitForDashboard(`${baseUrl}/api/config`, 20_000);
+    await verifyDashboardAssets(baseUrl);
+    await verifyConfiguredWorkspaceOnboarding(baseUrl);
+
+    let preferences = null;
+    await waitForCondition("configured-workspace onboarding preferences to persist", async () => {
+      const { response, payload } = await fetchJson(`${baseUrl}/api/preferences`);
+      if (!response.ok) {
+        return false;
+      }
+
+      const nextPreferences = payload?.preferences;
+      if (!nextPreferences?.onboardingAcknowledged) return false;
+      if (nextPreferences.ide !== "cursor") return false;
+      if (nextPreferences.markdownEditor !== "notion") return false;
+      if (nextPreferences.notifications?.soundEnabled !== false) return false;
+      if (nextPreferences.remoteSshHost !== "conductor-dev" || nextPreferences.remoteSshUser !== "pm") return false;
+
+      preferences = nextPreferences;
+      return true;
+    });
+
+    if (!preferences) {
+      throw new Error("configured-workspace onboarding preferences were not available after persistence wait");
+    }
+
+    let repository = null;
+    await waitForCondition("configured-workspace repository settings to persist", async () => {
+      const { response, payload } = await fetchJson(`${baseUrl}/api/repositories`);
+      if (!response.ok) {
+        return false;
+      }
+
+      const nextRepository = payload?.repositories?.[0];
+      if (!nextRepository) {
+        return false;
+      }
+      if (nextRepository.repo !== "example/release-smoke-onboarded") {
+        return false;
+      }
+
+      repository = nextRepository;
+      return true;
+    });
+
+    if (!repository) {
+      throw new Error("configured-workspace repository settings were not available after onboarding persistence wait");
+    }
+
+    if (dashboard.child.exitCode !== null && dashboard.child.exitCode !== 0) {
+      throw new Error(`configured-workspace dashboard exited early with code ${dashboard.child.exitCode}\n${dashboard.getLogs()}`);
+    }
+  } finally {
+    await stopProcess(dashboard.child);
+  }
+}
+
 const rootDir = resolve(process.cwd());
-const packDir = mkdtempSync(join(tmpdir(), "conductor-cli-pack-"));
-const installDir = mkdtempSync(join(tmpdir(), "conductor-cli-install-"));
-const repoDir = mkdtempSync(join(tmpdir(), "conductor-cli-repo-"));
-let dashboardProcess = null;
+const tempDirs = [];
+const packDir = createTempDir("conductor-cli-pack-", tempDirs);
+const installDir = createTempDir("conductor-cli-install-", tempDirs);
+let exitCode = 0;
 
 try {
   const { tarballPath } = packCliReleasePackage({ rootDir, packDestination: packDir });
@@ -43,7 +650,7 @@ try {
     cwd: installDir,
     stdio: "inherit",
   });
-  execFileSync("node", ["node_modules/conductor-oss/dist/index.js", "--version"], {
+  execFileSync("node", [getInstalledCliEntry(installDir), "--version"], {
     cwd: installDir,
     stdio: "inherit",
   });
@@ -81,98 +688,16 @@ try {
     fail("installed CLI package is missing bundled internal runtime packages");
   }
 
-  execFileSync(
-    "node",
-    [
-      "node_modules/conductor-oss/dist/index.js",
-      "init",
-      "--path",
-      repoDir,
-      "--project-id",
-      "release-smoke",
-      "--display-name",
-      "Release Smoke",
-      "--repo",
-      "example/release-smoke",
-      "--default-branch",
-      "main",
-    ],
-    {
-      cwd: installDir,
-      stdio: "inherit",
-    },
-  );
-
-  const configPath = join(repoDir, "conductor.yaml");
-  const configContents = readFileSync(configPath, "utf8").replace(/^port:\s*4747$/m, "port: 4111");
-  writeFileSync(configPath, configContents, "utf8");
-
-  execFileSync(
-    "node",
-    [
-      "node_modules/conductor-oss/dist/index.js",
-      "doctor",
-      "--workspace",
-      repoDir,
-      "--json",
-    ],
-    {
-      cwd: installDir,
-      stdio: "inherit",
-    },
-  );
-
-  dashboardProcess = spawn(
-    "node",
-    [
-      "node_modules/conductor-oss/dist/index.js",
-      "start",
-      "--no-watcher",
-      "--port",
-      "4111",
-      "--workspace",
-      repoDir,
-    ],
-    {
-      cwd: installDir,
-      env: {
-        ...process.env,
-        CONDUCTOR_WORKSPACE: repoDir,
-      },
-      stdio: ["ignore", "pipe", "pipe"],
-    },
-  );
-
-  let bufferedStdout = "";
-  let bufferedStderr = "";
-  dashboardProcess.stdout?.on("data", (chunk) => {
-    bufferedStdout += chunk.toString();
-  });
-  dashboardProcess.stderr?.on("data", (chunk) => {
-    bufferedStderr += chunk.toString();
-  });
-
-  await waitForDashboard("http://127.0.0.1:4111/api/config", 20000);
-
-  if (dashboardProcess.exitCode !== null && dashboardProcess.exitCode !== 0) {
-    fail(`packaged dashboard process exited early with code ${dashboardProcess.exitCode}\n${bufferedStdout}\n${bufferedStderr}`);
-  }
+  await verifyBrowserFirstLauncherFlow(installDir, tempDirs);
+  await verifyConfiguredWorkspaceFlow(installDir, tempDirs);
 
   console.log("release preflight passed");
 } catch (error) {
-  if (error instanceof Error) {
-    fail(error.message);
-  }
-  fail(String(error));
+  exitCode = 1;
+  console.error(error instanceof Error ? error.message : String(error));
 } finally {
-  if (dashboardProcess && dashboardProcess.exitCode === null) {
-    dashboardProcess.kill("SIGTERM");
-    await sleep(1000);
-    if (dashboardProcess.exitCode === null) {
-      dashboardProcess.kill("SIGKILL");
-    }
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
   }
-  rmSync(packDir, { recursive: true, force: true });
-  rmSync(installDir, { recursive: true, force: true });
-  rmSync(repoDir, { recursive: true, force: true });
+  process.exit(exitCode);
 }


### PR DESCRIPTION
## Summary
- default the public startup flow to a browser-first launcher so `npx conductor-oss@latest` opens the dashboard directly
- scaffold projects from the dashboard and keep repo-local `conductor.yaml` synced with preferences, repository settings, and dashboard agent launches
- harden the packaged release preflight to validate the real first-run flow end to end before publish

## Validation
- `pnpm typecheck`
- `pnpm build:release`
- `pnpm release:verify`
- `pnpm release:publish`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--open` flag to dashboard launcher for automatic browser opening
  * Streamlined setup wizard with smart defaults for tools and preferences
  * Automatic workspace and project configuration generation on first run
  * Real-time synchronization of settings between dashboard and local configuration files

* **Documentation**
  * Updated onboarding guide reflecting browser-first configuration workflow

* **Chores**
  * Version bumped to 0.2.3 across all packages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->