### PR TITLE
fix: verify npm publication before promoting latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -335,12 +335,51 @@ jobs:
             npm publish "$tarball" --access public --provenance
           done
 
-      - name: Publish to npm
+      - name: Publish CLI to npm release-candidate
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        shell: bash
         run: |
-          npm publish "${{ steps.pack.outputs.tarball_path }}" --access public --provenance
-          echo "✅ Published conductor-oss@${{ needs.version.outputs.new_version }}"
+          set -euo pipefail
+          npm publish "${{ steps.pack.outputs.tarball_path }}" --access public --provenance --tag release-candidate
+
+      - name: Verify published npm packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ needs.version.outputs.new_version }}"
+
+          node scripts/verify-npm-publication.mjs \
+            --package conductor-oss-native-darwin-universal \
+            --version "$version" \
+            --require-file bin/conductor
+
+          node scripts/verify-npm-publication.mjs \
+            --package conductor-oss-native-linux-x64 \
+            --version "$version" \
+            --require-file bin/conductor
+
+          node scripts/verify-npm-publication.mjs \
+            --package conductor-oss-native-win32-x64 \
+            --version "$version" \
+            --require-file bin/conductor.exe
+
+          node scripts/verify-npm-publication.mjs \
+            --package conductor-oss \
+            --version "$version" \
+            --require-file dist/launcher.js \
+            --require-file web/package.json
+
+      - name: Promote CLI npm dist-tag
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ needs.version.outputs.new_version }}"
+          npm dist-tag add "conductor-oss@$version" latest
+          npm dist-tag rm conductor-oss release-candidate || true
+          echo "✅ Published conductor-oss@$version"
 
       - name: Tag release
         shell: bash

