### PR TITLE
fix: use highest published semver as release version base

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,12 +57,51 @@ jobs:
           [ -z "$tag_ver" ] && tag_ver="0.0.0"
 
           pkg_ver=$(node -p "require('./packages/cli/package.json').version")
-          npm_ver=$(npm view conductor-oss version 2>/dev/null || echo "0.0.0")
 
-          echo "Tag: $tag_ver | Package: $pkg_ver | npm: $npm_ver"
+          npm_highest=$(node -e "
+            const { execSync } = require('child_process');
+            let raw = '[]';
+            try {
+              raw = execSync('npm view conductor-oss versions --json', { stdio: ['ignore', 'pipe', 'ignore'] })
+                .toString()
+                .trim() || '[]';
+            } catch {}
+
+            let versions;
+            try {
+              versions = JSON.parse(raw);
+            } catch {
+              versions = [];
+            }
+
+            if (typeof versions === 'string') versions = [versions];
+            if (!Array.isArray(versions)) versions = [];
+
+            const stable = versions
+              .map((v) => String(v).trim())
+              .filter((v) => /^\d+\.\d+\.\d+$/.test(v));
+
+            if (stable.length === 0) {
+              console.log('0.0.0');
+              process.exit(0);
+            }
+
+            const p = (v) => v.split('.').map(Number);
+            stable.sort((a, b) => {
+              const pa = p(a), pb = p(b);
+              for (let i = 0; i < 3; i++) {
+                if ((pa[i] || 0) !== (pb[i] || 0)) return (pa[i] || 0) - (pb[i] || 0);
+              }
+              return 0;
+            });
+
+            console.log(stable[stable.length - 1]);
+          ")
+
+          echo "Tag: $tag_ver | Package: $pkg_ver | npm-highest: $npm_highest"
 
           base=$(node -e "
-            const vs=['$tag_ver','$pkg_ver','$npm_ver'];
+            const vs=['$tag_ver','$pkg_ver','$npm_highest'];
             const p=v=>v.split('.').map(Number);
             vs.sort((a,b)=>{const pa=p(a),pb=p(b);for(let i=0;i<3;i++)if((pa[i]||0)!==(pb[i]||0))return(pa[i]||0)-(pb[i]||0);return 0});
             console.log(vs[vs.length-1]);


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Summary
Release version calculation currently uses `npm view conductor-oss version`, which follows only the `latest` dist-tag. That can lag behind versions already published under other tags like `release-candidate`.

This PR switches base version derivation to the highest stable semver from `npm view conductor-oss versions --json`.

## Why
When `release-candidate` is ahead of `latest`, using `latest` can compute a duplicate or stale next version.

## User-Facing Release Notes
- release workflow now derives its base version from the highest published stable semver, not only npm `latest`.
- avoids version regression when `release-candidate` is ahead of `latest`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to dynamically detect and utilize the highest stable version for release tagging and versioning logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->