### PR TITLE
fix: native package publish names

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -391,15 +391,15 @@ function resolveRepoCargoRoot(workspacePath: string): string | null {
 
 function resolveOptionalNativePackageNames(): string[] {
   if (process.platform === "darwin" && (process.arch === "arm64" || process.arch === "x64")) {
-    return ["@conductor-oss/native-darwin-universal"];
+    return ["conductor-oss-native-darwin-universal"];
   }
 
   if (process.platform === "linux" && process.arch === "x64") {
-    return ["@conductor-oss/native-linux-x64"];
+    return ["conductor-oss-native-linux-x64"];
   }
 
   if (process.platform === "win32" && process.arch === "x64") {
-    return ["@conductor-oss/native-win32-x64"];
+    return ["conductor-oss-native-win32-x64"];
   }
 
   return [];

--- a/scripts/cli-native-packages.mjs
+++ b/scripts/cli-native-packages.mjs
@@ -25,7 +25,7 @@ function copyOptionalFile(sourcePath, destinationPath) {
 export const CLI_NATIVE_TARGETS = [
   {
     id: "darwin-universal",
-    packageName: "@conductor-oss/native-darwin-universal",
+    packageName: "conductor-oss-native-darwin-universal",
     os: ["darwin"],
     cpu: ["arm64", "x64"],
     binaryName: "conductor",
@@ -33,7 +33,7 @@ export const CLI_NATIVE_TARGETS = [
   },
   {
     id: "linux-x64",
-    packageName: "@conductor-oss/native-linux-x64",
+    packageName: "conductor-oss-native-linux-x64",
     os: ["linux"],
     cpu: ["x64"],
     binaryName: "conductor",
@@ -41,7 +41,7 @@ export const CLI_NATIVE_TARGETS = [
   },
   {
     id: "win32-x64",
-    packageName: "@conductor-oss/native-win32-x64",
+    packageName: "conductor-oss-native-win32-x64",
     os: ["win32"],
     cpu: ["x64"],
     binaryName: "conductor.exe",


### PR DESCRIPTION
This release path was failing when the native runtime packages were published from GitHub Actions. The darwin packaging job produced a valid tarball, but `npm publish` returned a 404 for the package name, which stopped the release before the main CLI package could be published.

The failure affected users by blocking the release pipeline entirely. Even though the native binaries were built and packed correctly, the release job could not complete because the publish step targeted package names under the `@conductor-oss` scope that npm was not accepting for these native runtime artifacts.

The root cause was that the native package metadata and runtime lookup logic both assumed scoped package names such as `@conductor-oss/native-darwin-universal`. The workflow then tried to publish those tarballs directly to npm, where the registry rejected them with `E404 Not Found`.

This change switches the native runtime package identifiers to unscoped publishable names:

- `conductor-oss-native-darwin-universal`
- `conductor-oss-native-linux-x64`
- `conductor-oss-native-win32-x64`

The packaging metadata in `scripts/cli-native-packages.mjs` now emits those names, and the bundled-runtime resolver in `packages/cli/src/commands/start.ts` looks for the same packages at runtime. That keeps the publish path and the installed-package resolution path aligned.

Validation for this change was limited to the relevant local checks. I reran `bun run --cwd packages/cli test`, which passed, and confirmed the packaging metadata now emits the updated native package names. I did not rerun the full GitHub Actions release workflow locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated native package naming conventions for platform-specific builds across Darwin, Linux, and Windows environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->