### PR TITLE
fix: support npm packaging on Windows

### DIFF
--- a/scripts/cli-native-packages.mjs
+++ b/scripts/cli-native-packages.mjs
@@ -3,6 +3,8 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { execFileSync } from "node:child_process";
 
+const NPM_EXECUTABLE = process.platform === "win32" ? "npm.cmd" : "npm";
+
 function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"));
 }
@@ -137,7 +139,7 @@ export function packCliNativeReleasePackage({
   const destinationDir = packDestination ? resolve(packDestination) : stage.stageDir;
   mkdirSync(destinationDir, { recursive: true });
 
-  const tarballName = execFileSync("npm", ["pack", "--silent", "--pack-destination", destinationDir], {
+  const tarballName = execFileSync(NPM_EXECUTABLE, ["pack", "--silent", "--pack-destination", destinationDir], {
     cwd: stage.stageDir,
     encoding: "utf8",
   }).trim();

--- a/scripts/cli-release-stage.mjs
+++ b/scripts/cli-release-stage.mjs
@@ -15,6 +15,8 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { CLI_NATIVE_TARGETS } from "./cli-native-packages.mjs";
 
+const NPM_EXECUTABLE = process.platform === "win32" ? "npm.cmd" : "npm";
+
 function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"));
 }
@@ -238,7 +240,7 @@ function buildInternalPackageTarballs({ rootDir, cliVersion, tarballRoot, stagin
     writeJson(join(packageStageDir, "package.json"), sanitizedManifest);
     copyDistDirectory(sourceDistDir, join(packageStageDir, "dist"));
 
-    const tarballName = execFileSync("npm", ["pack", "--silent", "--pack-destination", tarballRoot], {
+    const tarballName = execFileSync(NPM_EXECUTABLE, ["pack", "--silent", "--pack-destination", tarballRoot], {
       cwd: packageStageDir,
       encoding: "utf8",
     }).trim();
@@ -332,7 +334,7 @@ export function createCliReleaseStage({ rootDir = process.cwd(), stageDir } = {}
   // If that still attempts to resolve unpublished internal versions, fall back to
   // installing only external deps and unpack internal tarballs manually.
   try {
-    execFileSync("npm", ["install", "--silent", "--omit=dev", "--omit=optional", "--no-package-lock", "--install-strategy=shallow"], {
+    execFileSync(NPM_EXECUTABLE, ["install", "--silent", "--omit=dev", "--omit=optional", "--no-package-lock", "--install-strategy=shallow"], {
       cwd: outputDir,
       stdio: ["ignore", "ignore", "pipe"],
     });
@@ -351,7 +353,7 @@ export function createCliReleaseStage({ rootDir = process.cwd(), stageDir } = {}
     manifest.dependencies = externalDeps;
     writeJson(join(outputDir, "package.json"), manifest);
 
-    execFileSync("npm", ["install", "--silent", "--omit=dev", "--omit=optional", "--no-package-lock"], {
+    execFileSync(NPM_EXECUTABLE, ["install", "--silent", "--omit=dev", "--omit=optional", "--no-package-lock"], {
       cwd: outputDir,
       stdio: "inherit",
     });
@@ -411,7 +413,7 @@ export function packCliReleasePackage({ rootDir = process.cwd(), stageDir, packD
   const destinationDir = packDestination ? resolve(packDestination) : stage.stageDir;
   mkdirSync(destinationDir, { recursive: true });
 
-  const tarballName = execFileSync("npm", ["pack", "--silent", "--pack-destination", destinationDir], {
+  const tarballName = execFileSync(NPM_EXECUTABLE, ["pack", "--silent", "--pack-destination", destinationDir], {
     cwd: stage.stageDir,
     encoding: "utf8",
   }).trim();

--- a/scripts/verify-cli-package.mjs
+++ b/scripts/verify-cli-package.mjs
@@ -11,6 +11,8 @@ import {
   resolveHostCliNativeTargetId,
 } from "./cli-native-packages.mjs";
 
+const NPM_EXECUTABLE = process.platform === "win32" ? "npm.cmd" : "npm";
+
 function fail(message) {
   throw new Error(`release preflight failed: ${message}`);
 }
@@ -730,11 +732,11 @@ try {
   });
   tempDirs.push(nativeStageDir);
 
-  execFileSync("npm", ["init", "-y"], {
+  execFileSync(NPM_EXECUTABLE, ["init", "-y"], {
     cwd: installDir,
     stdio: "ignore",
   });
-  execFileSync("npm", ["install", "--cache", npmCacheDir, "--omit=optional", tarballPath, nativeStageDir], {
+  execFileSync(NPM_EXECUTABLE, ["install", "--cache", npmCacheDir, "--omit=optional", tarballPath, nativeStageDir], {
     cwd: installDir,
     stdio: "inherit",
   });


### PR DESCRIPTION
## Summary
- use a Windows-safe npm executable in native package staging and packing scripts
- update release staging and packaged verification scripts to use the same cross-platform npm command
- unblock the Windows native release job so platform tarballs can be built in CI

## Validation
- node scripts/pack-cli-native.mjs --target darwin-universal --binary-path target/release/conductor --pack-destination /tmp/conductor-native-smoke
- node scripts/verify-cli-package.mjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced Windows compatibility for npm command execution in build and release scripts.

* **Chores**
  * Standardized platform-specific npm executable resolution across build tooling scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->