### PR TITLE
fix: bundled runtime deps in cli release

### DIFF
--- a/scripts/cli-release-stage.mjs
+++ b/scripts/cli-release-stage.mjs
@@ -113,6 +113,20 @@ function sanitizePublishedPackage(pkg, dependencies) {
   return sanitized;
 }
 
+function addDependency(target, dependencyName, specifier, sourceLabel) {
+  const existing = target[dependencyName];
+  if (!existing) {
+    target[dependencyName] = specifier;
+    return;
+  }
+
+  if (existing !== specifier) {
+    throw new Error(
+      `Conflicting dependency specifiers for ${dependencyName}: ${existing} vs ${specifier} (${sourceLabel})`,
+    );
+  }
+}
+
 function ensureWebBundle(rootDir) {
   const webDir = resolve(rootDir, "packages", "web");
   const standaloneDir = resolve(webDir, ".next", "standalone");
@@ -140,6 +154,7 @@ function buildInternalPackageTarballs({ rootDir, cliVersion, tarballRoot, stagin
   ];
 
   const tarballs = new Map();
+  const externalDependencies = {};
 
   for (const packageName of internalDependencyNames) {
     const sourceDir = workspacePackages.get(packageName);
@@ -158,9 +173,12 @@ function buildInternalPackageTarballs({ rootDir, cliVersion, tarballRoot, stagin
 
     const dependencies = {};
     for (const [dependencyName, specifier] of Object.entries(sourceManifest.dependencies ?? {})) {
-      dependencies[dependencyName] = internalDependencyNames.includes(dependencyName)
-        ? cliVersion
-        : specifier;
+      if (internalDependencyNames.includes(dependencyName)) {
+        dependencies[dependencyName] = cliVersion;
+      } else {
+        dependencies[dependencyName] = specifier;
+        addDependency(externalDependencies, dependencyName, specifier, packageName);
+      }
     }
 
     const sanitizedManifest = sanitizePublishedPackage(sourceManifest, dependencies);
@@ -175,7 +193,7 @@ function buildInternalPackageTarballs({ rootDir, cliVersion, tarballRoot, stagin
     tarballs.set(packageName, join(tarballRoot, tarballName));
   }
 
-  return { internalDependencyNames, tarballs };
+  return { internalDependencyNames, tarballs, externalDependencies };
 }
 
 export function createCliReleaseStage({ rootDir = process.cwd(), stageDir } = {}) {
@@ -196,7 +214,7 @@ export function createCliReleaseStage({ rootDir = process.cwd(), stageDir } = {}
   mkdirSync(internalStagingRoot, { recursive: true });
   mkdirSync(internalTarballRoot, { recursive: true });
 
-  const { internalDependencyNames, tarballs } = buildInternalPackageTarballs({
+  const { internalDependencyNames, tarballs, externalDependencies } = buildInternalPackageTarballs({
     rootDir: resolvedRootDir,
     cliVersion: cliPackage.version,
     tarballRoot: internalTarballRoot,
@@ -230,9 +248,12 @@ export function createCliReleaseStage({ rootDir = process.cwd(), stageDir } = {}
       ? `file:${tarballs.get(dependencyName)}`
       : specifier;
   }
+  for (const [dependencyName, specifier] of Object.entries(externalDependencies)) {
+    addDependency(stagedDependencies, dependencyName, specifier, "internal workspace package");
+  }
   for (const [dependencyName, specifier] of Object.entries(webPackage.dependencies ?? {})) {
-    if (!dependencyName.startsWith("@conductor-oss/") && !stagedDependencies[dependencyName]) {
-      stagedDependencies[dependencyName] = specifier;
+    if (!dependencyName.startsWith("@conductor-oss/")) {
+      addDependency(stagedDependencies, dependencyName, specifier, "@conductor-oss/web");
     }
   }
 
@@ -294,9 +315,12 @@ export function createCliReleaseStage({ rootDir = process.cwd(), stageDir } = {}
       ? cliPackage.version
       : specifier;
   }
+  for (const [dependencyName, specifier] of Object.entries(externalDependencies)) {
+    addDependency(publishedDependencies, dependencyName, specifier, "internal workspace package");
+  }
   for (const [dependencyName, specifier] of Object.entries(webPackage.dependencies ?? {})) {
-    if (!dependencyName.startsWith("@conductor-oss/") && !publishedDependencies[dependencyName]) {
-      publishedDependencies[dependencyName] = specifier;
+    if (!dependencyName.startsWith("@conductor-oss/")) {
+      addDependency(publishedDependencies, dependencyName, specifier, "@conductor-oss/web");
     }
   }
 


### PR DESCRIPTION
## Summary
This fixes the published CLI tarball so bundled internal packages can resolve their external runtime dependencies after `npx conductor-oss@latest` installs.

## User impact
`conductor-oss@0.2.13` installs past the old `workspace:*` error, but then fails at runtime with missing package errors such as:

```text
Cannot find package 'zod' from .../node_modules/@conductor-oss/core/dist/config.js
```

That makes the published CLI unusable even though the package now installs.

## Root cause
The staged release flow bundles internal workspace packages into the final CLI tarball, but it only promoted direct CLI dependencies and web bundle dependencies into the published top-level manifest.

Some bundled internal packages still require external runtime packages, including:
- `zod`
- `yaml`
- `@modelcontextprotocol/sdk`

Those were present inside internal package manifests but not guaranteed to be installed for the top-level published `conductor-oss` package.

## Fix
- collect external runtime dependencies declared by bundled internal workspace packages during release staging
- promote those dependencies into both the staged install manifest and the final published CLI manifest
- keep conflict detection strict so mismatched versions across bundled internal packages fail fast during packaging

## Validation
I packed the staged release tarball and verified the final published manifest now includes the required runtime dependencies:

```text
zod=^4.3.6
yaml=^2.8.2
@modelcontextprotocol/sdk=^1.27.1
```

## Notes
This fixes future publishes. The already-published `0.2.13` npm package remains broken until a corrected version is released.
