### PR TITLE
fix: heal legacy markdown project paths

### DIFF
--- a/.changeset/clean-suns-fry.md
+++ b/.changeset/clean-suns-fry.md
@@ -1,0 +1,5 @@
+---
+"conductor-oss": patch
+---
+
+Fix legacy project paths that point to Markdown files by healing them to the real repository directory during config load and dashboard sync. Also deduplicate canonical and symlinked board paths so the same repo board is not watched twice on macOS.

--- a/packages/core/src/__tests__/board-watcher-support-files.test.ts
+++ b/packages/core/src/__tests__/board-watcher-support-files.test.ts
@@ -1,10 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { OrchestratorConfig } from "../types.js";
-import { syncWorkspaceSupportFiles } from "../board-watcher.js";
+import { discoverBoards, syncWorkspaceSupportFiles } from "../board-watcher.js";
 
 function createTempDir(prefix: string): string {
   return mkdtempSync(join(tmpdir(), prefix));
@@ -109,6 +109,27 @@ test("syncWorkspaceSupportFiles writes placeholder project tags before first pro
     assert.match(tags, /#project\/my-project/);
     assert.match(snippets, /my-project/);
   } finally {
+    rmSync(workspacePath, { recursive: true, force: true });
+  }
+});
+
+test("discoverBoards deduplicates canonical and symlinked board paths", () => {
+  const workspacePath = createTempDir("conductor-board-dedupe-workspace-");
+  const aliasRoot = createTempDir("conductor-board-dedupe-alias-");
+  const aliasWorkspacePath = join(aliasRoot, "workspace-link");
+  const projectPath = join(workspacePath, "projects", "demo");
+
+  try {
+    symlinkSync(workspacePath, aliasWorkspacePath);
+    mkdirSync(projectPath, { recursive: true });
+    writeFileSync(join(projectPath, "CONDUCTOR.md"), "# Demo Board\n\n## Inbox\n", { encoding: "utf8", flag: "w" });
+
+    const config = createConfig(workspacePath, projectPath);
+    const boards = discoverBoards(aliasWorkspacePath, config);
+
+    assert.equal(boards.length, 1);
+  } finally {
+    rmSync(aliasRoot, { recursive: true, force: true });
     rmSync(workspacePath, { recursive: true, force: true });
   }
 });

