### PR TITLE
fix(ci): release workflow fails on workspace deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
               for (const depType of ['dependencies', 'devDependencies', 'peerDependencies']) {
                 if (!pkg[depType]) continue;
                 for (const [name, ver] of Object.entries(pkg[depType])) {
-                  if (name.startsWith('@conductor-oss/') && !ver.startsWith('file:')) {
+                  if (name.startsWith('@conductor-oss/') && !ver.startsWith('file:') && !ver.startsWith('workspace:')) {
                     pkg[depType][name] = '$new_version';
                   }
                 }
@@ -107,7 +107,9 @@ jobs:
             }
           "
 
-          pnpm install --lockfile-only
+          # Re-install to update lockfile with new versions.
+          # Use --no-frozen-lockfile since workspace deps changed.
+          pnpm install --no-frozen-lockfile
 
           echo "new_version=$new_version" >> "$GITHUB_OUTPUT"
           echo "tag_name=v$new_version" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The version bump script was converting `workspace:*` refs to hardcoded versions, causing pnpm to try fetching unpublished internal packages from npm. Now skips `workspace:` prefixed deps during the bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined the release workflow to properly handle workspace dependencies and ensure package locks are refreshed when internal package versions are updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->