--- a/scripts/verify-npm-publication.mjs
+++ b/scripts/verify-npm-publication.mjs
@@ -1,0 +1,198 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+
+const NPM_EXECUTABLE = process.platform === "win32" ? "npm.cmd" : "npm";
+
+function parseArgs(argv) {
+  const options = {
+    packageName: "",
+    version: "",
+    requireFiles: [],
+    timeoutMs: 120_000,
+    pollIntervalMs: 5_000,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--package") {
+      options.packageName = argv[index + 1] ?? "";
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--version") {
+      options.version = argv[index + 1] ?? "";
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--require-file") {
+      options.requireFiles.push(argv[index + 1] ?? "");
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--timeout-ms") {
+      options.timeoutMs = Number(argv[index + 1]);
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--poll-interval-ms") {
+      options.pollIntervalMs = Number(argv[index + 1]);
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!options.packageName) {
+    throw new Error("Missing required --package.");
+  }
+
+  if (!options.version) {
+    throw new Error("Missing required --version.");
+  }
+
+  if (!Number.isFinite(options.timeoutMs) || options.timeoutMs <= 0) {
+    throw new Error(`Invalid --timeout-ms value: ${options.timeoutMs}`);
+  }
+
+  if (!Number.isFinite(options.pollIntervalMs) || options.pollIntervalMs <= 0) {
+    throw new Error(`Invalid --poll-interval-ms value: ${options.pollIntervalMs}`);
+  }
+
+  return options;
+}
+
+function encodePackageName(packageName) {
+  return encodeURIComponent(packageName);
+}
+
+async function fetchPublishedMetadata(packageName, version) {
+  const response = await fetch(`https://registry.npmjs.org/${encodePackageName(packageName)}/${encodeURIComponent(version)}`, {
+    headers: { accept: "application/json" },
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Registry metadata lookup failed for ${packageName}@${version}: ${response.status} ${response.statusText}`);
+  }
+
+  return await response.json();
+}
+
+async function checkTarball(url) {
+  let response = await fetch(url, { method: "HEAD", redirect: "follow" });
+
+  if (response.status === 405) {
+    response = await fetch(url, {
+      method: "GET",
+      redirect: "follow",
+      headers: { Range: "bytes=0-0" },
+    });
+  }
+
+  return response;
+}
+
+async function waitForPublication({ packageName, version, timeoutMs, pollIntervalMs }) {
+  const startedAt = Date.now();
+  let lastProblem = "package metadata not found";
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const metadata = await fetchPublishedMetadata(packageName, version);
+    if (metadata?.dist?.tarball) {
+      const tarballResponse = await checkTarball(metadata.dist.tarball);
+      if (tarballResponse.ok) {
+        return metadata;
+      }
+      lastProblem = `tarball ${metadata.dist.tarball} returned ${tarballResponse.status} ${tarballResponse.statusText}`;
+    }
+
+    await sleep(pollIntervalMs);
+  }
+
+  throw new Error(`Timed out waiting for ${packageName}@${version} to become downloadable: ${lastProblem}`);
+}
+
+function packPublishedTarball({ packageName, version, destinationDir }) {
+  return execFileSync(
+    NPM_EXECUTABLE,
+    ["pack", "--silent", "--pack-destination", destinationDir, `${packageName}@${version}`],
+    {
+      cwd: destinationDir,
+      encoding: "utf8",
+    },
+  ).trim();
+}
+
+function unpackTarball(tarballPath, destinationDir) {
+  execFileSync("tar", ["-xzf", tarballPath, "-C", destinationDir], {
+    stdio: "pipe",
+  });
+}
+
+function verifyExtractedPackage({ packageName, version, unpackRoot, requireFiles }) {
+  const packageDir = join(unpackRoot, "package");
+  const manifestPath = join(packageDir, "package.json");
+
+  if (!existsSync(manifestPath)) {
+    throw new Error(`Downloaded tarball for ${packageName}@${version} is missing package/package.json`);
+  }
+
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  if (manifest.name !== packageName) {
+    throw new Error(`Downloaded tarball name mismatch: expected ${packageName}, received ${manifest.name}`);
+  }
+
+  if (manifest.version !== version) {
+    throw new Error(`Downloaded tarball version mismatch: expected ${version}, received ${manifest.version}`);
+  }
+
+  for (const relativePath of requireFiles) {
+    if (!relativePath) {
+      continue;
+    }
+    const requiredPath = join(packageDir, relativePath);
+    if (!existsSync(requiredPath)) {
+      throw new Error(`Downloaded tarball for ${packageName}@${version} is missing required file ${relativePath}`);
+    }
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const tempDir = mkdtempSync(join(tmpdir(), "conductor-npm-publication-"));
+
+  try {
+    const metadata = await waitForPublication(options);
+    const tarballName = packPublishedTarball({
+      packageName: options.packageName,
+      version: options.version,
+      destinationDir: tempDir,
+    });
+    const tarballPath = join(tempDir, tarballName);
+    unpackTarball(tarballPath, tempDir);
+    verifyExtractedPackage({
+      packageName: options.packageName,
+      version: options.version,
+      unpackRoot: tempDir,
+      requireFiles: options.requireFiles,
+    });
+
+    console.log(`Verified ${options.packageName}@${options.version} from ${metadata.dist.tarball}`);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+await main();


### PR DESCRIPTION
This fixes a release-path bug that allowed `conductor-oss@latest` to become temporarily unusable even though npm metadata already showed the new version as published.

On March 8, 2026, `conductor-oss@0.3.2` appeared in npm metadata before the public tarball was actually downloadable. During that window, users running `npx conductor-oss@latest` received a 404 from `https://registry.npmjs.org/conductor-oss/-/conductor-oss-0.3.2.tgz`. From the user side this looked like a broken package release even though the publish workflow had already advanced `latest`.

The root cause is that the release workflow treated a successful `npm publish` as enough to move the CLI package onto `latest`. That is optimistic. npm can expose version metadata before the tarball is consistently retrievable from the public registry, so our workflow was promoting a version before the package was actually installable.

This change adds an explicit post-publish verification step. The CLI package is now published under a temporary `release-candidate` dist-tag, the workflow waits for the public registry metadata and tarball to become available, downloads the package from npm, and verifies required files are present. The same verification is also run for the native packages so the release does not proceed while any platform package is still unavailable. Only after those checks pass does the workflow promote the CLI package to `latest`.

The practical effect is that users should no longer see `latest` point at a version that npm cannot download yet. If npm propagation is delayed, the workflow will wait instead of publishing a broken `latest`.

Validation for this change was done with the real registry behavior and the live CLI install path:

- `node scripts/verify-npm-publication.mjs --package conductor-oss --version 0.3.2 --require-file dist/launcher.js --require-file web/package.json`
- `npx -y conductor-oss@latest --help`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced npm package publishing workflow with release-candidate tagging and multi-stage verification before promoting releases to latest.
  * Added comprehensive package validation to verify tarball integrity, confirm required files exist in distributions, and ensure published package metadata accuracy.
  * Improved release automation with staged, automated verification checks across multiple package platforms prior to general availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->