### PR TITLE
fix: packaged dashboard open and assets

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -152,13 +152,53 @@ function startCloudflareQuickTunnel(localUrl: string): {
   };
 }
 
-function openDashboardInBrowser(url: string): void {
-  const opener = process.platform === "darwin" ? "open" : "xdg-open";
-  const child = spawn(opener, [url], { stdio: "ignore", detached: true });
+function resolveBrowserOpenCommand(): { command: string; argsPrefix: string[] } | null {
+  if (process.platform === "darwin") {
+    return {
+      command: existsSync("/usr/bin/open") ? "/usr/bin/open" : "open",
+      argsPrefix: [],
+    };
+  }
+
+  if (process.platform === "win32") {
+    return {
+      command: "cmd",
+      argsPrefix: ["/c", "start", ""],
+    };
+  }
+
+  if (existsSync("/usr/bin/xdg-open")) {
+    return {
+      command: "/usr/bin/xdg-open",
+      argsPrefix: [],
+    };
+  }
+
+  if (commandExists("xdg-open")) {
+    return {
+      command: "xdg-open",
+      argsPrefix: [],
+    };
+  }
+
+  return null;
+}
+
+function openDashboardInBrowser(url: string): boolean {
+  const opener = resolveBrowserOpenCommand();
+  if (!opener) {
+    console.log(chalk.yellow(`Could not find a browser opener. Open ${url} manually.`));
+    return false;
+  }
+
+  const child = spawn(opener.command, [...opener.argsPrefix, url], {
+    stdio: "ignore",
+  });
   child.unref();
   child.on("error", () => {
     console.log(chalk.yellow(`Could not open browser automatically. Open ${url} manually.`));
   });
+  return true;
 }
 
 async function waitForDashboard(url: string, timeoutMs = 15_000): Promise<boolean> {
@@ -453,9 +493,14 @@ export function registerStart(program: Command): void {
               const standaloneAppDir = dirname(standaloneServer);
               const standaloneStaticDir = join(standaloneAppDir, ".next", "static");
               const sourceStaticDir = join(webDir, ".next", "static");
+              const standalonePublicDir = join(standaloneAppDir, "public");
+              const sourcePublicDir = join(webDir, "public");
               if (!existsSync(standaloneStaticDir) && existsSync(sourceStaticDir)) {
                 mkdirSync(join(standaloneAppDir, ".next"), { recursive: true });
                 cpSync(sourceStaticDir, standaloneStaticDir, { recursive: true });
+              }
+              if (!existsSync(standalonePublicDir) && existsSync(sourcePublicDir)) {
+                cpSync(sourcePublicDir, standalonePublicDir, { recursive: true });
               }
 
               cmd = process.execPath;
@@ -568,18 +613,17 @@ export function registerStart(program: Command): void {
 
             if (opts.open) {
               const preferredUrl = unlockDashboardUrl ?? publicDashboardUrl ?? dashboardUrl;
-              if (preferredUrl) {
-                openDashboardInBrowser(preferredUrl);
-              } else {
-                void waitForDashboard(dashboardInternalUrl).then((ready) => {
-                  if (ready) {
-                    openDashboardInBrowser(dashboardUrl);
-                    return;
+              void waitForDashboard(dashboardInternalUrl).then((ready) => {
+                if (ready) {
+                  const targetUrl = preferredUrl || dashboardUrl;
+                  if (openDashboardInBrowser(targetUrl)) {
+                    console.log(chalk.bold("Opening Conductor in your browser..."));
                   }
+                  return;
+                }
 
-                  console.log(chalk.yellow(`Dashboard is still starting. Open ${dashboardUrl} manually if it does not open shortly.`));
-                });
-              }
+                console.log(chalk.yellow(`Dashboard is still starting. Open ${dashboardUrl} manually if it does not open shortly.`));
+              });
             }
           } catch {
             dashSpinner.warn("Could not start dashboard.");

--- a/scripts/cli-release-stage.mjs
+++ b/scripts/cli-release-stage.mjs
@@ -235,6 +235,8 @@ export function createCliReleaseStage({ rootDir = process.cwd(), stageDir } = {}
   );
   if (existsSync(webBundle.publicDir)) {
     cpSync(webBundle.publicDir, join(webOutputDir, "public"), { recursive: true });
+    cpSync(webBundle.publicDir, join(webOutputDir, ".next", "standalone", "public"), { recursive: true });
+    cpSync(webBundle.publicDir, join(webOutputDir, ".next", "standalone", "packages", "web", "public"), { recursive: true });
   }
   writeJson(join(webOutputDir, "package.json"), {
     name: "@conductor-oss/web-bundle",


### PR DESCRIPTION
## Summary
This fixes two packaged-install regressions in the npm-distributed Conductor CLI:

1. the dashboard does not reliably open automatically on first launch
2. packaged standalone installs can miss web `public/` assets, which breaks agent icons and other static assets in the dashboard

## User impact
After `npx conductor-oss@latest` or a global npm install, users can start Conductor successfully but still hit two product issues:

- the dashboard server starts without opening the browser for guided setup
- the dashboard loads with broken icons because the packaged standalone bundle is missing the `public/agents` assets where the standalone server expects them

## Root cause
### Browser open path
The CLI default path already routes to `start --open`, but the browser launch logic was too eager and too brittle:
- it attempted to open immediately instead of waiting for the dashboard to become reachable
- it used a generic opener path without a more robust OS-specific fallback

### Standalone asset layout
The release staging flow copied `packages/web/public` into `web/public`, but not into the standalone app tree used by the packaged Next server:
- `web/.next/standalone/public`
- `web/.next/standalone/packages/web/public`

That meant the packaged standalone server could boot while still failing to resolve static public assets such as the agent SVGs.

## Fix
- wait for the dashboard to be reachable before opening the browser
- use a more reliable browser opener resolution path per OS
- mirror `public/` into the standalone app directory at runtime when launching the packaged standalone server
- mirror `public/` into the standalone bundle locations during release staging so packaged installs already contain the expected asset layout

## Notes
This fixes future packaged releases. Existing published npm versions will not pick up the fix until a corrected release is published.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dashboard now automatically waits for readiness before opening in the browser
  * Improved browser opening with platform-specific support for macOS, Windows, and Linux

* **Bug Fixes**
  * Enhanced browser launcher with better fallback handling when opening platform isn't available

* **Chores**
  * Public assets are now properly copied during dashboard startup and release staging processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->