### PR TITLE
fix: smooth momentum-based touch scroll for mobile terminal

### DIFF
--- a/packages/web/next-env.d.ts
+++ b/packages/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/web/src/components/sessions/SessionTerminal.tsx
+++ b/packages/web/src/components/sessions/SessionTerminal.tsx
@@ -2362,57 +2362,110 @@ export function SessionTerminal({
       handleTerminalWheel(event);
     };
 
-    // --- Touch-scroll support for mobile ---
-    // xterm.js captures touch events on its canvas but can fail to propagate
-    // scroll on older WebKit builds and when the xterm buffer is small.  We
-    // register a parallel touchmove handler on the outer container so that
-    // vertical swipes always translate into terminal scroll-lines, and short
-    // taps (no scroll) still focus the terminal.
-    let touchStartY: number | null = null;
+    // --- Smooth touch-scroll with momentum for mobile ---
+    // xterm.js line-by-line scrolling feels choppy on touch.  We accumulate
+    // fractional pixel deltas so the terminal responds to the smallest finger
+    // movement, and add momentum (inertia) on touchend so the scroll coasts
+    // to a stop like a native list view.
+    let touchLastY: number | null = null;
     let touchScrolled = false;
-    const TOUCH_LINE_HEIGHT_PX = 18;
+    let touchAccumY = 0;
+    let touchVelocity = 0;
+    let touchLastTime = 0;
+    let momentumFrame: number | null = null;
+
+    // Measured from xterm.js default cell height.  This value only converts
+    // pixel deltas into line counts; a smaller value means more responsive
+    // (sub-line) feel because we emit a scrollLines(1) sooner.
+    const LINE_HEIGHT_PX = 16;
+    // Momentum tuning
+    const MOMENTUM_DECAY = 0.92;
+    const MOMENTUM_MIN_VELOCITY = 0.3;
+    const VELOCITY_WEIGHT = 0.6;
+
+    const cancelMomentum = () => {
+      if (momentumFrame !== null) {
+        cancelAnimationFrame(momentumFrame);
+        momentumFrame = null;
+      }
+    };
+
+    const stepMomentum = () => {
+      const term = termRef.current;
+      if (!term || Math.abs(touchVelocity) < MOMENTUM_MIN_VELOCITY) {
+        momentumFrame = null;
+        updateScrollState();
+        return;
+      }
+      touchAccumY += touchVelocity;
+      const lines = Math.trunc(touchAccumY / LINE_HEIGHT_PX);
+      if (lines !== 0) {
+        touchAccumY -= lines * LINE_HEIGHT_PX;
+        term.scrollLines(lines);
+      }
+      touchVelocity *= MOMENTUM_DECAY;
+      momentumFrame = requestAnimationFrame(stepMomentum);
+    };
 
     const onTouchStart = (event: TouchEvent) => {
+      cancelMomentum();
       if (event.touches.length === 1) {
-        touchStartY = event.touches[0]!.clientY;
+        touchLastY = event.touches[0]!.clientY;
+        touchLastTime = event.timeStamp;
         touchScrolled = false;
+        touchAccumY = 0;
+        touchVelocity = 0;
       }
     };
 
     const onTouchMove = (event: TouchEvent) => {
       const term = termRef.current;
-      if (!term || touchStartY === null || event.touches.length !== 1) {
+      if (!term || touchLastY === null || event.touches.length !== 1) {
         return;
       }
       const currentY = event.touches[0]!.clientY;
-      const deltaY = touchStartY - currentY;
-      const deltaLines = Math.trunc(deltaY / TOUCH_LINE_HEIGHT_PX);
-      if (deltaLines === 0) {
-        return;
-      }
-      // Only mark as scrolled and intercept when there is scrollback to
-      // scroll through.  When baseY === 0 the swipe is a no-op and we must
-      // NOT suppress the subsequent tap-to-focus in onTouchEnd.
+      const deltaY = touchLastY - currentY;
+      const now = event.timeStamp;
+      const dt = now - touchLastTime;
+
+      // Only scroll when there is scrollback to scroll through.
+      // When baseY === 0 the swipe is a no-op and we must NOT suppress
+      // the subsequent tap-to-focus in onTouchEnd.
       if (term.buffer.active.baseY > 0) {
         touchScrolled = true;
-        term.scrollLines(deltaLines);
-        updateScrollState();
+        touchAccumY += deltaY;
+
+        const lines = Math.trunc(touchAccumY / LINE_HEIGHT_PX);
+        if (lines !== 0) {
+          touchAccumY -= lines * LINE_HEIGHT_PX;
+          term.scrollLines(lines);
+        }
+
+        // Exponential moving average for velocity (px per frame @ 16ms)
+        if (dt > 0) {
+          const instantVelocity = (deltaY / dt) * 16;
+          touchVelocity = touchVelocity === 0
+            ? instantVelocity
+            : VELOCITY_WEIGHT * instantVelocity + (1 - VELOCITY_WEIGHT) * touchVelocity;
+        }
+
         event.preventDefault();
-      } else {
-        // Nothing to scroll – treat this gesture as a potential tap
-        touchScrolled = false;
       }
-      touchStartY = currentY;
-      touchStartY = currentY;
+      touchLastY = currentY;
+      touchLastTime = now;
     };
 
     const onTouchEnd = () => {
-      if (!touchScrolled && touchStartY !== null) {
-        // Short tap — focus the terminal (deferred from pointerdown)
+      if (!touchScrolled && touchLastY !== null) {
+        // Short tap: focus the terminal (deferred from pointerdown)
         focusTerminal();
+      } else if (touchScrolled && Math.abs(touchVelocity) >= MOMENTUM_MIN_VELOCITY) {
+        // Kick off momentum scroll
+        momentumFrame = requestAnimationFrame(stepMomentum);
       }
-      touchStartY = null;
+      touchLastY = null;
       touchScrolled = false;
+      updateScrollState();
     };
 
     container.addEventListener("wheel", wheelListener, { passive: false });
@@ -2421,6 +2474,7 @@ export function SessionTerminal({
     container.addEventListener("touchend", onTouchEnd, { passive: true });
     container.addEventListener("touchcancel", onTouchEnd, { passive: true });
     return () => {
+      cancelMomentum();
       container.removeEventListener("wheel", wheelListener);
       container.removeEventListener("touchstart", onTouchStart);
       container.removeEventListener("touchmove", onTouchMove);


### PR DESCRIPTION
## What

The touch scroll from #181 works but feels choppy and hard to use on mobile. This replaces it with a smooth, momentum-based scroll that matches native iOS/Android list behavior.

## Root Cause

The previous implementation used `Math.trunc(deltaY / 18)` which meant:
- You had to move your finger 18px before anything happened
- Then it jumped a full line at once
- Scroll stopped dead the instant you lifted your finger
- Small or fast swipes felt unresponsive

## Changes

### Fractional accumulation
Pixel deltas accumulate continuously. A `scrollLines(1)` fires as soon as the accumulated delta crosses the 16px line height threshold, so even tiny finger movements produce visible scroll.

### Momentum / inertia
Touch velocity is tracked with an exponential moving average during the swipe. On `touchend`, a `requestAnimationFrame` loop continues scrolling with 0.92x decay per frame until velocity drops below 0.3 px/frame. This gives the native "coast to stop" feel.

### Details
- Line height threshold: 18px → 16px (faster response)
- Momentum decay: 0.92 per frame (~60fps, stops in ~0.5s for a moderate flick)
- Velocity smoothing: 60/40 blend of instant vs previous velocity
- New touchstart cancels momentum immediately (re-touch stops scroll)
- Momentum frame cleaned up on unmount
- Fixed duplicate `touchStartY = currentY` line from previous PR

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## User-Facing Release Notes
- Terminal touch scrolling on mobile is now smooth with momentum, matching native scroll behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile touch scrolling in the session terminal now features inertial momentum scrolling for a smoother, more responsive scrolling experience on touch devices.

* **Chores**
  * Updated internal configuration module paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->