### PR TITLE
fix: release pack step output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,8 +195,9 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         id: pack
         run: |
+          set -eo pipefail
           mkdir -p .release-artifacts
-          tarball_path=$(node scripts/pack-cli-release.mjs --pack-destination .release-artifacts)
+          tarball_path=$(node scripts/pack-cli-release.mjs --pack-destination .release-artifacts | tail -n 1)
           echo "tarball_path=$tarball_path" >> "$GITHUB_OUTPUT"
 
       - name: Tag release

--- a/scripts/cli-release-stage.mjs
+++ b/scripts/cli-release-stage.mjs
@@ -243,18 +243,19 @@ export function createCliReleaseStage({ rootDir = process.cwd(), stageDir } = {}
 
   // Install external dependencies and resolve file: tarballs for internal ones.
   // Internal package tarballs reference other internal packages by version number,
-  // which don't exist on npm until after the first publish. Use --install-strategy=shallow
-  // so npm only installs direct dependencies without recursing into sub-deps.
-  // The bundleDependencies field ensures internal packages are packed into the final tarball.
+  // which don't exist on npm until after the first publish. Try a shallow install
+  // first so npm only installs direct dependencies without recursing into sub-deps.
+  // If that still attempts to resolve unpublished internal versions, fall back to
+  // installing only external deps and unpack internal tarballs manually.
   try {
-    execFileSync("npm", ["install", "--omit=dev", "--no-package-lock", "--install-strategy=shallow"], {
+    execFileSync("npm", ["install", "--silent", "--omit=dev", "--no-package-lock", "--install-strategy=shallow"], {
       cwd: outputDir,
-      stdio: "inherit",
+      stdio: ["ignore", "ignore", "pipe"],
     });
   } catch {
     // If shallow install fails (pre-publish), fall back to installing only external deps
     // by temporarily removing internal deps from package.json, installing, then restoring.
-    console.log("Shallow install failed, falling back to manual external-only install...");
+    console.error("Shallow install failed, falling back to manual external-only install...");
     const manifest = readJson(join(outputDir, "package.json"));
     const fullDeps = { ...manifest.dependencies };
     const externalDeps = {};
@@ -266,7 +267,7 @@ export function createCliReleaseStage({ rootDir = process.cwd(), stageDir } = {}
     manifest.dependencies = externalDeps;
     writeJson(join(outputDir, "package.json"), manifest);
 
-    execFileSync("npm", ["install", "--omit=dev", "--no-package-lock"], {
+    execFileSync("npm", ["install", "--silent", "--omit=dev", "--no-package-lock"], {
       cwd: outputDir,
       stdio: "inherit",
     });


### PR DESCRIPTION
## Summary
This fixes the remaining GitHub Actions release failure on `main`.

## Failure
The merged packaging PR fixed the raw `workspace:*` publish bug, but the `Release` workflow still failed in the `Pack CLI` step on the merged commit because the workflow captured multi-line stdout from the pack script and wrote it directly into `GITHUB_OUTPUT`.

That produced:

```text
Error: Unable to process file command 'output' successfully.
Error: Invalid format 'added 216 packages, and audited 217 packages in 10s'
```

## Root cause
`scripts/pack-cli-release.mjs` ultimately triggers staged npm installs. The workflow step stored the full stdout of that command in `tarball_path=$(...)`, and then appended it to `GITHUB_OUTPUT`. Any install chatter made the output file invalid.

## Fix
- silence normal npm install stdout in the staged release flow
- send the fallback notice to stderr instead of stdout
- update the workflow to use `set -eo pipefail`
- capture only the last line from the pack script, which is the tarball path

## Validation
I ran the same command shape used by CI and verified it now emits exactly one clean line:

```text
tarball_path=/tmp/.../conductor-oss-0.2.8.tgz
```

That removes the `Invalid format` failure path in the release job.
