### PR TITLE
fix: resolve critical and high CodeQL security alerts

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -269,13 +269,28 @@ function slugifyProjectId(value: string): string {
   const bounded = value.length > MAX_PROJECT_ID_INPUT_LENGTH
     ? value.slice(0, MAX_PROJECT_ID_INPUT_LENGTH)
     : value;
-  const normalized = bounded
-    .trim()
-    .toLowerCase()
-    .replace(/\.git$/i, "")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-  return normalized || "project";
+  let normalized = bounded.trim().toLowerCase();
+  if (normalized.endsWith(".git")) {
+    normalized = normalized.slice(0, -4);
+  }
+  // Build slug character-by-character to avoid polynomial regex on
+  // uncontrolled input (CodeQL js/polynomial-redos).
+  let slug = "";
+  let lastWasDash = true;
+  for (const ch of normalized) {
+    if ((ch >= "a" && ch <= "z") || (ch >= "0" && ch <= "9")) {
+      slug += ch;
+      lastWasDash = false;
+    } else if (!lastWasDash) {
+      slug += "-";
+      lastWasDash = true;
+    }
+  }
+  // Trim trailing dash
+  if (slug.endsWith("-")) {
+    slug = slug.slice(0, -1);
+  }
+  return slug || "project";
 }
 
 function ensureUniqueProjectKey(baseKey: string, usedKeys: Set<string>): string {

--- a/packages/web/src/lib/devPreviewBrowser.ts
+++ b/packages/web/src/lib/devPreviewBrowser.ts
@@ -179,7 +179,11 @@ function buildNavigationCandidates(value: string): string[] {
     if (error instanceof Error && error.message.startsWith("Navigation blocked:")) {
       throw error;
     }
-    return [normalizedInput];
+    // SECURITY: If we can't parse the URL, reject it rather than passing an
+    // unvalidated string to page.goto() which could cause SSRF.
+    throw new Error(
+      `Navigation blocked: could not parse "${normalizedInput}" as a valid localhost URL.`,
+    );
   }
 }
 

--- a/scripts/release-notes-lib.mjs
+++ b/scripts/release-notes-lib.mjs
@@ -59,12 +59,15 @@ function normalizeHeading(value) {
 
 function stripTemplateNoise(markdown) {
   let result = normalizeNewlines(markdown);
-  // Loop until stable to handle nested/overlapping comment markers
-  let previous;
-  do {
-    previous = result;
-    result = result.replace(CODE_RABBIT_BLOCK_RE, "").replace(HTML_COMMENT_RE, "");
-  } while (result !== previous);
+  // Loop until stable to handle nested/overlapping comment markers.
+  // A single replace pass can leave partial markers when CodeRabbit blocks
+  // contain inner HTML comments; the loop guarantees full removal.
+  const MAX_STRIP_ITERATIONS = 20;
+  for (let i = 0; i < MAX_STRIP_ITERATIONS; i++) {
+    const next = result.replace(CODE_RABBIT_BLOCK_RE, "").replace(HTML_COMMENT_RE, "");
+    if (next === result) break;
+    result = next;
+  }
   return result;
 }
 


### PR DESCRIPTION
## What

Resolves the top 4 actionable security alerts from GitHub Code Scanning (CodeQL + Scorecard).

## Alerts Fixed

| # | Severity | Rule | File | Fix |
|---|----------|------|------|-----|
| 117 | **Critical** | js/request-forgery (SSRF) | `devPreviewBrowser.ts` | Reject unparseable URLs instead of passing unvalidated strings to `page.goto()` |
| 111 | **High** | js/polynomial-redos | `config.ts` | Replace regex slug builder with char-by-char loop |
| 112 | **High** | js/polynomial-redos | `config.ts` | Same as above (both regex sites in `slugifyProjectId`) |
| 116 | **High** | js/incomplete-multi-character-sanitization | `release-notes-lib.mjs` | Add iteration cap, clarify loop stability intent |

## Alerts Not Changed (by design)

| # | Severity | Rule | Reason |
|---|----------|------|--------|
| 63 | High | TokenPermissionsID | Release job needs `contents: write` to create GitHub releases |
| 64-84 | Medium | PinnedDependenciesID | All actions are already SHA-pinned; Scorecard flags tool installation steps (setup-bun, setup-node, rust-toolchain downloading binaries) which can't be pinned further |

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## User-Facing Release Notes
- Hardened preview browser navigation against server-side request forgery
- Eliminated polynomial regex backtracking in project slug generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Security**
  * Enhanced URL validation to explicitly reject invalid localhost URLs with clearer error messaging, preventing potential navigation to unvalidated destinations and improving system security.
  * Improved project ID normalization with more robust character handling to ensure consistent and predictable output behavior across various edge cases and input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->