### PR TITLE
fix: guard detached host state for non-unix builds

### DIFF
--- a/crates/conductor-server/src/state/detached_runtime.rs
+++ b/crates/conductor-server/src/state/detached_runtime.rs
@@ -174,6 +174,7 @@ struct DetachedHostStreamSlot {
     tx: mpsc::Sender<DetachedPtyHostStreamMessage>,
 }
 
+#[cfg(unix)]
 struct DetachedHostState {
     token: String,
     child_pid: u32,


### PR DESCRIPTION
## Summary
- guard the detached host state struct behind `cfg(unix)` so Windows does not compile Unix-only PTY state types
- follow up the decoder fix with the remaining struct-level non-Unix compile cleanup
- unblock the Windows native release workflow on `main`

## Type of Change
- [x] Bug fix
- [x] Improvement

## User-Facing Release Notes
- Restored another Windows release build regression after the detached terminal transport update.
- Non-Unix builds no longer compile Unix-only detached host state types.

## Testing
- cargo test --workspace
- cargo clippy --workspace -- -D warnings
- reviewed the failing Windows native release log for run `23014163741`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal state management for detached runtime operations on Unix-based systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->