--- a/packages/core/src/__tests__/project-paths.test.ts
+++ b/packages/core/src/__tests__/project-paths.test.ts
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { validateConfig } from "../config.js";
+import { resolveConfiguredProjectPath } from "../project-paths.js";
+
+function createTempDir(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+test("resolveConfiguredProjectPath heals legacy markdown-file project paths", () => {
+  const sandbox = createTempDir("conductor-project-paths-");
+
+  try {
+    const projectsDir = join(sandbox, "projects");
+    const repoDir = join(projectsDir, "aba-copilot");
+    const markdownPath = join(projectsDir, "ABA-Copilot.md");
+
+    mkdirSync(repoDir, { recursive: true });
+    writeFileSync(markdownPath, "# legacy board pointer\n", "utf8");
+
+    const resolved = resolveConfiguredProjectPath(markdownPath, "your-org/aba-copilot");
+    assert.equal(resolved, realpathSync.native(repoDir));
+  } finally {
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+});
+
+test("validateConfig normalizes project paths to the actual repository directory", () => {
+  const sandbox = createTempDir("conductor-config-paths-");
+
+  try {
+    const projectsDir = join(sandbox, "projects");
+    const repoDir = join(projectsDir, "aba-copilot");
+    const markdownPath = join(projectsDir, "ABA-Copilot.md");
+
+    mkdirSync(repoDir, { recursive: true });
+    writeFileSync(markdownPath, "# legacy board pointer\n", "utf8");
+
+    const config = validateConfig({
+      projects: {
+        "aba-copilot": {
+          repo: "your-org/aba-copilot",
+          path: markdownPath,
+        },
+      },
+    });
+
+    assert.equal(config.projects["aba-copilot"]?.path, realpathSync.native(repoDir));
+  } finally {
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+});

--- a/packages/core/src/board-diagnostics.ts
+++ b/packages/core/src/board-diagnostics.ts
@@ -1,4 +1,4 @@
-import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, statSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, realpathSync, renameSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import type { BoardConfigEntry, ColumnAliasesConfig, OrchestratorConfig } from "./types.js";
 import {
@@ -44,7 +44,16 @@ const MAX_LOG_BYTES = 1_000_000;
 const LOG_ROTATIONS = 3;
 
 function normalizePath(pathname: string): string {
-  return pathname.replace(/\\/g, "/");
+  return canonicalizeExistingPath(pathname).replace(/\\/g, "/");
+}
+
+function canonicalizeExistingPath(pathname: string): string {
+  if (!existsSync(pathname)) return pathname;
+  try {
+    return realpathSync.native(pathname);
+  } catch {
+    return pathname;
+  }
 }
 
 function ensureParent(pathname: string): void {

--- a/packages/core/src/board-watcher.ts
+++ b/packages/core/src/board-watcher.ts
@@ -15,7 +15,7 @@
  * Board columns: Inbox → Ready to Dispatch → Dispatching → In Progress → Review → Done → Blocked
  */
 
-import { readFileSync, writeFileSync, appendFileSync, existsSync, statSync, readdirSync, mkdirSync, watch as fsWatch } from "node:fs";
+import { readFileSync, writeFileSync, appendFileSync, existsSync, realpathSync, statSync, readdirSync, mkdirSync, watch as fsWatch } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { createHash, randomBytes } from "node:crypto";
 import { execFile } from "node:child_process";
@@ -2211,7 +2211,7 @@ export function discoverBoards(
         isAbsolutePath(resolvedPattern),
       );
       for (const match of matches) {
-        boards.add(match);
+        boards.add(canonicalizeExistingPath(match));
       }
     }
     return [...boards];
@@ -2231,9 +2231,10 @@ function discoverBoardsLegacy(workspacePath: string, config?: OrchestratorConfig
 
   const addBoard = (path: string): void => {
     if (!existsSync(path)) return;
-    if (seen.has(path)) return;
-    seen.add(path);
-    boards.push(path);
+    const canonicalPath = canonicalizeExistingPath(path);
+    if (seen.has(canonicalPath)) return;
+    seen.add(canonicalPath);
+    boards.push(canonicalPath);
   };
 
   // Workspace-level board
@@ -2314,6 +2315,19 @@ function discoverBoardsLegacy(workspacePath: string, config?: OrchestratorConfig
   }
 
   return boards;
+}
+
+function canonicalizeExistingPath(pathname: string): string {
+  const resolvedPath = resolve(pathname);
+  if (!existsSync(resolvedPath)) {
+    return resolvedPath;
+  }
+
+  try {
+    return realpathSync.native(resolvedPath);
+  } catch {
+    return resolvedPath;
+  }
 }
 
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -17,6 +17,7 @@ import { parse as parseYaml } from "yaml";
 import { z } from "zod";
 import type { OrchestratorConfig } from "./types.js";
 import { generateSessionPrefix } from "./paths.js";
+import { resolveConfiguredProjectPath } from "./project-paths.js";
 
 // =============================================================================
 // ZOD SCHEMAS
@@ -214,7 +215,7 @@ function expandHome(filepath: string): string {
 /** Expand all path fields in the config */
 function expandPaths(config: OrchestratorConfig): OrchestratorConfig {
   for (const project of Object.values(config.projects)) {
-    project.path = expandHome(project.path);
+    project.path = resolveConfiguredProjectPath(project.path, project.repo);
     if (project.devServer?.cwd) {
       project.devServer.cwd = expandHome(project.devServer.cwd);
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -76,6 +76,7 @@ export {
   expandHome,
   validateAndStoreOrigin,
 } from "./paths.js";
+export { resolveConfiguredProjectPath } from "./project-paths.js";
 
 // Board watcher -- Obsidian CONDUCTOR.md integration
 export {

--- a/packages/core/src/project-paths.ts
+++ b/packages/core/src/project-paths.ts
@@ -1,0 +1,76 @@
+import { existsSync, realpathSync, statSync } from "node:fs";
+import { basename, dirname, extname, join, resolve } from "node:path";
+import { homedir } from "node:os";
+import { expandHome } from "./paths.js";
+
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function extractRepoTail(repoValue: string | null | undefined): string | null {
+  if (typeof repoValue !== "string") return null;
+  const trimmed = repoValue.trim();
+  if (trimmed.length === 0) return null;
+
+  const parts = trimmed
+    .replace(/\.git$/i, "")
+    .split(/[/:]/)
+    .filter(Boolean);
+
+  return parts[parts.length - 1] ?? null;
+}
+
+function uniqueCandidates(values: Array<string | null | undefined>): string[] {
+  const seen = new Set<string>();
+  const next: string[] = [];
+
+  for (const value of values) {
+    if (!value) continue;
+    const resolved = resolve(value);
+    if (seen.has(resolved)) continue;
+    seen.add(resolved);
+    next.push(resolved);
+  }
+
+  return next;
+}
+
+export function resolveConfiguredProjectPath(
+  projectPath: string,
+  repoValue?: string | null,
+): string {
+  const expandedPath = resolve(expandHome(projectPath));
+  if (isDirectory(expandedPath)) {
+    return realpathSync.native(expandedPath);
+  }
+
+  const pathExt = extname(expandedPath);
+  const pathStem = pathExt ? basename(expandedPath, pathExt) : basename(expandedPath);
+  const repoTail = extractRepoTail(repoValue);
+  const siblingDir = dirname(expandedPath);
+  const workspaceProjectsDir = resolve(homedir(), ".openclaw", "workspace", "projects");
+  const legacyProjectsDir = resolve(homedir(), ".openclaw", "projects");
+
+  const candidates = uniqueCandidates([
+    pathExt ? join(siblingDir, pathStem) : null,
+    pathExt ? join(siblingDir, pathStem.toLowerCase()) : null,
+    repoTail ? join(siblingDir, repoTail) : null,
+    repoTail ? join(siblingDir, repoTail.toLowerCase()) : null,
+    repoTail ? join(workspaceProjectsDir, repoTail) : null,
+    repoTail ? join(workspaceProjectsDir, repoTail.toLowerCase()) : null,
+    repoTail ? join(legacyProjectsDir, repoTail) : null,
+    repoTail ? join(legacyProjectsDir, repoTail.toLowerCase()) : null,
+  ]);
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate) && isDirectory(candidate)) {
+      return realpathSync.native(candidate);
+    }
+  }
+
+  return expandedPath;
+}

--- a/packages/web/src/app/api/preferences/route.ts
+++ b/packages/web/src/app/api/preferences/route.ts
@@ -4,7 +4,7 @@ import { parse, stringify } from "yaml";
 import { syncWorkspaceSupportFiles, type UserPreferences } from "@conductor-oss/core";
 import { getServices, invalidateServicesCache } from "@/lib/services";
 import { guardApiAccess, guardApiActionAccess } from "@/lib/auth";
-import { syncAllProjectLocalConfigs } from "@/lib/projectConfigSync";
+import { normalizeRootProjectPaths, syncAllProjectLocalConfigs } from "@/lib/projectConfigSync";
 
 export const dynamic = "force-dynamic";
 
@@ -158,6 +158,7 @@ export async function PUT(request: NextRequest) {
     }
 
     nextRoot["preferences"] = nextPreferences;
+    await normalizeRootProjectPaths(nextRoot);
 
     const updatedYaml = stringify(nextRoot, {
       lineWidth: 0,

--- a/packages/web/src/app/api/repositories/route.ts
+++ b/packages/web/src/app/api/repositories/route.ts
@@ -9,7 +9,7 @@ import { parse, stringify } from "yaml";
 import { syncWorkspaceSupportFiles } from "@conductor-oss/core";
 import { getServices, invalidateServicesCache } from "@/lib/services";
 import { guardApiAccess, guardApiActionAccess } from "@/lib/auth";
-import { syncProjectLocalConfig } from "@/lib/projectConfigSync";
+import { normalizeRootProjectPaths, syncProjectLocalConfig } from "@/lib/projectConfigSync";
 
 export const dynamic = "force-dynamic";
 
@@ -371,6 +371,7 @@ export async function PUT(request: NextRequest) {
 
     nextProjects[id] = nextProject;
     nextRoot["projects"] = nextProjects;
+    await normalizeRootProjectPaths(nextRoot);
 
     const updatedYaml = stringify(nextRoot, { lineWidth: 0 });
     await writeFile(configPath, updatedYaml, "utf8");

--- a/packages/web/src/app/api/spawn/route.ts
+++ b/packages/web/src/app/api/spawn/route.ts
@@ -5,7 +5,7 @@ import { syncWorkspaceSupportFiles } from "@conductor-oss/core";
 import { getServices, invalidateServicesCache } from "@/lib/services";
 import { guardApiAccess, guardApiActionAccess } from "@/lib/auth";
 import { sessionToDashboard } from "@/lib/serialize";
-import { syncProjectLocalConfig } from "@/lib/projectConfigSync";
+import { normalizeRootProjectPaths, syncProjectLocalConfig } from "@/lib/projectConfigSync";
 
 /** POST /api/spawn -- Spawn a new agent session. */
 
@@ -39,6 +39,7 @@ async function persistSpawnAgentSelection(configPath: string, projectId: string,
     ...nextPreferences,
     codingAgent: agent,
   };
+  await normalizeRootProjectPaths(nextRoot);
 
   const updatedYaml = stringify(nextRoot, { lineWidth: 0 });
   await writeFile(configPath, updatedYaml, "utf8");

--- a/packages/web/src/app/api/workspaces/route.ts
+++ b/packages/web/src/app/api/workspaces/route.ts
@@ -13,7 +13,7 @@ import {
 } from "@conductor-oss/core";
 import { getServices, invalidateServicesCache } from "@/lib/services";
 import { guardApiAccess, guardApiActionAccess } from "@/lib/auth";
-import { syncProjectLocalConfig } from "@/lib/projectConfigSync";
+import { normalizeRootProjectPaths, syncProjectLocalConfig } from "@/lib/projectConfigSync";
 
 const execFileAsync = promisify(execFile);
 
@@ -282,6 +282,7 @@ async function writeProjectToConfig(args: {
   const nextProjects = toProjectMap(nextRoot.projects);
   nextProjects[args.projectId] = args.projectData;
   nextRoot.projects = nextProjects;
+  await normalizeRootProjectPaths(nextRoot);
 
   const updatedYaml = stringify(nextRoot, {
     lineWidth: 0,

--- a/packages/web/src/lib/projectConfigSync.ts
+++ b/packages/web/src/lib/projectConfigSync.ts
@@ -1,7 +1,11 @@
 import { join, resolve } from "node:path";
-import { writeFile } from "node:fs/promises";
+import { stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { buildConductorYaml, type ScaffoldProjectConfig } from "@conductor-oss/core";
+import {
+  buildConductorYaml,
+  resolveConfiguredProjectPath,
+  type ScaffoldProjectConfig,
+} from "@conductor-oss/core";
 
 type MutableConfig = Record<string, unknown>;
 
@@ -25,6 +29,14 @@ function expandHome(value: string): string {
   return resolve(value);
 }
 
+async function isDirectory(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 function normalizePreferences(value: unknown) {
   const root = toObject(value);
   const notifications = toObject(root["notifications"]);
@@ -45,14 +57,18 @@ function normalizePreferences(value: unknown) {
   };
 }
 
-function buildProjectScaffold(projectId: string, project: Record<string, unknown>): ScaffoldProjectConfig {
+function buildProjectScaffold(
+  projectId: string,
+  project: Record<string, unknown>,
+  projectPath: string,
+): ScaffoldProjectConfig {
   const agentConfig = toObject(project["agentConfig"]);
 
   return {
     projectId,
     displayName: asNonEmptyString(project["name"]) ?? projectId,
     repo: asNonEmptyString(project["repo"]) ?? `local-${projectId}`,
-    path: expandHome(asNonEmptyString(project["path"]) ?? projectId),
+    path: projectPath,
     agent: asNonEmptyString(project["agent"]) ?? "claude-code",
     defaultBranch: asNonEmptyString(project["defaultBranch"]) ?? "main",
     defaultWorkingDirectory: asNonEmptyString(project["defaultWorkingDirectory"]),
@@ -66,11 +82,43 @@ function buildProjectScaffold(projectId: string, project: Record<string, unknown
   };
 }
 
+export async function normalizeRootProjectPaths(rootConfig: MutableConfig): Promise<void> {
+  const projects = toObject(rootConfig["projects"]);
+
+  for (const [projectId, rawProject] of Object.entries(projects)) {
+    const project = toObject(rawProject);
+    const rawProjectPath = asNonEmptyString(project["path"]);
+    if (!rawProjectPath) {
+      continue;
+    }
+
+    const resolvedProjectPath = resolveConfiguredProjectPath(
+      rawProjectPath,
+      asNonEmptyString(project["repo"]),
+    );
+
+    if (!await isDirectory(resolvedProjectPath)) {
+      continue;
+    }
+
+    projects[projectId] = {
+      ...project,
+      path: resolvedProjectPath,
+    };
+  }
+
+  rootConfig["projects"] = projects;
+}
+
 export async function syncProjectLocalConfig(rootConfig: MutableConfig, projectId: string): Promise<void> {
   const projects = toObject(rootConfig["projects"]);
   const project = toObject(projects[projectId]);
-  const projectPath = asNonEmptyString(project["path"]);
-  if (!projectPath) {
+  const rawProjectPath = asNonEmptyString(project["path"]);
+  if (!rawProjectPath) {
+    return;
+  }
+  const projectPath = resolveConfiguredProjectPath(rawProjectPath, asNonEmptyString(project["repo"]));
+  if (!await isDirectory(projectPath)) {
     return;
   }
 
@@ -78,13 +126,13 @@ export async function syncProjectLocalConfig(rootConfig: MutableConfig, projectI
     port: typeof rootConfig["port"] === "number" ? rootConfig["port"] : 4747,
     dashboardUrl: asNonEmptyString(rootConfig["dashboardUrl"]),
     preferences: normalizePreferences(rootConfig["preferences"]),
-    projects: [buildProjectScaffold(projectId, project)],
+    projects: [buildProjectScaffold(projectId, project, projectPath)],
   });
-
-  await writeFile(join(expandHome(projectPath), "conductor.yaml"), yaml, "utf8");
+  await writeFile(join(projectPath, "conductor.yaml"), yaml, "utf8");
 }
 
 export async function syncAllProjectLocalConfigs(rootConfig: MutableConfig): Promise<void> {
+  await normalizeRootProjectPaths(rootConfig);
   const projects = toObject(rootConfig["projects"]);
   for (const projectId of Object.keys(projects)) {
     await syncProjectLocalConfig(rootConfig, projectId);

--- a/scripts/verify-cli-package.mjs
+++ b/scripts/verify-cli-package.mjs
@@ -1,7 +1,7 @@
 import { execFileSync, spawn } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { packCliReleasePackage } from "./cli-release-stage.mjs";
 
@@ -29,6 +29,40 @@ function escapeRegExp(value) {
 
 function yamlContainsProject(content, projectId) {
   return new RegExp(`(^|\\n)  ${escapeRegExp(projectId)}:`, "m").test(content);
+}
+
+function replaceProjectPathInYaml(content, projectId, nextPath) {
+  const lines = content.split("\n");
+  let inProject = false;
+  let replaced = false;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (/^  [^:\n]+:\s*$/.test(line)) {
+      inProject = line.trim() === `${projectId}:`;
+      continue;
+    }
+
+    if (!inProject) {
+      continue;
+    }
+
+    if (/^    [^:\n]+:/.test(line) && line.trimStart().startsWith("path:")) {
+      lines[index] = `    path: ${nextPath}`;
+      replaced = true;
+      break;
+    }
+
+    if (/^  [^:\n]+:\s*$/.test(line)) {
+      inProject = false;
+    }
+  }
+
+  if (!replaced) {
+    throw new Error(`Failed to replace path for project ${projectId}`);
+  }
+
+  return lines.join("\n");
 }
 
 function spawnInstalledCli(installDir, args, options = {}) {
@@ -299,6 +333,7 @@ async function verifyDashboardReadyState(baseUrl) {
 async function verifyBrowserFirstLauncherFlow(installDir, tempDirs) {
   const homeDir = createTempDir("conductor-cli-home-", tempDirs);
   const projectDir = createTempDir("conductor-cli-project-", tempDirs);
+  const canonicalProjectDir = realpathSync.native(projectDir);
   const baseUrl = "http://127.0.0.1:4747";
 
   const launcher = spawnInstalledCli(installDir, [], {
@@ -402,7 +437,7 @@ async function verifyBrowserFirstLauncherFlow(installDir, tempDirs) {
         && projectYaml.includes("soundEnabled: false")
         && projectYaml.includes("remoteSshHost: conductor-dev")
         && projectYaml.includes("remoteSshUser: pm")
-        && projectYaml.includes(`path: ${projectDir}`)
+        && projectYaml.includes(`path: ${canonicalProjectDir}`)
         && projectYaml.includes("agent: claude-code");
     });
 
@@ -415,6 +450,15 @@ async function verifyBrowserFirstLauncherFlow(installDir, tempDirs) {
     if (!repository) {
       throw new Error("new project was not exposed through /api/repositories");
     }
+
+    const legacyMarkdownPath = join(dirname(projectDir), "ABA-Copilot.md");
+    writeFileSync(legacyMarkdownPath, "# legacy board pointer\n", "utf8");
+    const rewrittenBootstrapConfig = replaceProjectPathInYaml(
+      readTextFile(bootstrapConfigPath),
+      createdProjectId,
+      legacyMarkdownPath,
+    );
+    writeFileSync(bootstrapConfigPath, rewrittenBootstrapConfig, "utf8");
 
     const updateRepositoryResult = await fetchJson(`${baseUrl}/api/repositories`, {
       method: "PUT",
@@ -446,7 +490,9 @@ async function verifyBrowserFirstLauncherFlow(installDir, tempDirs) {
       const projectYaml = readTextFile(projectConfigPath);
       return yamlContainsProject(projectYaml, createdProjectId)
         && projectYaml.includes("repo: example/browser-first-smoke")
-        && projectYaml.includes("defaultWorkingDirectory: app");
+        && projectYaml.includes("defaultWorkingDirectory: app")
+        && projectYaml.includes(`path: ${canonicalProjectDir}`)
+        && !projectYaml.includes(`path: ${legacyMarkdownPath}`);
     });
 
     const updatePreferencesResult = await fetchJson(`${baseUrl}/api/preferences`, {
@@ -503,7 +549,9 @@ async function verifyBrowserFirstLauncherFlow(installDir, tempDirs) {
       const projectYaml = readTextFile(projectConfigPath);
       return projectYaml.includes("codingAgent: codex")
         && yamlContainsProject(projectYaml, createdProjectId)
-        && projectYaml.includes("agent: codex");
+        && projectYaml.includes("agent: codex")
+        && projectYaml.includes(`path: ${canonicalProjectDir}`)
+        && !projectYaml.includes(`path: ${legacyMarkdownPath}`);
     });
 
     const createdSessionId = spawnResult.payload?.session?.id;
@@ -516,7 +564,10 @@ async function verifyBrowserFirstLauncherFlow(installDir, tempDirs) {
     }
 
     const bootstrapConfig = readTextFile(bootstrapConfigPath);
-    if (!yamlContainsProject(bootstrapConfig, createdProjectId) || !bootstrapConfig.includes(`path: ${projectDir}`)) {
+    if (
+      !yamlContainsProject(bootstrapConfig, createdProjectId) ||
+      !bootstrapConfig.includes(`path: ${canonicalProjectDir}`)
+    ) {
       throw new Error("home workspace config did not retain the created project");
     }
 


### PR DESCRIPTION
## Summary
- heal legacy project paths that point at markdown files to the real repo directory in core config loading and dashboard sync
- normalize persisted dashboard config writes so stale markdown-file project paths are corrected on updates
- deduplicate canonical and symlinked board paths to avoid double-watching the same repo board on macOS
- extend clean-install release verification to cover the legacy markdown-path case

## Validation
- pnpm --filter @conductor-oss/core test
- pnpm typecheck
- pnpm build:release
- pnpm release:verify
- pnpm changeset status --verbose

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Fixed handling of legacy project paths pointing to Markdown files, now properly resolving them to the actual repository directory during configuration loading and dashboard synchronization
* Resolved duplicate board watching on macOS by deduplicating canonical and symlinked board paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->