### PR TITLE
chore: release packages 0.2.5

### DIFF
--- a/.changeset/clean-suns-fry.md
+++ b/.changeset/clean-suns-fry.md
@@ -1,5 +1,0 @@
----
-"conductor-oss": patch
----
-
-Fix legacy project paths that point to Markdown files by healing them to the real repository directory during config load and dashboard sync. Also deduplicate canonical and symlinked board paths so the same repo board is not watched twice on macOS.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conductor-oss",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -33,7 +33,7 @@ const program = new Command();
 program
   .name("co")
   .description("Conductor — markdown-native AI agent orchestrator")
-  .version("0.2.4");
+  .version("0.2.5");
 
 registerSpawn(program);
 registerList(program);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/core",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-amp/package.json
+++ b/packages/plugins/agent-amp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-amp",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-amp/src/index.ts
+++ b/packages/plugins/agent-amp/src/index.ts
@@ -148,7 +148,7 @@ export const manifest = {
   name: "amp",
   slot: "agent" as const,
   description: "Agent plugin: Amp CLI",
-  version: "0.2.4",
+  version: "0.2.5",
 };
 
 function createAgent(): Agent {

--- a/packages/plugins/agent-ccr/package.json
+++ b/packages/plugins/agent-ccr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-ccr",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-ccr/src/index.ts
+++ b/packages/plugins/agent-ccr/src/index.ts
@@ -148,7 +148,7 @@ export const manifest = {
   name: "ccr",
   slot: "agent" as const,
   description: "Agent plugin: Claude Code Router",
-  version: "0.2.4",
+  version: "0.2.5",
 };
 
 function createAgent(): Agent {

--- a/packages/plugins/agent-claude-code/package.json
+++ b/packages/plugins/agent-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-claude-code",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -192,7 +192,7 @@ export const manifest = {
   name: "claude-code",
   slot: "agent" as const,
   description: "Agent plugin: Claude Code CLI",
-  version: "0.2.4",
+  version: "0.2.5",
 };
 
 // =============================================================================

--- a/packages/plugins/agent-codex/package.json
+++ b/packages/plugins/agent-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-codex",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -85,7 +85,7 @@ export const manifest = {
   name: "codex",
   slot: "agent" as const,
   description: "Agent plugin: OpenAI Codex CLI",
-  version: "0.2.4",
+  version: "0.2.5",
 };
 
 // =============================================================================

