### PR TITLE
[codex] publish CLI to GitHub Packages and refresh docs

### DIFF
--- a/crates/conductor-executors/src/agents/mod.rs
+++ b/crates/conductor-executors/src/agents/mod.rs
@@ -166,8 +166,6 @@ pub fn build_runtime_env(
 }
 
 fn candidate_paths(dir: &Path, command: &str) -> Vec<PathBuf> {
-    let candidates = vec![dir.join(command)];
-
     #[cfg(windows)]
     {
         let pathext = env::var_os("PATHEXT")
@@ -180,12 +178,19 @@ fn candidate_paths(dir: &Path, command: &str) -> Vec<PathBuf> {
                     .collect::<Vec<_>>()
             })
             .unwrap_or_else(|| vec![".exe".to_string(), ".cmd".to_string(), ".bat".to_string()]);
-        for ext in pathext {
-            candidates.push(dir.join(format!("{command}{ext}")));
-        }
+        std::iter::once(dir.join(command))
+            .chain(
+                pathext
+                    .into_iter()
+                    .map(|ext| dir.join(format!("{command}{ext}"))),
+            )
+            .collect()
     }
 
-    candidates
+    #[cfg(not(windows))]
+    {
+        vec![dir.join(command)]
+    }
 }
 
 fn is_executable_candidate(candidate: &Path) -> bool {


### PR DESCRIPTION
## Summary

This update broadens the branch from the earlier Windows-only packaging fix into a release and packaging pass for the published CLI, plus a documentation refresh for the current app surface.

The release workflow now produces a second tarball variant for GitHub Packages and publishes it with the repository token. The release staging scripts were updated so the packaged manifest can be rewritten with an alternate published package name and registry metadata, which keeps the npm package flow intact while enabling GitHub Packages publication from the same release pipeline.

The packaged CLI smoke test was also corrected to match the server's actual contract. The verifier had been waiting for a dashboard spawn-time agent override to rewrite the saved repo-local `conductor.yaml`, which is not how the app behaves. Spawn requests are meant to choose the agent for that session only; saved defaults stay in preferences and repository settings unless the user explicitly edits them. The verifier now checks the spawned session's selected agent while confirming the saved config remains stable.

Finally, the root README was rewritten from the current codebase rather than older product framing. It now documents the Rust backend, Next.js dashboard, tmux-backed session runtime, worktree/local workspace modes, supported agent adapters, preview flow, GitHub integration, access-control options, and the current source/npm install paths.

## User impact

Users cutting releases can now publish the CLI to GitHub Packages as part of the existing workflow instead of maintaining a separate manual path. At the same time, the packaged CLI verification step is aligned with intended runtime behavior, which removes a false-negative timeout in release validation. The README is also more accurate for contributors and operators setting up or evaluating the app.

## Root cause

The release tooling only staged the CLI for its default npm registry package identity, so the workflow could not produce a GitHub Packages-targeted artifact without additional manual steps. Separately, the verifier encoded an outdated assumption that dashboard launch choices should persist back into repo-local defaults, but the backend explicitly preserves those defaults and treats spawn-time agent overrides as session-scoped.

## What changed

- Added a GitHub Packages tarball build step and publish step to the release workflow.
- Extended the CLI release staging scripts with `publishedName` and `publishRegistry` support so manifests can be rewritten for alternate publication targets.
- Updated the packaged CLI verifier to assert the spawned session agent instead of expecting spawn-time agent choices to mutate saved config.
- Rewrote the root README to document the current architecture, setup paths, feature set, and operational constraints.

## Validation

```bash
node scripts/verify-cli-package.mjs
```

The packaged CLI release preflight passed locally after the verifier update.
