### PR TITLE
fix(web): allow configured dashboardUrl host for ngrok/phone access

### DIFF
--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -333,7 +333,21 @@ export async function getDashboardAccess(request?: Request): Promise<DashboardAc
   if (clerkAccess) return clerkAccess;
 
   const requireAuth = access?.requireAuth === true || envRequiresAuth() || hasLegacyAllowListConfigured();
-  if (!isLoopbackHost(host)) {
+
+  // Trust the configured dashboardUrl host (for remote access via tunnels like ngrok).
+  let isTrustedDashboardHost = false;
+  try {
+    const { config } = await getServices();
+    const configuredDashboardUrl = config.dashboardUrl?.trim();
+    if (configuredDashboardUrl) {
+      const dashboardHost = new URL(configuredDashboardUrl).hostname.toLowerCase();
+      isTrustedDashboardHost = host.toLowerCase() === dashboardHost;
+    }
+  } catch {
+    // Ignore config lookup errors and continue with default host checks.
+  }
+
+  if (!isLoopbackHost(host) && !isTrustedDashboardHost) {
     return {
       ok: false,
       authenticated: false,


### PR DESCRIPTION
## Problem
Remote dashboard access via ngrok was still returning 403 even with dashboardUrl configured in conductor.yaml.

## Root cause
getDashboardAccess() only trusted loopback hosts and blocked all non-local hosts by default.

## Fix
- Parse config.dashboardUrl from loaded config
- Trust requests whose hostname matches that configured dashboard host
- Keep default hardening for unknown hosts

This keeps security defaults intact while making first-party tunnel access (phone/remote) work out of the box.