--- a/packages/plugins/agent-cursor-cli/package.json
+++ b/packages/plugins/agent-cursor-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-cursor-cli",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-cursor-cli/src/index.ts
+++ b/packages/plugins/agent-cursor-cli/src/index.ts
@@ -148,7 +148,7 @@ export const manifest = {
   name: "cursor-cli",
   slot: "agent" as const,
   description: "Agent plugin: Cursor CLI",
-  version: "0.2.4",
+  version: "0.2.5",
 };
 
 function createAgent(): Agent {

--- a/packages/plugins/agent-droid/package.json
+++ b/packages/plugins/agent-droid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-droid",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-droid/src/index.ts
+++ b/packages/plugins/agent-droid/src/index.ts
@@ -148,7 +148,7 @@ export const manifest = {
   name: "droid",
   slot: "agent" as const,
   description: "Agent plugin: Factory Droid CLI",
-  version: "0.2.4",
+  version: "0.2.5",
 };
 
 function createAgent(): Agent {

--- a/packages/plugins/agent-gemini/package.json
+++ b/packages/plugins/agent-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-gemini",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/plugins/agent-gemini/src/index.ts
+++ b/packages/plugins/agent-gemini/src/index.ts
@@ -80,7 +80,7 @@ export const manifest = {
   name: "gemini",
   slot: "agent" as const,
   description: "Agent plugin: Google Gemini CLI",
-  version: "0.2.4",
+  version: "0.2.5",
 };
 
 // =============================================================================

--- a/packages/plugins/agent-github-copilot/package.json
+++ b/packages/plugins/agent-github-copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-github-copilot",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-github-copilot/src/index.ts
+++ b/packages/plugins/agent-github-copilot/src/index.ts
@@ -148,7 +148,7 @@ export const manifest = {
   name: "github-copilot",
   slot: "agent" as const,
   description: "Agent plugin: GitHub Copilot CLI",
-  version: "0.2.4",
+  version: "0.2.5",
 };
 
 function createAgent(): Agent {

--- a/packages/plugins/agent-opencode/package.json
+++ b/packages/plugins/agent-opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-opencode",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-opencode/src/index.ts
+++ b/packages/plugins/agent-opencode/src/index.ts
@@ -148,7 +148,7 @@ export const manifest = {
   name: "opencode",
   slot: "agent" as const,
   description: "Agent plugin: OpenCode CLI",
-  version: "0.2.4",
+  version: "0.2.5",
 };
 
 function createAgent(): Agent {

--- a/packages/plugins/agent-qwen-code/package.json
+++ b/packages/plugins/agent-qwen-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-agent-qwen-code",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-qwen-code/src/index.ts
+++ b/packages/plugins/agent-qwen-code/src/index.ts
@@ -148,7 +148,7 @@ export const manifest = {
   name: "qwen-code",
   slot: "agent" as const,
   description: "Agent plugin: Qwen Code CLI",
-  version: "0.2.4",
+  version: "0.2.5",
 };
 
 function createAgent(): Agent {

--- a/packages/plugins/mcp-server/package.json
+++ b/packages/plugins/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-mcp-server",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/mcp-server/src/index.ts
+++ b/packages/plugins/mcp-server/src/index.ts
@@ -103,7 +103,7 @@ function serializeProject(id: string, p: ProjectConfig): Record<string, unknown>
 export function createMcpServer(): McpServer {
   const server = new McpServer({
     name: "conductor",
-    version: "0.2.4",
+    version: "0.2.5",
   });
 
   // -------------------------------------------------------------------------

--- a/packages/plugins/notifier-desktop/package.json
+++ b/packages/plugins/notifier-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-notifier-desktop",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-desktop/src/index.ts
+++ b/packages/plugins/notifier-desktop/src/index.ts
@@ -22,7 +22,7 @@ export const manifest = {
   name: "desktop",
   slot: "notifier" as const,
   description: "Notifier plugin: desktop notifications (macOS + Linux)",
-  version: "0.2.4",
+  version: "0.2.5",
 };
 
 const PLATFORM = platform();

--- a/packages/plugins/notifier-discord/package.json
+++ b/packages/plugins/notifier-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-notifier-discord",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-discord/src/index.ts
+++ b/packages/plugins/notifier-discord/src/index.ts
@@ -18,7 +18,7 @@ export const manifest = {
   name: "discord",
   slot: "notifier" as const,
   description: "Notifier plugin: Discord via REST API",
-  version: "0.2.4",
+  version: "0.2.5",
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/plugins/runtime-tmux/package.json
+++ b/packages/plugins/runtime-tmux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-runtime-tmux",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/runtime-tmux/src/index.ts
+++ b/packages/plugins/runtime-tmux/src/index.ts
@@ -45,7 +45,7 @@ export const manifest = {
   name: "tmux",
   slot: "runtime" as const,
   description: "Runtime plugin: tmux sessions",
-  version: "0.2.4",
+  version: "0.2.5",
 };
 
 /** Only allow safe characters in session IDs */

--- a/packages/plugins/scm-github/package.json
+++ b/packages/plugins/scm-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-scm-github",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/scm-github/src/index.ts
+++ b/packages/plugins/scm-github/src/index.ts
@@ -411,7 +411,7 @@ export const manifest = {
   name: "github",
   slot: "scm" as const,
   description: "SCM plugin: GitHub PRs, CI checks, reviews, merge readiness",
-  version: "0.2.4",
+  version: "0.2.5",
 };
 
 export function create(): SCM {

--- a/packages/plugins/terminal-web/package.json
+++ b/packages/plugins/terminal-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-terminal-web",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/terminal-web/src/index.ts
+++ b/packages/plugins/terminal-web/src/index.ts
@@ -16,7 +16,7 @@ export const manifest = {
   name: "web",
   slot: "terminal" as const,
   description: "Terminal plugin: web terminal via browser",
-  version: "0.2.4",
+  version: "0.2.5",
 };
 
 export function create(config?: Record<string, unknown>): Terminal {

--- a/packages/plugins/tracker-github/package.json
+++ b/packages/plugins/tracker-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-tracker-github",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/tracker-github/src/index.ts
+++ b/packages/plugins/tracker-github/src/index.ts
@@ -161,7 +161,7 @@ export const manifest = {
   name: "github",
   slot: "tracker" as const,
   description: "Tracker plugin: GitHub Issues",
-  version: "0.2.4",
+  version: "0.2.5",
 };
 
 export function create(): Tracker {

--- a/packages/plugins/webhook/package.json
+++ b/packages/plugins/webhook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-webhook",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/workspace-worktree/package.json
+++ b/packages/plugins/workspace-worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conductor-oss/plugin-workspace-worktree",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/workspace-worktree/src/index.ts
+++ b/packages/plugins/workspace-worktree/src/index.ts
@@ -41,7 +41,7 @@ export const manifest = {
   name: "worktree",
   slot: "workspace" as const,
   description: "Workspace plugin: git worktrees",
-  version: "0.2.4",
+  version: "0.2.5",
 };
 
 /** Run a git command in a given directory */


### PR DESCRIPTION
## Summary
- record the published 0.2.5 version bump in Git after manual npm publish
- remove the consumed changeset file
- align GitHub history with the live npm release

## Validation
- pnpm build:release
- pnpm release:verify
- pnpm release:publish
- npm view conductor-oss version