### PR TITLE
chore: gitignore local native binary directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ pnpm-lock.yaml
 /dashboard/node_modules
 /dashboard/dist
 projects/
+packages/cli/native/


### PR DESCRIPTION
Adds packages/cli/native/ to .gitignore. This directory contains the locally-built Rust binary copied for development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to exclude build artifacts from version control, maintaining a cleaner repository structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->