### PR TITLE
fix: support Windows process lifecycle checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,6 +451,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "uuid",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3371,6 +3372,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/crates/conductor-server/Cargo.toml
+++ b/crates/conductor-server/Cargo.toml
@@ -34,3 +34,6 @@ tower = "0.5"
 base64 = "0.22"
 rand = "0.8"
 rsa = { version = "0.9", features = ["pem"] }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_Threading"] }

--- a/crates/conductor-server/src/state/workspace.rs
+++ b/crates/conductor-server/src/state/workspace.rs
@@ -458,13 +458,47 @@ fn sanitize_token(value: &str) -> String {
 }
 
 pub(crate) fn is_process_alive(pid: u32) -> bool {
-    if pid == 0 || pid > i32::MAX as u32 {
-        return false;
+    #[cfg(unix)]
+    {
+        if pid == 0 || pid > i32::MAX as u32 {
+            return false;
+        }
+        let pid = pid as libc::pid_t;
+        // SAFETY: libc::kill with signal 0 only checks process existence.
+        let result = unsafe { libc::kill(pid, 0) };
+        result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
     }
-    let pid = pid as libc::pid_t;
-    // SAFETY: libc::kill with signal 0 only checks process existence.
-    let result = unsafe { libc::kill(pid, 0) };
-    result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+
+    #[cfg(windows)]
+    {
+        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::System::Threading::{
+            GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, STILL_ACTIVE,
+        };
+
+        if pid == 0 {
+            return false;
+        }
+
+        // SAFETY: OpenProcess/GetExitCodeProcess only inspect an explicit pid.
+        unsafe {
+            let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+            if handle.is_null() {
+                return false;
+            }
+
+            let mut exit_code = 0u32;
+            let result = GetExitCodeProcess(handle, &mut exit_code);
+            CloseHandle(handle);
+            result != 0 && exit_code == STILL_ACTIVE
+        }
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = pid;
+        false
+    }
 }
 
 pub(crate) fn terminate_process(pid: u32) -> bool {
@@ -499,7 +533,44 @@ pub(crate) fn terminate_process(pid: u32) -> bool {
         let killed = unsafe { libc::kill(pid, libc::SIGKILL) };
         killed == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
     }
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    {
+        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::System::Threading::{
+            OpenProcess, TerminateProcess, WaitForSingleObject, PROCESS_QUERY_LIMITED_INFORMATION,
+            PROCESS_TERMINATE, SYNCHRONIZE, WAIT_OBJECT_0,
+        };
+
+        if pid == 0 {
+            return false;
+        }
+        if !is_process_alive(pid) {
+            return true;
+        }
+
+        // SAFETY: OpenProcess/TerminateProcess target a specific pid and handle is closed before returning.
+        unsafe {
+            let handle = OpenProcess(
+                PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE | SYNCHRONIZE,
+                0,
+                pid,
+            );
+            if handle.is_null() {
+                return false;
+            }
+
+            let terminated = TerminateProcess(handle, 1);
+            let wait_result = if terminated != 0 {
+                WaitForSingleObject(handle, 2_000)
+            } else {
+                1
+            };
+            CloseHandle(handle);
+
+            wait_result == WAIT_OBJECT_0 || !is_process_alive(pid)
+        }
+    }
+    #[cfg(not(any(unix, windows)))]
     {
         let _ = pid;
         false


### PR DESCRIPTION
## Summary

This follow-up fixes the Windows build failure introduced by the merged session orchestration work in #120. The Rust backend added detached-runtime process checks in `conductor-server`, but the helper in `workspace.rs` still assumed a Unix environment and called `libc::kill` and `libc::pid_t` unconditionally. That compiles on Unix, but it fails immediately on Windows because those symbols are not available there.

The fix makes the detached-process helpers explicitly platform-aware. Unix keeps the existing `kill(..., 0)` and signal-based termination behavior, while Windows now uses native process APIs through `windows-sys` to detect live processes and terminate them when Conductor needs to clean up a detached runtime. This keeps the original runtime-management intent intact instead of just compiling around the error with a no-op implementation.

## Validation

The following checks passed locally:

- `cargo clippy --workspace -- -D warnings`
- `cargo test -p conductor-server -- --nocapture`

I also attempted a Windows-target `cargo check`, but it could not complete on this macOS machine because the `x86_64-pc-windows-gnu` target pulls in `ring`, which requires a MinGW cross-compiler that is not installed here. The Windows-hosted GitHub Actions job is the authoritative verification for that path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Windows platform compatibility for process management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->