### PR TITLE
fix(core): guard post-launch prompt delivery on runtime liveness

### DIFF
--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1016,6 +1016,16 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
 
           while (Date.now() - startTime < maxWaitMs) {
             try {
+              const alive = await runtime.isAlive(handle);
+              if (!alive) {
+                console.log(`[session-manager] ${sessionId}: runtime exited before initial prompt delivery`);
+                return;
+              }
+            } catch {
+              // Can't check liveness; continue probing output.
+            }
+
+            try {
               const output = await runtime.getOutput(handle, 20);
               // Claude Code shows "❯" when ready for input
               // Codex shows ">" or "$" when ready
@@ -1024,13 +1034,23 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
                 break;
               }
             } catch {
-              // Can't read output -- keep trying
+              // Can't read output; keep trying.
             }
             await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
           }
 
+          try {
+            const aliveBeforeSend = await runtime.isAlive(handle);
+            if (!aliveBeforeSend) {
+              console.log(`[session-manager] ${sessionId}: skipping initial prompt, runtime is no longer alive`);
+              return;
+            }
+          } catch {
+            // If liveness check fails, try sending once.
+          }
+
           if (!ready) {
-            console.log(`[session-manager] ${sessionId}: agent prompt not detected after ${maxWaitMs / 1000}s, sending anyway`);
+            console.log(`[session-manager] ${sessionId}: agent prompt not detected after ${maxWaitMs / 1000}s, attempting send`);
           }
 
           await runtime.sendMessage(handle, initialPrompt);


### PR DESCRIPTION
## Problem
When an agent process exits during spawn, the async post-launch prompt delivery logic can still send the initial task prompt later.

In this failure mode, prompt text can end up pasted into a plain shell buffer instead of the agent process.

## Fix
- Added `runtime.isAlive(handle)` checks while probing for readiness
- Abort prompt delivery early if runtime exits
- Re-check liveness immediately before `sendMessage`
- Keep explicit logs for early-exit behavior

## Result
No prompt dump into dead shell sessions when agent startup fails.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened initial prompt delivery reliability with enhanced runtime availability monitoring and liveness checks throughout the delivery flow.
  * Improved error messaging in timeout and detection scenarios to more accurately reflect system state and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->