### PR TITLE
fix(ci): convert workspace deps during version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
               for (const depType of ['dependencies', 'devDependencies', 'peerDependencies']) {
                 if (!pkg[depType]) continue;
                 for (const [name, ver] of Object.entries(pkg[depType])) {
-                  if (name.startsWith('@conductor-oss/') && !ver.startsWith('file:') && !ver.startsWith('workspace:')) {
+                  if (name.startsWith('@conductor-oss/') && !ver.startsWith('file:')) {
                     pkg[depType][name] = '${{ steps.version.outputs.new_version }}';
                   }
                 }


### PR DESCRIPTION
The pack script needs version numbers, not workspace:* protocol. Build+test still happen before bump.