### PR TITLE
fix: align Windows process status types

### DIFF
--- a/crates/conductor-server/src/state/workspace.rs
+++ b/crates/conductor-server/src/state/workspace.rs
@@ -490,7 +490,7 @@ pub(crate) fn is_process_alive(pid: u32) -> bool {
             let mut exit_code = 0u32;
             let result = GetExitCodeProcess(handle, &mut exit_code);
             CloseHandle(handle);
-            result != 0 && exit_code == STILL_ACTIVE
+            result != 0 && exit_code == STILL_ACTIVE as u32
         }
     }
 


### PR DESCRIPTION
## Summary

This is a follow-up to #122.

The previous Windows compatibility follow-up fixed the `windows-sys` module imports, but the Windows runner still failed because `GetExitCodeProcess` writes a `u32` while `STILL_ACTIVE` from `windows-sys 0.59` is typed as `i32`. That left one remaining type mismatch on the Windows-only code path.

This patch keeps the same behavior and only aligns the comparison type by casting `STILL_ACTIVE` to `u32` before comparing it with the reported process exit code.

## Validation

- `cargo clippy --workspace -- -D warnings`
- `cargo test -p conductor-server state::tmux_runtime::tests::restore_runtime_sessions_reattaches_running_tmux_sessions -- --nocapture`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Windows platform compatibility issue in process liveliness checks to ensure proper type handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->