### PR TITLE
fix: use stable windows-sys process constants

### DIFF
--- a/crates/conductor-server/src/state/workspace.rs
+++ b/crates/conductor-server/src/state/workspace.rs
@@ -471,9 +471,9 @@ pub(crate) fn is_process_alive(pid: u32) -> bool {
 
     #[cfg(windows)]
     {
-        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
         use windows_sys::Win32::System::Threading::{
-            GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, STILL_ACTIVE,
+            GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
         };
 
         if pid == 0 {
@@ -535,11 +535,12 @@ pub(crate) fn terminate_process(pid: u32) -> bool {
     }
     #[cfg(windows)]
     {
-        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::Foundation::{CloseHandle, WAIT_OBJECT_0};
         use windows_sys::Win32::System::Threading::{
             OpenProcess, TerminateProcess, WaitForSingleObject, PROCESS_QUERY_LIMITED_INFORMATION,
-            PROCESS_TERMINATE, SYNCHRONIZE, WAIT_OBJECT_0,
+            PROCESS_TERMINATE,
         };
+        const PROCESS_SYNCHRONIZE: u32 = 0x0010_0000;
 
         if pid == 0 {
             return false;
@@ -551,7 +552,7 @@ pub(crate) fn terminate_process(pid: u32) -> bool {
         // SAFETY: OpenProcess/TerminateProcess target a specific pid and handle is closed before returning.
         unsafe {
             let handle = OpenProcess(
-                PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE | SYNCHRONIZE,
+                PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE | PROCESS_SYNCHRONIZE,
                 0,
                 pid,
             );


### PR DESCRIPTION
## Summary

This is a follow-up to #121.

The Windows process lifecycle fix in #121 was correct at the behavior level, but it imported several process status constants from the wrong `windows-sys` module for the version pinned in this repository. On the Windows runner, `STILL_ACTIVE` and `WAIT_OBJECT_0` are exported from `Win32::Foundation`, and there is no generic `SYNCHRONIZE` symbol under `Win32::System::Threading` in `windows-sys 0.59`. That caused the Windows build to fail before the new runtime-cleanup logic could even compile.

This patch keeps the same Windows process-lifecycle behavior and only fixes the compatibility layer: it imports `STILL_ACTIVE` and `WAIT_OBJECT_0` from `Win32::Foundation` and uses the explicit synchronize access bit when opening a process handle. That makes the implementation match the actual API surface exposed by the dependency version used in CI.

## Validation

- `cargo clippy --workspace -- -D warnings`
- `cargo test -p conductor-server -- --nocapture`
