### PR TITLE
fix: harden workspace continuity across terminal, dispatcher, and preview

### DIFF
--- a/crates/conductor-executors/src/update.rs
+++ b/crates/conductor-executors/src/update.rs
@@ -399,8 +399,11 @@ mod tests {
 
     #[test]
     fn binary_exists_on_path_is_sane() {
-        // `sh` is available in all CI runners and developer environments.
-        assert!(binary_exists_on_path(&["sh"]));
+        // Use the current test binary path so this assertion stays stable even when other
+        // tests temporarily override PATH in parallel.
+        let current_exe = std::env::current_exe().expect("current test binary path");
+        let current_exe = current_exe.to_string_lossy().to_string();
+        assert!(binary_exists_on_path(&[current_exe.as_str()]));
         // Definitely fake name should not.
         assert!(!binary_exists_on_path(&[
             "conductor-this-does-not-exist-xyz"

--- a/crates/conductor-relay/src/relay.rs
+++ b/crates/conductor-relay/src/relay.rs
@@ -89,11 +89,14 @@ struct DeviceRecord {
 
 #[derive(Debug)]
 struct TerminalSessionRecord {
+    terminal_id: String,
+    session_id: String,
     device_id: String,
     owner_user_id: String,
     browser: Option<TerminalConnectionRecord>,
     bridge: Option<TerminalConnectionRecord>,
     bridge_ready_waiters: Vec<oneshot::Sender<()>>,
+    browser_disconnected_at: Option<Instant>,
 }
 
 #[derive(Debug, Clone)]
@@ -127,6 +130,10 @@ struct ProxiedPreviewResponse {
 }
 
 const TERMINAL_SESSION_READY_TIMEOUT: Duration = Duration::from_secs(8);
+#[cfg(not(test))]
+const TERMINAL_BROWSER_REATTACH_GRACE: Duration = Duration::from_secs(15);
+#[cfg(test)]
+const TERMINAL_BROWSER_REATTACH_GRACE: Duration = Duration::from_millis(25);
 
 #[derive(Debug)]
 struct RateBucket {
@@ -1092,10 +1099,27 @@ impl RelayState {
         device_id: &str,
         session_id: &str,
     ) -> std::result::Result<String, (StatusCode, String)> {
-        let terminal_id = Uuid::new_v4().to_string();
-        let (bridge_ready_tx, bridge_ready_rx) = oneshot::channel();
+        let normalized_session_id = session_id.trim();
+        if normalized_session_id.is_empty() {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "Session id is required.".to_string(),
+            ));
+        }
 
-        let start_message = {
+        enum TerminalSessionStart {
+            Reuse {
+                terminal_id: String,
+            },
+            StartNew {
+                terminal_id: String,
+                bridge_tx: mpsc::UnboundedSender<Message>,
+                payload: String,
+            },
+        }
+
+        let (bridge_ready_tx, bridge_ready_rx) = oneshot::channel();
+        let start = {
             let mut inner = self.inner.lock().await;
             let Some(device) = inner.devices.get(device_id) else {
                 return Err((StatusCode::NOT_FOUND, "Device not found.".to_string()));
@@ -1103,75 +1127,100 @@ impl RelayState {
             if device.owner_user_id != user_id {
                 return Err((StatusCode::FORBIDDEN, "Device access denied.".to_string()));
             }
-            if session_id.trim().is_empty() {
-                return Err((
-                    StatusCode::BAD_REQUEST,
-                    "Session id is required.".to_string(),
-                ));
+
+            if let Some(existing) = inner.terminal_sessions.values_mut().find(|session| {
+                session.owner_user_id == user_id
+                    && session.device_id == device_id
+                    && session.session_id == normalized_session_id
+                    && session.browser.is_none()
+            }) {
+                let terminal_id = existing.terminal_id.clone();
+                existing.browser_disconnected_at = None;
+                if existing.bridge.is_some() {
+                    let _ = bridge_ready_tx.send(());
+                } else {
+                    existing.bridge_ready_waiters.push(bridge_ready_tx);
+                }
+                TerminalSessionStart::Reuse { terminal_id }
+            } else {
+                let terminal_id = Uuid::new_v4().to_string();
+                let bridge_tx = inner
+                    .channels
+                    .get(device_id)
+                    .and_then(|channel| channel.bridge.as_ref().map(|record| record.tx.clone()))
+                    .ok_or((
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        "Device is offline.".to_string(),
+                    ))?;
+
+                inner.terminal_sessions.insert(
+                    terminal_id.clone(),
+                    TerminalSessionRecord {
+                        terminal_id: terminal_id.clone(),
+                        session_id: normalized_session_id.to_string(),
+                        device_id: device_id.to_string(),
+                        owner_user_id: user_id.to_string(),
+                        browser: None,
+                        bridge: None,
+                        bridge_ready_waiters: vec![bridge_ready_tx],
+                        browser_disconnected_at: None,
+                    },
+                );
+
+                let payload = serde_json::to_string(&BrowserToBridgeMessage::TerminalProxyStart {
+                    terminal_id: terminal_id.clone(),
+                    session_id: normalized_session_id.to_string(),
+                })
+                .map_err(|err| (StatusCode::BAD_GATEWAY, err.to_string()))?;
+
+                TerminalSessionStart::StartNew {
+                    terminal_id,
+                    bridge_tx,
+                    payload,
+                }
             }
-
-            let bridge_tx = inner
-                .channels
-                .get(device_id)
-                .and_then(|channel| channel.bridge.as_ref().map(|record| record.tx.clone()))
-                .ok_or((
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    "Device is offline.".to_string(),
-                ))?;
-
-            inner.terminal_sessions.insert(
-                terminal_id.clone(),
-                TerminalSessionRecord {
-                    device_id: device_id.to_string(),
-                    owner_user_id: user_id.to_string(),
-                    browser: None,
-                    bridge: None,
-                    bridge_ready_waiters: vec![bridge_ready_tx],
-                },
-            );
-
-            let payload = serde_json::to_string(&BrowserToBridgeMessage::TerminalProxyStart {
-                terminal_id: terminal_id.clone(),
-                session_id: session_id.trim().to_string(),
-            })
-            .map_err(|err| (StatusCode::BAD_GATEWAY, err.to_string()))?;
-
-            (bridge_tx, payload)
         };
 
-        let (bridge_tx, payload) = start_message;
-        if bridge_tx.send(Message::Text(payload.into())).is_err() {
-            let mut inner = self.inner.lock().await;
-            inner.terminal_sessions.remove(&terminal_id);
-            return Err((
-                StatusCode::SERVICE_UNAVAILABLE,
-                "Device disconnected before terminal could start.".to_string(),
-            ));
-        }
+        let terminal_id = match start {
+            TerminalSessionStart::Reuse { terminal_id } => terminal_id,
+            TerminalSessionStart::StartNew {
+                terminal_id,
+                bridge_tx,
+                payload,
+            } => {
+                if bridge_tx.send(Message::Text(payload.into())).is_err() {
+                    let mut inner = self.inner.lock().await;
+                    inner.terminal_sessions.remove(&terminal_id);
+                    return Err((
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        "Device disconnected before terminal could start.".to_string(),
+                    ));
+                }
+                terminal_id
+            }
+        };
 
         match tokio::time::timeout(TERMINAL_SESSION_READY_TIMEOUT, bridge_ready_rx).await {
-            Ok(Ok(())) => {}
+            Ok(Ok(())) => Ok(terminal_id),
             Ok(Err(_)) => {
                 let mut inner = self.inner.lock().await;
                 inner.terminal_sessions.remove(&terminal_id);
-                return Err((
+                Err((
                     StatusCode::BAD_GATEWAY,
                     "Device stopped attaching the relay terminal before it became ready."
                         .to_string(),
-                ));
+                ))
             }
             Err(_) => {
                 let mut inner = self.inner.lock().await;
                 inner.terminal_sessions.remove(&terminal_id);
-                return Err((
+                Err((
                     StatusCode::GATEWAY_TIMEOUT,
                     "Timed out waiting for the paired device relay terminal to become ready."
                         .to_string(),
-                ));
+                ))
             }
         }
-
-        Ok(terminal_id)
     }
 
     async fn authorize_terminal_session_browser(
@@ -1216,39 +1265,100 @@ impl RelayState {
         peer_kind: TerminalPeerKind,
         tx: mpsc::UnboundedSender<Message>,
     ) -> Result<()> {
-        let mut inner = self.inner.lock().await;
-        let session = inner
-            .terminal_sessions
-            .get_mut(terminal_id)
-            .ok_or_else(|| anyhow::anyhow!("terminal session not found"))?;
-        let record = TerminalConnectionRecord { tx };
-        match peer_kind {
-            TerminalPeerKind::Browser => session.browser = Some(record),
-            TerminalPeerKind::Bridge => {
-                session.bridge = Some(record);
-                for waiter in session.bridge_ready_waiters.drain(..) {
-                    let _ = waiter.send(());
+        let replaced = {
+            let mut inner = self.inner.lock().await;
+            let session = inner
+                .terminal_sessions
+                .get_mut(terminal_id)
+                .ok_or_else(|| anyhow::anyhow!("terminal session not found"))?;
+            let record = TerminalConnectionRecord { tx };
+            match peer_kind {
+                TerminalPeerKind::Browser => {
+                    session.browser_disconnected_at = None;
+                    session.browser.replace(record).map(|record| record.tx)
+                }
+                TerminalPeerKind::Bridge => {
+                    let replaced = session.bridge.replace(record).map(|record| record.tx);
+                    for waiter in session.bridge_ready_waiters.drain(..) {
+                        let _ = waiter.send(());
+                    }
+                    replaced
                 }
             }
+        };
+
+        if let Some(previous) = replaced {
+            let _ = previous.send(Message::Close(None));
         }
         Ok(())
     }
 
     async fn unregister_terminal_connection(&self, terminal_id: &str, peer_kind: TerminalPeerKind) {
+        let mut bridge_cleanup = None;
         let counterpart = {
             let mut inner = self.inner.lock().await;
-            let Some(session) = inner.terminal_sessions.remove(terminal_id) else {
+            let Some(session) = inner.terminal_sessions.get_mut(terminal_id) else {
                 return;
             };
 
             match peer_kind {
-                TerminalPeerKind::Browser => session.bridge.map(|record| record.tx),
-                TerminalPeerKind::Bridge => session.browser.map(|record| record.tx),
+                TerminalPeerKind::Browser => {
+                    session.browser = None;
+                    if session.bridge.is_some() {
+                        let disconnected_at = Instant::now();
+                        session.browser_disconnected_at = Some(disconnected_at);
+                        bridge_cleanup = Some(disconnected_at);
+                        None
+                    } else {
+                        inner.terminal_sessions.remove(terminal_id);
+                        None
+                    }
+                }
+                TerminalPeerKind::Bridge => {
+                    let session = inner.terminal_sessions.remove(terminal_id).expect("session exists");
+                    session.browser.map(|record| record.tx)
+                }
             }
         };
 
+        if let Some(disconnected_at) = bridge_cleanup {
+            let state = self.clone();
+            let terminal_id = terminal_id.to_string();
+            tokio::spawn(async move {
+                tokio::time::sleep(TERMINAL_BROWSER_REATTACH_GRACE).await;
+                state
+                    .cleanup_terminal_session_if_browser_absent(&terminal_id, disconnected_at)
+                    .await;
+            });
+        }
+
         if let Some(counterpart) = counterpart {
             let _ = counterpart.send(Message::Close(None));
+        }
+    }
+
+    async fn cleanup_terminal_session_if_browser_absent(
+        &self,
+        terminal_id: &str,
+        disconnected_at: Instant,
+    ) {
+        let bridge = {
+            let mut inner = self.inner.lock().await;
+            let Some(session) = inner.terminal_sessions.get(terminal_id) else {
+                return;
+            };
+            if session.browser.is_some() || session.browser_disconnected_at != Some(disconnected_at) {
+                return;
+            }
+
+            inner
+                .terminal_sessions
+                .remove(terminal_id)
+                .and_then(|session| session.bridge.map(|record| record.tx))
+        };
+
+        if let Some(bridge) = bridge {
+            let _ = bridge.send(Message::Close(None));
         }
     }
 
@@ -2879,6 +2989,150 @@ mod tests {
             .expect("create task should finish")
             .expect("terminal should be created");
         assert_eq!(created_terminal_id, terminal_id);
+    }
+
+    #[tokio::test]
+    async fn create_terminal_session_reuses_existing_detached_terminal() {
+        let state = RelayState::default();
+        let (control_bridge_tx, mut control_bridge_rx) = mpsc::unbounded_channel::<Message>();
+        let (terminal_bridge_tx, _terminal_bridge_rx) = mpsc::unbounded_channel::<Message>();
+
+        {
+            let mut inner = state.inner.lock().await;
+            inner.devices.insert(
+                "device-123".to_string(),
+                DeviceRecord {
+                    device_id: "device-123".to_string(),
+                    owner_user_id: "user@example.com".to_string(),
+                    name: "Mac".to_string(),
+                    hostname: "macbook-pro".to_string(),
+                    os: "darwin".to_string(),
+                    arch: "arm64".to_string(),
+                    refresh_token: "refresh-token".to_string(),
+                },
+            );
+            inner.channels.insert(
+                "device-123".to_string(),
+                BridgeChannel {
+                    bridge: Some(ConnectionRecord {
+                        id: 1,
+                        user_id: "user@example.com".to_string(),
+                        tx: control_bridge_tx,
+                    }),
+                    browsers: HashMap::new(),
+                    last_status: None,
+                },
+            );
+            inner.terminal_sessions.insert(
+                "terminal-1".to_string(),
+                TerminalSessionRecord {
+                    terminal_id: "terminal-1".to_string(),
+                    session_id: "session-abc".to_string(),
+                    device_id: "device-123".to_string(),
+                    owner_user_id: "user@example.com".to_string(),
+                    browser: None,
+                    bridge: Some(TerminalConnectionRecord { tx: terminal_bridge_tx }),
+                    bridge_ready_waiters: vec![],
+                    browser_disconnected_at: Some(Instant::now()),
+                },
+            );
+        }
+
+        let terminal_id = state
+            .create_terminal_session("user@example.com", "device-123", "session-abc")
+            .await
+            .expect("terminal should be reused");
+
+        assert_eq!(terminal_id, "terminal-1");
+        assert!(control_bridge_rx.try_recv().is_err(), "reuse should not start a new bridge proxy session");
+    }
+
+    #[tokio::test]
+    async fn browser_disconnect_keeps_bridge_alive_long_enough_to_reattach() {
+        let state = RelayState::default();
+        let (browser_tx, _browser_rx) = mpsc::unbounded_channel::<Message>();
+        let (bridge_tx, mut bridge_rx) = mpsc::unbounded_channel::<Message>();
+
+        {
+            let mut inner = state.inner.lock().await;
+            inner.terminal_sessions.insert(
+                "terminal-1".to_string(),
+                TerminalSessionRecord {
+                    terminal_id: "terminal-1".to_string(),
+                    session_id: "session-abc".to_string(),
+                    device_id: "device-123".to_string(),
+                    owner_user_id: "user@example.com".to_string(),
+                    browser: Some(TerminalConnectionRecord { tx: browser_tx }),
+                    bridge: Some(TerminalConnectionRecord { tx: bridge_tx }),
+                    bridge_ready_waiters: vec![],
+                    browser_disconnected_at: None,
+                },
+            );
+        }
+
+        state
+            .unregister_terminal_connection("terminal-1", TerminalPeerKind::Browser)
+            .await;
+
+        let (replacement_browser_tx, _replacement_browser_rx) = mpsc::unbounded_channel::<Message>();
+        state
+            .register_terminal_connection("terminal-1", TerminalPeerKind::Browser, replacement_browser_tx)
+            .await
+            .expect("browser should reattach");
+
+        tokio::time::sleep(TERMINAL_BROWSER_REATTACH_GRACE + Duration::from_millis(10)).await;
+
+        {
+            let inner = state.inner.lock().await;
+            let session = inner
+                .terminal_sessions
+                .get("terminal-1")
+                .expect("session should stay alive after browser reattach");
+            assert!(session.browser.is_some());
+            assert!(session.bridge.is_some());
+        }
+        assert!(bridge_rx.try_recv().is_err(), "bridge should stay open after reattach");
+    }
+
+    #[tokio::test]
+    async fn browser_disconnect_eventually_closes_bridge_if_not_reattached() {
+        let state = RelayState::default();
+        let (browser_tx, _browser_rx) = mpsc::unbounded_channel::<Message>();
+        let (bridge_tx, mut bridge_rx) = mpsc::unbounded_channel::<Message>();
+
+        {
+            let mut inner = state.inner.lock().await;
+            inner.terminal_sessions.insert(
+                "terminal-1".to_string(),
+                TerminalSessionRecord {
+                    terminal_id: "terminal-1".to_string(),
+                    session_id: "session-abc".to_string(),
+                    device_id: "device-123".to_string(),
+                    owner_user_id: "user@example.com".to_string(),
+                    browser: Some(TerminalConnectionRecord { tx: browser_tx }),
+                    bridge: Some(TerminalConnectionRecord { tx: bridge_tx }),
+                    bridge_ready_waiters: vec![],
+                    browser_disconnected_at: None,
+                },
+            );
+        }
+
+        state
+            .unregister_terminal_connection("terminal-1", TerminalPeerKind::Browser)
+            .await;
+
+        tokio::time::sleep(TERMINAL_BROWSER_REATTACH_GRACE + Duration::from_millis(10)).await;
+
+        {
+            let inner = state.inner.lock().await;
+            assert!(
+                !inner.terminal_sessions.contains_key("terminal-1"),
+                "session should be cleaned up after grace period"
+            );
+        }
+
+        let close_message = bridge_rx.recv().await.expect("bridge should receive cleanup close");
+        assert!(matches!(close_message, Message::Close(_)));
     }
 }
 

--- a/crates/conductor-relay/src/relay.rs
+++ b/crates/conductor-relay/src/relay.rs
@@ -1315,7 +1315,10 @@ impl RelayState {
                     }
                 }
                 TerminalPeerKind::Bridge => {
-                    let session = inner.terminal_sessions.remove(terminal_id).expect("session exists");
+                    let session = inner
+                        .terminal_sessions
+                        .remove(terminal_id)
+                        .expect("session exists");
                     session.browser.map(|record| record.tx)
                 }
             }
@@ -1347,7 +1350,8 @@ impl RelayState {
             let Some(session) = inner.terminal_sessions.get(terminal_id) else {
                 return;
             };
-            if session.browser.is_some() || session.browser_disconnected_at != Some(disconnected_at) {
+            if session.browser.is_some() || session.browser_disconnected_at != Some(disconnected_at)
+            {
                 return;
             }
 
@@ -3031,7 +3035,9 @@ mod tests {
                     device_id: "device-123".to_string(),
                     owner_user_id: "user@example.com".to_string(),
                     browser: None,
-                    bridge: Some(TerminalConnectionRecord { tx: terminal_bridge_tx }),
+                    bridge: Some(TerminalConnectionRecord {
+                        tx: terminal_bridge_tx,
+                    }),
                     bridge_ready_waiters: vec![],
                     browser_disconnected_at: Some(Instant::now()),
                 },
@@ -3044,7 +3050,10 @@ mod tests {
             .expect("terminal should be reused");
 
         assert_eq!(terminal_id, "terminal-1");
-        assert!(control_bridge_rx.try_recv().is_err(), "reuse should not start a new bridge proxy session");
+        assert!(
+            control_bridge_rx.try_recv().is_err(),
+            "reuse should not start a new bridge proxy session"
+        );
     }
 
     #[tokio::test]
@@ -3074,9 +3083,14 @@ mod tests {
             .unregister_terminal_connection("terminal-1", TerminalPeerKind::Browser)
             .await;
 
-        let (replacement_browser_tx, _replacement_browser_rx) = mpsc::unbounded_channel::<Message>();
+        let (replacement_browser_tx, _replacement_browser_rx) =
+            mpsc::unbounded_channel::<Message>();
         state
-            .register_terminal_connection("terminal-1", TerminalPeerKind::Browser, replacement_browser_tx)
+            .register_terminal_connection(
+                "terminal-1",
+                TerminalPeerKind::Browser,
+                replacement_browser_tx,
+            )
             .await
             .expect("browser should reattach");
 
@@ -3091,7 +3105,10 @@ mod tests {
             assert!(session.browser.is_some());
             assert!(session.bridge.is_some());
         }
-        assert!(bridge_rx.try_recv().is_err(), "bridge should stay open after reattach");
+        assert!(
+            bridge_rx.try_recv().is_err(),
+            "bridge should stay open after reattach"
+        );
     }
 
     #[tokio::test]
@@ -3131,7 +3148,10 @@ mod tests {
             );
         }
 
-        let close_message = bridge_rx.recv().await.expect("bridge should receive cleanup close");
+        let close_message = bridge_rx
+            .recv()
+            .await
+            .expect("bridge should receive cleanup close");
         assert!(matches!(close_message, Message::Close(_)));
     }
 }

--- a/crates/conductor-server/src/routes/terminal.rs
+++ b/crates/conductor-server/src/routes/terminal.rs
@@ -2563,7 +2563,9 @@ mod tests {
         assert!(injected.contains("const sessionIdFromPath = () => {"));
         assert!(injected.contains("const storageKey = () => {"));
         assert!(injected.contains("const MESSAGE_TYPE = 'conductor-ttyd-auth-token';"));
-        assert!(injected.contains("const REQUEST_MESSAGE_TYPE = 'conductor-ttyd-auth-token-request';"));
+        assert!(
+            injected.contains("const REQUEST_MESSAGE_TYPE = 'conductor-ttyd-auth-token-request';")
+        );
         assert!(injected.contains("const TOKEN_REQUEST_THROTTLE_MS = 1500;"));
         assert!(
             injected.contains("const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);")

--- a/crates/conductor-server/src/routes/terminal.rs
+++ b/crates/conductor-server/src/routes/terminal.rs
@@ -633,6 +633,8 @@ const TTYD_AUTH_SYNC_SHIM: &str = r#"
 
     const STORAGE_KEY = 'conductor.ttyd.token';
     const MESSAGE_TYPE = 'conductor-ttyd-auth-token';
+    const REQUEST_MESSAGE_TYPE = 'conductor-ttyd-auth-token-request';
+    const TOKEN_REQUEST_THROTTLE_MS = 1500;
     const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
 
     const readLocationBridgeId = () => {
@@ -664,6 +666,8 @@ const TTYD_AUTH_SYNC_SHIM: &str = r#"
     };
 
     let currentToken = '';
+    let lastTokenRequestAt = 0;
+    let unloading = false;
     const setToken = (value) => {
         const token = typeof value === 'string' ? value.trim() : '';
         currentToken = token;
@@ -674,6 +678,26 @@ const TTYD_AUTH_SYNC_SHIM: &str = r#"
             } else {
                 window.localStorage.removeItem(STORAGE_KEY);
             }
+        } catch {
+        }
+    };
+
+    const requestFreshToken = (reason) => {
+        if (unloading || !window.parent || window.parent === window) {
+            return;
+        }
+
+        const now = Date.now();
+        if (now - lastTokenRequestAt < TOKEN_REQUEST_THROTTLE_MS) {
+            return;
+        }
+        lastTokenRequestAt = now;
+
+        try {
+            window.parent.postMessage({
+                type: REQUEST_MESSAGE_TYPE,
+                reason,
+            }, '*');
         } catch {
         }
     };
@@ -702,14 +726,29 @@ const TTYD_AUTH_SYNC_SHIM: &str = r#"
         }
     };
 
+    const attachSocketListeners = (socket) => {
+        if (!socket || socket.__conductorTokenRefreshHookAttached) {
+            return socket;
+        }
+
+        socket.__conductorTokenRefreshHookAttached = true;
+        socket.addEventListener('close', () => {
+            requestFreshToken('websocket-close');
+        });
+        socket.addEventListener('error', () => {
+            requestFreshToken('websocket-error');
+        });
+        return socket;
+    };
+
     const nativeWebSocket = window.WebSocket;
     if (typeof nativeWebSocket === 'function' && !window.__conductorTtydWebSocketPatched) {
         const patchedWebSocket = function(url, protocols) {
             const normalizedUrl = normalizeWebSocketUrl(String(url));
             if (arguments.length > 1) {
-                return new nativeWebSocket(normalizedUrl, protocols);
+                return attachSocketListeners(new nativeWebSocket(normalizedUrl, protocols));
             }
-            return new nativeWebSocket(normalizedUrl);
+            return attachSocketListeners(new nativeWebSocket(normalizedUrl));
         };
 
         Object.setPrototypeOf(patchedWebSocket, nativeWebSocket);
@@ -752,6 +791,7 @@ const TTYD_AUTH_SYNC_SHIM: &str = r#"
 
     window.addEventListener('message', handleMessage);
     window.addEventListener('beforeunload', () => {
+        unloading = true;
         window.removeEventListener('message', handleMessage);
     }, { once: true });
 })();
@@ -2500,6 +2540,8 @@ mod tests {
         assert!(injected.contains("window.__conductorTtydAuthSyncShimInstalled"));
         assert!(injected.contains("const STORAGE_KEY = 'conductor.ttyd.token';"));
         assert!(injected.contains("const MESSAGE_TYPE = 'conductor-ttyd-auth-token';"));
+        assert!(injected.contains("const REQUEST_MESSAGE_TYPE = 'conductor-ttyd-auth-token-request';"));
+        assert!(injected.contains("const TOKEN_REQUEST_THROTTLE_MS = 1500;"));
         assert!(
             injected.contains("const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);")
         );
@@ -2507,6 +2549,10 @@ mod tests {
         assert!(injected.contains("const resolveProxyWebSocketUrl = () => {"));
         assert!(injected.contains("window.__conductorTtydWebSocketPatched"));
         assert!(injected.contains("const nativeWebSocket = window.WebSocket;"));
+        assert!(injected.contains("const requestFreshToken = (reason) => {"));
+        assert!(injected.contains("const attachSocketListeners = (socket) => {"));
+        assert!(injected.contains("requestFreshToken('websocket-close');"));
+        assert!(injected.contains("requestFreshToken('websocket-error');"));
         assert!(injected.contains("const normalizeWebSocketUrl = (value) => {"));
         assert!(injected.contains("const url = new URL(window.location.href);"));
         assert!(injected.contains("candidate.hostname"));

--- a/docs/terminal-architecture-review.md
+++ b/docs/terminal-architecture-review.md
@@ -1,0 +1,121 @@
+# Terminal Architecture Review
+
+## Verdict
+
+Yes, the terminal architecture is good enough to keep and harden.
+
+No, the pre-Apr 9 implementation was not yet robust enough.
+
+The right move is:
+- keep the iframe surface
+- keep ttyd as the PTY web runtime
+- keep the backend ttyd facade and bridge relay model
+- change the ownership and identity rules around terminal lifecycle
+
+That means the architecture wins or loses on **identity preservation**, not on whether the iframe exists.
+
+## What should remain
+
+### 1. Browser iframe shell
+- ttyd already owns xterm, fit, keyboard, clipboard, and PTY rendering well enough
+- replacing it would create a large new surface area with little immediate product value
+
+### 2. Backend ttyd facade
+- the backend already provides auth, HTML injection hooks, websocket facade, snapshots, and policy control
+- this is the right place to own token minting, headers, cookies, and terminal access checks
+
+### 3. Relay bridge model for remote devices
+- for paired-device terminals, the relay is still the right boundary
+- browser does not need direct access to the device backend
+- the relay remains the trust and routing boundary between dashboard and paired device
+
+## What had to change
+
+### Problem 1. UI visibility was treated like terminal death
+Hidden tabs and switched sessions were still hitting browser hidden-state behavior or being unmounted too aggressively.
+
+Fixes already landed:
+- `bd84ecb` preserve live session surfaces across tab switches
+- `1d06921` preserve session surfaces while switching
+- `fa3ebf6` keep session terminals stable while inactive
+
+### Problem 2. Token refresh and reconnect looked like terminal replacement
+The browser and ttyd auth path could re-resolve connection state too aggressively.
+
+Fix already landed:
+- `6638ee9` preserve ttyd identity across reconnects
+
+### Problem 3. Bridge relay ownership was wrong
+The relay treated browser disconnect like terminal death. Passive lifecycle events could also mint a fresh relay terminal too eagerly.
+
+Fixes already landed:
+- `505b5d1` preserve bridge terminal identity on passive recovery
+- relay reattach grace and stable terminal reuse in `conductor-relay`
+
+## Architecture rules going forward
+
+These are the invariants the terminal stack must preserve.
+
+### Rule 1. Terminal identity is separate from auth token identity
+- rotating auth must not imply a new terminal
+- passive refresh should re-sync auth, not replace the surface
+
+### Rule 2. Terminal identity is separate from React visibility
+- inactive session surfaces stay mounted
+- hidden terminals do not thrash because status changed elsewhere
+
+### Rule 3. Browser disconnect is not terminal death
+- relay-backed terminals get a browser reattach grace window
+- during that grace window, the bridge-side proxy stays alive
+- browser reconnect should reuse the same terminal identity when possible
+
+### Rule 4. New relay terminals are created only when needed
+- passive visibility return should not mint a new relay terminal
+- websocket close or error is the correct trigger for active recovery
+
+### Rule 5. Structural changes, not token changes, decide reloads
+- URL shape change, session change, or explicit replacement can reload
+- token-only changes should stay on the existing surface
+
+## What was implemented in the relay
+
+The relay now:
+- stores terminal sessions with explicit `terminal_id` and `session_id`
+- reuses an existing detached terminal for the same `user_id + device_id + session_id`
+- keeps the bridge-side terminal alive briefly after browser disconnect
+- cleans up only if the browser does not reattach within the grace window
+- closes the bridge-side proxy only after that grace window expires
+
+## Why this architecture is better
+
+This keeps the current product shape, but fixes the wrong ownership boundaries.
+
+The terminal should feel like a durable object:
+- UI can hide and show it
+- auth can rotate
+- the browser can briefly disconnect
+- the network can flap
+
+None of those should imply a new terminal unless the transport actually died.
+
+## What is still not done
+
+This does not yet prove the system is the fastest or unbreakable.
+
+Remaining work:
+- live browser soak tests across tab switch, session switch, reload, and sleep/wake
+- benchmark time-to-first-prompt and reconnect latency for local and bridge sessions
+- instrumentation for iframe reload count, reconnect count, and relay terminal reuse rate
+- per-agent startup optimization, Codex, Claude Code, Qwen, OpenCode
+- hot session pooling if product data shows startup latency is still the main bottleneck
+
+## Bottom line
+
+The core architecture is worth keeping.
+
+The mistake was not the iframe. The mistake was letting terminal identity leak across UI state, token refresh, and relay ownership boundaries.
+
+That is now the design bar:
+- same session should feel like the same terminal
+- passive lifecycle events should not create new terminals
+- only real transport failure should force explicit recovery

--- a/docs/workspace-soak-checklist.md
+++ b/docs/workspace-soak-checklist.md
@@ -1,0 +1,58 @@
+# Workspace Soak Checklist
+
+Use this after terminal, dispatcher, or preview changes. The goal is to prove that the dashboard keeps identity and continuity under real usage, not just unit tests.
+
+## Debug hooks
+
+In development builds, the dashboard exposes lightweight debug state in the browser console:
+
+- `window.__conductorSessionTerminalDebug?.getState()`
+- `window.__conductorDispatcherDebug?.getState()`
+- `window.__conductorSessionPreviewDebug?.getState()`
+
+Capture those snapshots before and after each scenario.
+
+## Terminal
+
+- [ ] Open a live coding session terminal.
+- [ ] Record initial terminal metrics.
+- [ ] Switch between terminal, dispatcher, preview, and skills tabs 10 times.
+- [ ] Switch between two different sessions 10 times.
+- [ ] Background the tab for 30 seconds, return, and confirm the same terminal remains usable.
+- [ ] Toggle network offline and back online, then confirm recovery happens without apparent terminal replacement unless the transport actually died.
+- [ ] Confirm terminal metrics show sensible counts for iframe loads, silent refreshes, and reconnect-driven refreshes.
+
+## Dispatcher
+
+- [ ] Open a busy dispatcher thread with live streaming output.
+- [ ] Record initial dispatcher metrics.
+- [ ] Scroll upward while new output is streaming and confirm the feed does not jump unexpectedly.
+- [ ] Hide the dispatcher tab, wait for live output elsewhere, then return.
+- [ ] Confirm the feed content is still present and does not duplicate entries after reconnect.
+- [ ] Confirm dispatcher metrics show reconnects and fallback reloads only when expected.
+
+## Preview
+
+- [ ] Open preview on an active dev server URL.
+- [ ] Record initial preview metrics.
+- [ ] Switch away from preview and back repeatedly.
+- [ ] Confirm the preview stays mounted and the Elements, Console, and Network tabs keep useful state.
+- [ ] In Inspect mode, select an element, queue it for terminal input, and confirm the selection survives short tab switches.
+- [ ] Disconnect or kill the preview worker session and confirm the preview falls back to a disconnected state instead of a hard failure.
+- [ ] Confirm preview metrics show status loads, poll counts, auto-connect attempts, and screenshot loads.
+
+## Suggested pass criteria
+
+- Terminal feels like the same surface after passive lifecycle events.
+- Dispatcher feed does not duplicate or wipe conversation state on reconnect.
+- Preview does not hard-reset just because the user switched tabs.
+- Debug metrics match the visible behavior.
+
+## Capture on failure
+
+- Commit hash
+- Browser and OS
+- Session id
+- Debug hook snapshots for terminal, dispatcher, and preview
+- Relevant network errors and websocket close codes
+- Short screen recording if the issue is visual

--- a/packages/web/src/app/api/sessions/[id]/preview/route.test.ts
+++ b/packages/web/src/app/api/sessions/[id]/preview/route.test.ts
@@ -156,6 +156,49 @@ test("GET forwards dashboard access headers to backend preview lookups", async (
   }
 });
 
+test("GET returns disconnected preview state when the session no longer exists", async () => {
+  resetEnv();
+  process.env.CONDUCTOR_BACKEND_URL = "http://127.0.0.1:4749";
+
+  global.fetch = (async (input: string | URL | Request) => {
+    const url = typeof input === "string" || input instanceof URL
+      ? String(input)
+      : input.url;
+
+    if (url.endsWith("/api/sessions/session-1")) {
+      return new Response(JSON.stringify({ error: "not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response("not found", { status: 404 });
+  }) as typeof fetch;
+
+  try {
+    const response = await GET(
+      new NextRequest("http://127.0.0.1:3000/api/sessions/session-1/preview"),
+      { params: Promise.resolve({ id: "session-1" }) },
+    );
+
+    assert.equal(response.status, 200);
+
+    const payload = await response.json() as {
+      connected: boolean;
+      candidateUrls: string[];
+      currentUrl: string | null;
+      lastError: string | null;
+    };
+
+    assert.equal(payload.connected, false);
+    assert.deepEqual(payload.candidateUrls, []);
+    assert.equal(payload.currentUrl, null);
+    assert.equal(payload.lastError, "Session is no longer available.");
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
 test("GET resolves bridge-backed preview session context via the paired device and preserves local bridge candidates", async () => {
   resetEnv();
   process.env.CONDUCTOR_BACKEND_URL = "http://127.0.0.1:4749";

--- a/packages/web/src/app/api/sessions/[id]/preview/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/preview/route.ts
@@ -44,6 +44,8 @@ function withLookupError(
   };
 }
 
+const MISSING_SESSION_PREVIEW_ERROR = "Session is no longer available.";
+
 export async function GET(request: NextRequest, context: RouteParams): Promise<Response> {
   const denied = await guardApiAccess(request, "viewer");
   if (denied) return denied;
@@ -59,11 +61,16 @@ export async function GET(request: NextRequest, context: RouteParams): Promise<R
     request,
     headers: forwardedHeaders,
   });
+  const manager = getPreviewBrowserManager();
   if (!previewContext.session && !previewContext.error) {
-    return NextResponse.json({ error: `Session ${id} not found` }, { status: 404 });
+    await manager.destroySession(id);
+    const status = withLookupError(
+      await manager.getStatus(id, []),
+      MISSING_SESSION_PREVIEW_ERROR,
+    );
+    return NextResponse.json(status, { headers: { "Cache-Control": "no-store" } });
   }
 
-  const manager = getPreviewBrowserManager();
   if (previewContext.session && TERMINAL_STATUSES.has(previewContext.session.status)) {
     await manager.destroySession(id);
     const status = withLookupError(
@@ -102,8 +109,10 @@ export async function POST(request: NextRequest, context: RouteParams): Promise<
     request,
     headers: forwardedHeaders,
   });
+  const manager = getPreviewBrowserManager();
   if (!previewContext.session && !previewContext.error) {
-    return NextResponse.json({ error: `Session ${id} not found` }, { status: 404 });
+    await manager.destroySession(id);
+    return NextResponse.json({ error: MISSING_SESSION_PREVIEW_ERROR }, { status: 404 });
   }
 
   let body: PreviewCommandRequest;
@@ -113,7 +122,6 @@ export async function POST(request: NextRequest, context: RouteParams): Promise<
     return NextResponse.json({ error: "Invalid preview command payload" }, { status: 400 });
   }
 
-  const manager = getPreviewBrowserManager();
   await manager.configureBridgePreview(
     id,
     previewContext.bridgePreview,

--- a/packages/web/src/components/dispatcher/DispatcherPane.tsx
+++ b/packages/web/src/components/dispatcher/DispatcherPane.tsx
@@ -25,6 +25,7 @@ type DispatcherPaneProps = {
   threads?: DashboardSession[];
   projectId: string;
   bridgeId?: string | null;
+  active?: boolean;
   modelAccess?: ModelAccessPreferences;
   runtimeModelCatalogs?: Record<string, RuntimeAgentModelCatalog>;
   onSelectThread?: (threadId: string) => void;
@@ -171,6 +172,7 @@ export function DispatcherPane({
   threads = [],
   projectId,
   bridgeId,
+  active = true,
   modelAccess = {} as ModelAccessPreferences,
   runtimeModelCatalogs = {},
   onSelectThread,
@@ -441,6 +443,7 @@ export function DispatcherPane({
       <DispatcherSessionPane
         session={thread}
         bridgeId={bridgeId}
+        active={active}
         onToggleCollapse={onToggleCollapse}
         className={className}
         hideOpenSessionAction

--- a/packages/web/src/components/dispatcher/DispatcherSessionPane.test.ts
+++ b/packages/web/src/components/dispatcher/DispatcherSessionPane.test.ts
@@ -1,0 +1,71 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EMPTY_FEED_PAYLOAD, applyFeedDelta } from "./dispatcherFeedState.js";
+
+function makeEntry(id: string, text: string, streaming = false) {
+  return {
+    id,
+    kind: "assistant" as const,
+    label: "assistant",
+    text,
+    createdAt: "2026-04-10T00:00:00.000Z",
+    attachments: [],
+    source: "test",
+    streaming,
+    metadata: {},
+  };
+}
+
+test("applyFeedDelta dedupes append entries by id", () => {
+  const current = {
+    ...EMPTY_FEED_PAYLOAD,
+    entries: [makeEntry("entry-1", "hello", true)],
+  };
+
+  const next = applyFeedDelta(current, {
+    type: "append",
+    entries: [makeEntry("entry-1", "hello world", false), makeEntry("entry-2", "second", false)],
+    totalEntries: 2,
+    windowLimit: 200,
+    truncated: false,
+    sessionStatus: "running",
+    approvalState: null,
+    parserState: null,
+    runtimeStatus: null,
+    source: "stream",
+    error: null,
+    integration: null,
+  });
+
+  assert.equal(next.entries.length, 2);
+  assert.equal(next.entries[0]?.id, "entry-1");
+  assert.equal(next.entries[0]?.text, "hello world");
+  assert.equal(next.entries[1]?.id, "entry-2");
+});
+
+test("applyFeedDelta patch appends textDelta onto the existing entry text", () => {
+  const current = {
+    ...EMPTY_FEED_PAYLOAD,
+    entries: [makeEntry("entry-1", "hello", true)],
+  };
+
+  const next = applyFeedDelta(current, {
+    type: "patch",
+    entryId: "entry-1",
+    entry: makeEntry("entry-1", "hello world", true),
+    textDelta: " world",
+    totalEntries: 1,
+    windowLimit: 200,
+    truncated: false,
+    sessionStatus: "running",
+    approvalState: null,
+    parserState: null,
+    runtimeStatus: null,
+    source: "stream",
+    error: null,
+    integration: null,
+  });
+
+  assert.equal(next.entries.length, 1);
+  assert.equal(next.entries[0]?.text, "hello world");
+});

--- a/packages/web/src/components/dispatcher/DispatcherSessionPane.tsx
+++ b/packages/web/src/components/dispatcher/DispatcherSessionPane.tsx
@@ -135,6 +135,7 @@ type FeedDeltaEvent =
 type DispatcherSessionPaneProps = {
   session: DashboardSession;
   bridgeId?: string | null;
+  active?: boolean;
   onClose?: () => void;
   onToggleCollapse?: () => void;
   className?: string;
@@ -192,7 +193,7 @@ type RepositorySettingsPayload = {
   pathHealth: RepositoryPathHealth;
 };
 
-const EMPTY_FEED_PAYLOAD: SessionFeedPayload = {
+export const EMPTY_FEED_PAYLOAD: SessionFeedPayload = {
   entries: [],
   totalEntries: 0,
   windowLimit: 120,
@@ -374,14 +375,36 @@ function normalizeFeedDelta(value: unknown): FeedDeltaEvent | null {
   return null;
 }
 
-function applyFeedDelta(current: SessionFeedPayload, delta: FeedDeltaEvent): SessionFeedPayload {
+function mergeFeedEntriesById(
+  currentEntries: SessionFeedEntry[],
+  nextEntries: SessionFeedEntry[],
+): SessionFeedEntry[] {
+  if (nextEntries.length === 0) {
+    return currentEntries;
+  }
+
+  const merged = currentEntries.slice();
+  const indexById = new Map(merged.map((entry, index) => [entry.id, index]));
+  for (const entry of nextEntries) {
+    const existingIndex = indexById.get(entry.id);
+    if (existingIndex === undefined) {
+      indexById.set(entry.id, merged.length);
+      merged.push(entry);
+      continue;
+    }
+    merged[existingIndex] = entry;
+  }
+  return merged;
+}
+
+export function applyFeedDelta(current: SessionFeedPayload, delta: FeedDeltaEvent): SessionFeedPayload {
   if (delta.type === "replace") {
     return delta.payload;
   }
 
   if (delta.type === "append") {
     return {
-      entries: [...current.entries, ...delta.entries],
+      entries: mergeFeedEntriesById(current.entries, delta.entries),
       totalEntries: delta.totalEntries,
       windowLimit: delta.windowLimit,
       truncated: delta.truncated,
@@ -1135,6 +1158,7 @@ function shouldShowDispatcherApprovalBanner(
 export function DispatcherSessionPane({
   session,
   bridgeId = null,
+  active = true,
   onClose,
   onToggleCollapse,
   className,
@@ -1160,6 +1184,19 @@ export function DispatcherSessionPane({
   const feedRef = useRef<HTMLDivElement>(null);
   const feedContentRef = useRef<HTMLDivElement>(null);
   const autoScrollEnabledRef = useRef(true);
+  const [pageVisible, setPageVisible] = useState(true);
+  const shouldRunLiveUpdates = active && pageVisible;
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      setPageVisible(!document.hidden);
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, []);
+
   const sessionApiPaths = useMemo(() => ({
     feed: apiPaths.feed,
     stream: apiPaths.stream,
@@ -1244,24 +1281,30 @@ export function DispatcherSessionPane({
       setPayload(nextPayload);
     } catch (error) {
       setLoadingError(error instanceof Error ? error.message : "Failed to load session feed");
-      setPayload(EMPTY_FEED_PAYLOAD);
     } finally {
       setLoading(false);
     }
   }, [bridgeId, sessionApiPaths.feed]);
 
   useEffect(() => {
+    if (!active) {
+      return;
+    }
     void loadFeed();
-  }, [loadFeed]);
+  }, [active, loadFeed]);
 
   useEffect(() => {
-    if (hideRepositoryControls) {
+    if (!active || hideRepositoryControls) {
       return;
     }
     void loadRepository();
-  }, [hideRepositoryControls, loadRepository]);
+  }, [active, hideRepositoryControls, loadRepository]);
 
   useEffect(() => {
+    if (!shouldRunLiveUpdates) {
+      return;
+    }
+
     let cancelled = false;
     let reconnectTimer: number | null = null;
     let reconnectAttempt = 0;
@@ -1376,7 +1419,7 @@ export function DispatcherSessionPane({
       clearReconnect();
       streamAbortRef.current?.abort();
     };
-  }, [bridgeId, loadFeed, session.projectId, sessionApiPaths.stream]);
+  }, [bridgeId, loadFeed, session.projectId, sessionApiPaths.stream, shouldRunLiveUpdates]);
 
   useEffect(() => {
     autoScrollEnabledRef.current = true;

--- a/packages/web/src/components/dispatcher/DispatcherSessionPane.tsx
+++ b/packages/web/src/components/dispatcher/DispatcherSessionPane.tsx
@@ -43,94 +43,16 @@ import { isDispatcherFeedNearBottom } from "@/components/dispatcher/dispatcherFe
 import type { TerminalInsertRequest } from "@/components/sessions/terminalInsert";
 import type { DashboardSession } from "@/lib/types";
 import type { SessionRuntimeStatus } from "@/lib/sessionRuntimeStatus";
-
-type FeedEntryKind = "assistant" | "status" | "system" | "tool" | "user";
-
-type SessionFeedEntry = {
-  id: string;
-  kind: FeedEntryKind;
-  label: string;
-  text: string;
-  createdAt: string | null;
-  attachments: unknown[];
-  source: string;
-  streaming: boolean;
-  metadata: Record<string, unknown>;
-};
-
-type SessionParserState = {
-  kind: string;
-  message: string;
-  command: string | null;
-};
-
-type DispatcherFeedIntegration = {
-  projectId: string;
-  threadId: string;
-  bridgeId: string | null;
-  openclaw: {
-    threadId: string | null;
-    sessionId: string | null;
-  };
-  heartbeat: {
-    state: string | null;
-    nextAt: string | null;
-  };
-  memory: {
-    projectPath: string | null;
-    sessionPath: string | null;
-  };
-};
-
-type SessionFeedPayload = {
-  entries: SessionFeedEntry[];
-  totalEntries: number;
-  windowLimit: number;
-  truncated: boolean;
-  sessionStatus: string | null;
-  approvalState: string | null;
-  parserState: SessionParserState | null;
-  runtimeStatus: SessionRuntimeStatus | null;
-  source: string | null;
-  error: string | null;
-  integration: DispatcherFeedIntegration | null;
-};
-
-type FeedDeltaEvent =
-  | {
-      type: "append";
-      entries: SessionFeedEntry[];
-      totalEntries: number;
-      windowLimit: number;
-      truncated: boolean;
-      sessionStatus: string | null;
-      approvalState: string | null;
-      parserState: SessionParserState | null;
-      runtimeStatus: SessionRuntimeStatus | null;
-      source: string | null;
-      error: string | null;
-      integration: DispatcherFeedIntegration | null;
-    }
-  | {
-      type: "patch";
-      entryId: string;
-      entry: SessionFeedEntry | null;
-      textDelta: string | null;
-      totalEntries: number;
-      windowLimit: number;
-      truncated: boolean;
-      sessionStatus: string | null;
-      approvalState: string | null;
-      parserState: SessionParserState | null;
-      runtimeStatus: SessionRuntimeStatus | null;
-      source: string | null;
-      error: string | null;
-      integration: DispatcherFeedIntegration | null;
-    }
-  | {
-      type: "replace";
-      payload: SessionFeedPayload;
-    };
+import {
+  EMPTY_FEED_PAYLOAD,
+  applyFeedDelta,
+  type DispatcherFeedIntegration,
+  type FeedDeltaEvent,
+  type FeedEntryKind,
+  type SessionFeedEntry,
+  type SessionFeedPayload,
+  type SessionParserState,
+} from "./dispatcherFeedState";
 
 type DispatcherSessionPaneProps = {
   session: DashboardSession;
@@ -191,20 +113,6 @@ type RepositorySettingsPayload = {
   archiveScript: string;
   copyFiles: string;
   pathHealth: RepositoryPathHealth;
-};
-
-export const EMPTY_FEED_PAYLOAD: SessionFeedPayload = {
-  entries: [],
-  totalEntries: 0,
-  windowLimit: 120,
-  truncated: false,
-  sessionStatus: null,
-  approvalState: null,
-  parserState: null,
-  runtimeStatus: null,
-  source: null,
-  error: null,
-  integration: null,
 };
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -373,107 +281,6 @@ function normalizeFeedDelta(value: unknown): FeedDeltaEvent | null {
     };
   }
   return null;
-}
-
-function mergeFeedEntriesById(
-  currentEntries: SessionFeedEntry[],
-  nextEntries: SessionFeedEntry[],
-): SessionFeedEntry[] {
-  if (nextEntries.length === 0) {
-    return currentEntries;
-  }
-
-  const merged = currentEntries.slice();
-  const indexById = new Map(merged.map((entry, index) => [entry.id, index]));
-  for (const entry of nextEntries) {
-    const existingIndex = indexById.get(entry.id);
-    if (existingIndex === undefined) {
-      indexById.set(entry.id, merged.length);
-      merged.push(entry);
-      continue;
-    }
-    merged[existingIndex] = entry;
-  }
-  return merged;
-}
-
-export function applyFeedDelta(current: SessionFeedPayload, delta: FeedDeltaEvent): SessionFeedPayload {
-  if (delta.type === "replace") {
-    return delta.payload;
-  }
-
-  if (delta.type === "append") {
-    return {
-      entries: mergeFeedEntriesById(current.entries, delta.entries),
-      totalEntries: delta.totalEntries,
-      windowLimit: delta.windowLimit,
-      truncated: delta.truncated,
-      sessionStatus: delta.sessionStatus,
-      approvalState: delta.approvalState,
-      parserState: delta.parserState,
-      runtimeStatus: delta.runtimeStatus,
-      source: delta.source,
-      error: delta.error,
-      integration: delta.integration ?? current.integration,
-    };
-  }
-
-  const nextEntry = delta.entry;
-  if (!nextEntry) {
-    return {
-      ...current,
-      totalEntries: delta.totalEntries,
-      windowLimit: delta.windowLimit,
-      truncated: delta.truncated,
-      sessionStatus: delta.sessionStatus,
-      approvalState: delta.approvalState,
-      parserState: delta.parserState,
-      runtimeStatus: delta.runtimeStatus,
-      source: delta.source,
-      error: delta.error,
-      integration: delta.integration ?? current.integration,
-    };
-  }
-
-  const entries = current.entries.slice();
-  let patchIndex = -1;
-  for (let index = entries.length - 1; index >= 0; index -= 1) {
-    if (entries[index]?.id === delta.entryId) {
-      patchIndex = index;
-      break;
-    }
-  }
-
-  if (patchIndex >= 0) {
-    const existing = entries[patchIndex];
-    if (
-      delta.textDelta !== null
-      && nextEntry.text.startsWith(existing.text)
-    ) {
-      entries[patchIndex] = {
-        ...nextEntry,
-        text: existing.text + delta.textDelta,
-      };
-    } else {
-      entries[patchIndex] = nextEntry;
-    }
-  } else {
-    entries.push(nextEntry);
-  }
-
-  return {
-    entries,
-    totalEntries: delta.totalEntries,
-    windowLimit: delta.windowLimit,
-    truncated: delta.truncated,
-    sessionStatus: delta.sessionStatus,
-    approvalState: delta.approvalState,
-    parserState: delta.parserState,
-    runtimeStatus: delta.runtimeStatus,
-    source: delta.source,
-    error: delta.error,
-    integration: delta.integration ?? current.integration,
-  };
 }
 
 function normalizeRepositorySettings(value: unknown): RepositorySettingsPayload | null {
@@ -1186,6 +993,19 @@ export function DispatcherSessionPane({
   const autoScrollEnabledRef = useRef(true);
   const [pageVisible, setPageVisible] = useState(true);
   const shouldRunLiveUpdates = active && pageVisible;
+  const mountedAtRef = useRef(Date.now());
+  const firstFeedLoadedAtRef = useRef<number | null>(null);
+  const lastFeedLoadedAtRef = useRef<number | null>(null);
+  const lastStreamEventAtRef = useRef<number | null>(null);
+  const loadFeedCountRef = useRef(0);
+  const loadFeedFailureCountRef = useRef(0);
+  const streamConnectCountRef = useRef(0);
+  const streamReconnectCountRef = useRef(0);
+  const streamFallbackReloadCountRef = useRef(0);
+  const deltaAppendCountRef = useRef(0);
+  const deltaPatchCountRef = useRef(0);
+  const deltaReplaceCountRef = useRef(0);
+  const liveUpdatePauseCountRef = useRef(0);
   useEffect(() => {
     const handleVisibilityChange = () => {
       setPageVisible(!document.hidden);
@@ -1196,6 +1016,22 @@ export function DispatcherSessionPane({
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, []);
+
+  useEffect(() => {
+    mountedAtRef.current = Date.now();
+    firstFeedLoadedAtRef.current = null;
+    lastFeedLoadedAtRef.current = null;
+    lastStreamEventAtRef.current = null;
+    loadFeedCountRef.current = 0;
+    loadFeedFailureCountRef.current = 0;
+    streamConnectCountRef.current = 0;
+    streamReconnectCountRef.current = 0;
+    streamFallbackReloadCountRef.current = 0;
+    deltaAppendCountRef.current = 0;
+    deltaPatchCountRef.current = 0;
+    deltaReplaceCountRef.current = 0;
+    liveUpdatePauseCountRef.current = 0;
+  }, [session.id]);
 
   const sessionApiPaths = useMemo(() => ({
     feed: apiPaths.feed,
@@ -1270,6 +1106,7 @@ export function DispatcherSessionPane({
   }, [bridgeId, hideRepositoryControls, session.projectId, sessionApiPaths.repositories]);
 
   const loadFeed = useCallback(async () => {
+    loadFeedCountRef.current += 1;
     setLoading(true);
     setLoadingError(null);
     try {
@@ -1278,8 +1115,14 @@ export function DispatcherSessionPane({
       if (!response.ok) {
         throw new Error(nextPayload.error ?? `Failed to load session feed (${response.status})`);
       }
+      const now = Date.now();
+      if (firstFeedLoadedAtRef.current === null) {
+        firstFeedLoadedAtRef.current = now;
+      }
+      lastFeedLoadedAtRef.current = now;
       setPayload(nextPayload);
     } catch (error) {
+      loadFeedFailureCountRef.current += 1;
       setLoadingError(error instanceof Error ? error.message : "Failed to load session feed");
     } finally {
       setLoading(false);
@@ -1302,6 +1145,7 @@ export function DispatcherSessionPane({
 
   useEffect(() => {
     if (!shouldRunLiveUpdates) {
+      liveUpdatePauseCountRef.current += 1;
       return;
     }
 
@@ -1322,6 +1166,7 @@ export function DispatcherSessionPane({
       try {
         parsed = JSON.parse(raw) as unknown;
       } catch {
+        streamFallbackReloadCountRef.current += 1;
         void loadFeed();
         return;
       }
@@ -1330,6 +1175,7 @@ export function DispatcherSessionPane({
         ? (parsed as Record<string, unknown>)
         : null;
       if (record?.type === "refresh") {
+        streamFallbackReloadCountRef.current += 1;
         dispatchProjectBoardRefresh({
           projectId: session.projectId,
           reason: "dispatcher_feed_refresh",
@@ -1340,8 +1186,18 @@ export function DispatcherSessionPane({
 
       const delta = normalizeFeedDelta(parsed);
       if (!delta) {
+        streamFallbackReloadCountRef.current += 1;
         void loadFeed();
         return;
+      }
+
+      lastStreamEventAtRef.current = Date.now();
+      if (delta.type === "append") {
+        deltaAppendCountRef.current += delta.entries.length;
+      } else if (delta.type === "patch") {
+        deltaPatchCountRef.current += 1;
+      } else {
+        deltaReplaceCountRef.current += 1;
       }
 
       const boardRefreshReason = delta.type === "append"
@@ -1367,6 +1223,7 @@ export function DispatcherSessionPane({
           ? 250
           : Math.min(500 * 2 ** (reconnectAttempt - 1), 12_000);
       reconnectAttempt += 1;
+      streamReconnectCountRef.current += 1;
       reconnectTimer = window.setTimeout(() => {
         reconnectTimer = null;
         void connect();
@@ -1382,12 +1239,14 @@ export function DispatcherSessionPane({
       streamAbortRef.current = ac;
       const streamUrl = withBridgeQuery(sessionApiPaths.stream, bridgeId);
       try {
+        streamConnectCountRef.current += 1;
         const res = await fetch(streamUrl, {
           cache: "no-store",
           signal: ac.signal,
         });
         if (!res.ok || !res.body) {
           if (!cancelled) {
+            streamFallbackReloadCountRef.current += 1;
             void loadFeed();
             scheduleReconnect();
           }
@@ -1401,11 +1260,13 @@ export function DispatcherSessionPane({
           applySseData(frame.data);
         }
         if (!cancelled) {
+          streamFallbackReloadCountRef.current += 1;
           void loadFeed();
           scheduleReconnect();
         }
       } catch {
         if (!cancelled && !ac.signal.aborted) {
+          streamFallbackReloadCountRef.current += 1;
           void loadFeed();
           scheduleReconnect();
         }
@@ -1420,6 +1281,51 @@ export function DispatcherSessionPane({
       streamAbortRef.current?.abort();
     };
   }, [bridgeId, loadFeed, session.projectId, sessionApiPaths.stream, shouldRunLiveUpdates]);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "development") return;
+
+    window.__conductorDispatcherDebug = {
+      sessionId: session.id,
+      getState: () => ({
+        sessionId: session.id,
+        active,
+        pageVisible,
+        shouldRunLiveUpdates,
+        entries: payload.entries.length,
+        loading,
+        loadingError,
+        metrics: {
+          mountedAt: new Date(mountedAtRef.current).toISOString(),
+          mountedAgeMs: Date.now() - mountedAtRef.current,
+          firstFeedLoadLatencyMs: firstFeedLoadedAtRef.current === null
+            ? null
+            : firstFeedLoadedAtRef.current - mountedAtRef.current,
+          lastFeedLoadedAt: lastFeedLoadedAtRef.current === null
+            ? null
+            : new Date(lastFeedLoadedAtRef.current).toISOString(),
+          lastStreamEventAt: lastStreamEventAtRef.current === null
+            ? null
+            : new Date(lastStreamEventAtRef.current).toISOString(),
+          loadFeedCount: loadFeedCountRef.current,
+          loadFeedFailureCount: loadFeedFailureCountRef.current,
+          streamConnectCount: streamConnectCountRef.current,
+          streamReconnectCount: streamReconnectCountRef.current,
+          streamFallbackReloadCount: streamFallbackReloadCountRef.current,
+          deltaAppendCount: deltaAppendCountRef.current,
+          deltaPatchCount: deltaPatchCountRef.current,
+          deltaReplaceCount: deltaReplaceCountRef.current,
+          liveUpdatePauseCount: liveUpdatePauseCountRef.current,
+        },
+      }),
+    };
+
+    return () => {
+      if (window.__conductorDispatcherDebug?.sessionId === session.id) {
+        delete window.__conductorDispatcherDebug;
+      }
+    };
+  }, [active, loading, loadingError, pageVisible, payload.entries.length, session.id, shouldRunLiveUpdates]);
 
   useEffect(() => {
     autoScrollEnabledRef.current = true;

--- a/packages/web/src/components/dispatcher/dispatcherFeedState.ts
+++ b/packages/web/src/components/dispatcher/dispatcherFeedState.ts
@@ -1,0 +1,205 @@
+import type { SessionRuntimeStatus } from "@/lib/sessionRuntimeStatus";
+
+export type FeedEntryKind = "assistant" | "status" | "system" | "tool" | "user";
+
+export type SessionFeedEntry = {
+  id: string;
+  kind: FeedEntryKind;
+  label: string;
+  text: string;
+  createdAt: string | null;
+  attachments: unknown[];
+  source: string;
+  streaming: boolean;
+  metadata: Record<string, unknown>;
+};
+
+export type SessionParserState = {
+  kind: string;
+  message: string;
+  command: string | null;
+};
+
+export type DispatcherFeedIntegration = {
+  projectId: string;
+  threadId: string;
+  bridgeId: string | null;
+  openclaw: {
+    threadId: string | null;
+    sessionId: string | null;
+  };
+  heartbeat: {
+    state: string | null;
+    nextAt: string | null;
+  };
+  memory: {
+    projectPath: string | null;
+    sessionPath: string | null;
+  };
+};
+
+export type SessionFeedPayload = {
+  entries: SessionFeedEntry[];
+  totalEntries: number;
+  windowLimit: number;
+  truncated: boolean;
+  sessionStatus: string | null;
+  approvalState: string | null;
+  parserState: SessionParserState | null;
+  runtimeStatus: SessionRuntimeStatus | null;
+  source: string | null;
+  error: string | null;
+  integration: DispatcherFeedIntegration | null;
+};
+
+export type FeedDeltaEvent =
+  | {
+      type: "append";
+      entries: SessionFeedEntry[];
+      totalEntries: number;
+      windowLimit: number;
+      truncated: boolean;
+      sessionStatus: string | null;
+      approvalState: string | null;
+      parserState: SessionParserState | null;
+      runtimeStatus: SessionRuntimeStatus | null;
+      source: string | null;
+      error: string | null;
+      integration: DispatcherFeedIntegration | null;
+    }
+  | {
+      type: "patch";
+      entryId: string;
+      entry: SessionFeedEntry | null;
+      textDelta: string | null;
+      totalEntries: number;
+      windowLimit: number;
+      truncated: boolean;
+      sessionStatus: string | null;
+      approvalState: string | null;
+      parserState: SessionParserState | null;
+      runtimeStatus: SessionRuntimeStatus | null;
+      source: string | null;
+      error: string | null;
+      integration: DispatcherFeedIntegration | null;
+    }
+  | {
+      type: "replace";
+      payload: SessionFeedPayload;
+    };
+
+export const EMPTY_FEED_PAYLOAD: SessionFeedPayload = {
+  entries: [],
+  totalEntries: 0,
+  windowLimit: 120,
+  truncated: false,
+  sessionStatus: null,
+  approvalState: null,
+  parserState: null,
+  runtimeStatus: null,
+  source: null,
+  error: null,
+  integration: null,
+};
+
+function mergeFeedEntriesById(
+  currentEntries: SessionFeedEntry[],
+  nextEntries: SessionFeedEntry[],
+): SessionFeedEntry[] {
+  if (nextEntries.length === 0) {
+    return currentEntries;
+  }
+
+  const merged = currentEntries.slice();
+  const indexById = new Map(merged.map((entry, index) => [entry.id, index]));
+  for (const entry of nextEntries) {
+    const existingIndex = indexById.get(entry.id);
+    if (existingIndex === undefined) {
+      indexById.set(entry.id, merged.length);
+      merged.push(entry);
+      continue;
+    }
+    merged[existingIndex] = entry;
+  }
+  return merged;
+}
+
+export function applyFeedDelta(current: SessionFeedPayload, delta: FeedDeltaEvent): SessionFeedPayload {
+  if (delta.type === "replace") {
+    return delta.payload;
+  }
+
+  if (delta.type === "append") {
+    return {
+      entries: mergeFeedEntriesById(current.entries, delta.entries),
+      totalEntries: delta.totalEntries,
+      windowLimit: delta.windowLimit,
+      truncated: delta.truncated,
+      sessionStatus: delta.sessionStatus,
+      approvalState: delta.approvalState,
+      parserState: delta.parserState,
+      runtimeStatus: delta.runtimeStatus,
+      source: delta.source,
+      error: delta.error,
+      integration: delta.integration ?? current.integration,
+    };
+  }
+
+  const entries = current.entries.slice();
+  const nextEntry = delta.entry;
+  if (!nextEntry) {
+    return {
+      ...current,
+      entries: entries.filter((entry) => entry.id !== delta.entryId),
+      totalEntries: delta.totalEntries,
+      windowLimit: delta.windowLimit,
+      truncated: delta.truncated,
+      sessionStatus: delta.sessionStatus,
+      approvalState: delta.approvalState,
+      parserState: delta.parserState,
+      runtimeStatus: delta.runtimeStatus,
+      source: delta.source,
+      error: delta.error,
+      integration: delta.integration ?? current.integration,
+    };
+  }
+
+  let patchIndex = -1;
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    if (entries[index]?.id === delta.entryId) {
+      patchIndex = index;
+      break;
+    }
+  }
+
+  if (patchIndex >= 0) {
+    const existing = entries[patchIndex];
+    if (
+      delta.textDelta !== null
+      && nextEntry.text.startsWith(existing.text)
+    ) {
+      entries[patchIndex] = {
+        ...nextEntry,
+        text: existing.text + delta.textDelta,
+      };
+    } else {
+      entries[patchIndex] = nextEntry;
+    }
+  } else {
+    entries.push(nextEntry);
+  }
+
+  return {
+    entries,
+    totalEntries: delta.totalEntries,
+    windowLimit: delta.windowLimit,
+    truncated: delta.truncated,
+    sessionStatus: delta.sessionStatus,
+    approvalState: delta.approvalState,
+    parserState: delta.parserState,
+    runtimeStatus: delta.runtimeStatus,
+    source: delta.source,
+    error: delta.error,
+    integration: delta.integration ?? current.integration,
+  };
+}

--- a/packages/web/src/components/sessions/SessionDetail.tsx
+++ b/packages/web/src/components/sessions/SessionDetail.tsx
@@ -380,6 +380,7 @@ export function SessionDetail({
                 thread={session}
                 projectId={session.projectId}
                 bridgeId={session.bridgeId ?? bridgeId}
+                active={active && activeTab === "dispatcher"}
                 className="h-full w-full border-0 xl:w-full"
               />
             </TabsContent>
@@ -406,17 +407,16 @@ export function SessionDetail({
           )}
           <TabsContent
             value="preview"
-            className={STANDARD_TAB_PANEL_CLASS_NAME}
+            forceMount
+            className={PRESERVE_LIVE_SURFACE_TAB_PANEL_CLASS_NAME}
           >
-            {previewTabActive ? (
-              <SessionPreview
-                key={sessionId}
-                sessionId={sessionId}
-                active={previewTabActive}
-                onQueueTerminalInsert={queueTerminalInsert}
-                onConnectionChange={handlePreviewConnectionChange}
-              />
-            ) : null}
+            <SessionPreview
+              key={sessionId}
+              sessionId={sessionId}
+              active={previewTabActive}
+              onQueueTerminalInsert={queueTerminalInsert}
+              onConnectionChange={handlePreviewConnectionChange}
+            />
           </TabsContent>
 
           <TabsContent

--- a/packages/web/src/components/sessions/SessionDetail.tsx
+++ b/packages/web/src/components/sessions/SessionDetail.tsx
@@ -79,6 +79,11 @@ interface SessionDetailProps {
 
 type SessionTab = "overview" | "dispatcher" | "terminal" | "preview" | "skills";
 
+const STANDARD_TAB_PANEL_CLASS_NAME = "min-h-0 h-full min-w-0 w-full overflow-hidden focus-visible:outline-none [&[hidden]]:block data-[state=inactive]:pointer-events-none data-[state=inactive]:absolute data-[state=inactive]:inset-0 data-[state=inactive]:invisible data-[state=inactive]:opacity-0";
+// Keep terminal-like surfaces painted with opacity only. `visibility:hidden` was causing browser-level
+// suspension / blanking on tab switches even though the panels stayed force-mounted.
+const PRESERVE_LIVE_SURFACE_TAB_PANEL_CLASS_NAME = "min-h-0 h-full min-w-0 w-full overflow-hidden focus-visible:outline-none [&[hidden]]:block data-[state=active]:relative data-[state=active]:z-10 data-[state=inactive]:pointer-events-none data-[state=inactive]:absolute data-[state=inactive]:inset-0 data-[state=inactive]:opacity-0 data-[state=inactive]:select-none";
+
 function resolveSessionTab(
   value: string | null,
   session: Pick<DashboardSession, "metadata"> | null | undefined,
@@ -361,7 +366,7 @@ export function SessionDetail({
         )}
 
         <div className="relative min-h-0 min-w-0 h-0 flex-1 overflow-hidden">
-          <TabsContent value="overview" className="min-h-0 h-full min-w-0 w-full overflow-hidden focus-visible:outline-none [&[hidden]]:block data-[state=inactive]:pointer-events-none data-[state=inactive]:absolute data-[state=inactive]:inset-0 data-[state=inactive]:invisible data-[state=inactive]:opacity-0">
+          <TabsContent value="overview" className={STANDARD_TAB_PANEL_CLASS_NAME}>
             <SessionOverview session={session} sessionId={sessionId} active={active && activeTab === "overview"} />
           </TabsContent>
 
@@ -369,7 +374,7 @@ export function SessionDetail({
             <TabsContent
               value="dispatcher"
               forceMount
-              className="min-h-0 h-full min-w-0 w-full overflow-hidden focus-visible:outline-none [&[hidden]]:block data-[state=inactive]:pointer-events-none data-[state=inactive]:absolute data-[state=inactive]:inset-0 data-[state=inactive]:invisible data-[state=inactive]:opacity-0"
+              className={PRESERVE_LIVE_SURFACE_TAB_PANEL_CLASS_NAME}
             >
               <DispatcherPane
                 thread={session}
@@ -383,8 +388,8 @@ export function SessionDetail({
               value="terminal"
               forceMount
               className={immersiveTerminalActive
-                ? "flex min-h-0 h-full min-w-0 w-full flex-col overflow-hidden bg-[#060404] focus-visible:outline-none [&[hidden]]:block data-[state=inactive]:pointer-events-none data-[state=inactive]:absolute data-[state=inactive]:inset-0 data-[state=inactive]:invisible data-[state=inactive]:opacity-0"
-                : "flex min-h-0 h-full min-w-0 flex-col w-full overflow-hidden bg-transparent focus-visible:outline-none [&[hidden]]:block data-[state=inactive]:pointer-events-none data-[state=inactive]:absolute data-[state=inactive]:inset-0 data-[state=inactive]:invisible data-[state=inactive]:opacity-0"}
+                ? `flex min-h-0 h-full min-w-0 w-full flex-col overflow-hidden bg-[#060404] ${PRESERVE_LIVE_SURFACE_TAB_PANEL_CLASS_NAME}`
+                : `flex min-h-0 h-full min-w-0 w-full flex-col overflow-hidden bg-transparent ${PRESERVE_LIVE_SURFACE_TAB_PANEL_CLASS_NAME}`}
             >
               <SessionTerminal
                 sessionId={sessionId}
@@ -401,7 +406,7 @@ export function SessionDetail({
           )}
           <TabsContent
             value="preview"
-            className="min-h-0 h-full min-w-0 w-full overflow-hidden focus-visible:outline-none [&[hidden]]:block data-[state=inactive]:pointer-events-none data-[state=inactive]:absolute data-[state=inactive]:inset-0 data-[state=inactive]:invisible data-[state=inactive]:opacity-0"
+            className={STANDARD_TAB_PANEL_CLASS_NAME}
           >
             {previewTabActive ? (
               <SessionPreview
@@ -416,7 +421,7 @@ export function SessionDetail({
 
           <TabsContent
             value="skills"
-            className="min-h-0 h-full min-w-0 w-full overflow-hidden focus-visible:outline-none [&[hidden]]:block data-[state=inactive]:pointer-events-none data-[state=inactive]:absolute data-[state=inactive]:inset-0 data-[state=inactive]:invisible data-[state=inactive]:opacity-0"
+            className={STANDARD_TAB_PANEL_CLASS_NAME}
           >
             <SessionSkills
               session={session}

--- a/packages/web/src/components/sessions/SessionPreview.tsx
+++ b/packages/web/src/components/sessions/SessionPreview.tsx
@@ -219,6 +219,19 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
   const previewCommandQueueRef = useRef<Promise<void>>(Promise.resolve());
   const imageRef = useRef<HTMLImageElement | null>(null);
   const previewSurfaceRef = useRef<HTMLDivElement | null>(null);
+  const mountedAtRef = useRef(Date.now());
+  const firstStatusLoadedAtRef = useRef<number | null>(null);
+  const firstConnectedAtRef = useRef<number | null>(null);
+  const lastConnectedAtRef = useRef<number | null>(null);
+  const statusLoadCountRef = useRef(0);
+  const statusLoadFailureCountRef = useRef(0);
+  const statusPollCountRef = useRef(0);
+  const commandCountRef = useRef(0);
+  const commandFailureCountRef = useRef(0);
+  const domLoadCountRef = useRef(0);
+  const domLoadFailureCountRef = useRef(0);
+  const autoConnectAttemptCountRef = useRef(0);
+  const screenshotLoadCountRef = useRef(0);
   const [pageVisible, setPageVisible] = useState(true);
   const shouldRunPreview = active && pageVisible;
   const autoConnectCandidate = selectPreviewAutoConnectCandidate(status?.candidateUrls ?? []);
@@ -234,34 +247,65 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
     };
   }, []);
 
-  const loadStatus = useCallback(async () => {
-    const response = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/preview`, {
-      cache: "no-store",
-    });
-    const payload = await response.json().catch(() => null) as
-      | PreviewStatusResponse
-      | { error?: string }
-      | null;
+  useEffect(() => {
+    mountedAtRef.current = Date.now();
+    firstStatusLoadedAtRef.current = null;
+    firstConnectedAtRef.current = null;
+    lastConnectedAtRef.current = null;
+    statusLoadCountRef.current = 0;
+    statusLoadFailureCountRef.current = 0;
+    statusPollCountRef.current = 0;
+    commandCountRef.current = 0;
+    commandFailureCountRef.current = 0;
+    domLoadCountRef.current = 0;
+    domLoadFailureCountRef.current = 0;
+    autoConnectAttemptCountRef.current = 0;
+    screenshotLoadCountRef.current = 0;
+  }, [sessionId]);
 
-    if (!response.ok) {
-      throw new Error(payload && "error" in payload ? payload.error ?? "Failed to load preview state" : `Failed to load preview state: ${response.status}`);
+  const loadStatus = useCallback(async (reason: "initial" | "poll" | "manual" = "manual") => {
+    statusLoadCountRef.current += 1;
+    if (reason === "poll") {
+      statusPollCountRef.current += 1;
     }
 
-    setStatus(payload as PreviewStatusResponse);
-    setCommandError(null);
-    setUrlInput((current) => {
-      const nextStatus = payload as PreviewStatusResponse;
-      if (current.trim().length > 0 && current !== nextStatus.currentUrl) {
-        return current;
+    try {
+      const response = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/preview`, {
+        cache: "no-store",
+      });
+      const payload = await response.json().catch(() => null) as
+        | PreviewStatusResponse
+        | { error?: string }
+        | null;
+
+      if (!response.ok) {
+        throw new Error(payload && "error" in payload ? payload.error ?? "Failed to load preview state" : `Failed to load preview state: ${response.status}`);
       }
-      return nextStatus.currentUrl
-        ?? selectPreviewAutoConnectCandidate(nextStatus.candidateUrls)
-        ?? nextStatus.candidateUrls[0]
-        ?? current;
-    });
+
+      const now = Date.now();
+      if (firstStatusLoadedAtRef.current === null) {
+        firstStatusLoadedAtRef.current = now;
+      }
+      setStatus(payload as PreviewStatusResponse);
+      setCommandError(null);
+      setUrlInput((current) => {
+        const nextStatus = payload as PreviewStatusResponse;
+        if (current.trim().length > 0 && current !== nextStatus.currentUrl) {
+          return current;
+        }
+        return nextStatus.currentUrl
+          ?? selectPreviewAutoConnectCandidate(nextStatus.candidateUrls)
+          ?? nextStatus.candidateUrls[0]
+          ?? current;
+      });
+    } catch (error) {
+      statusLoadFailureCountRef.current += 1;
+      throw error;
+    }
   }, [sessionId]);
 
   const runCommand = useCallback(async (command: PreviewCommandRequest): Promise<PreviewStatusResponse> => {
+    commandCountRef.current += 1;
     setBusy(true);
     setCommandError(null);
     try {
@@ -287,6 +331,9 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
       const nextStatus = payload as PreviewStatusResponse;
       setStatus(nextStatus);
       return nextStatus;
+    } catch (error) {
+      commandFailureCountRef.current += 1;
+      throw error;
     } finally {
       setBusy(false);
     }
@@ -310,6 +357,7 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
       return;
     }
 
+    domLoadCountRef.current += 1;
     setDomLoading(true);
     try {
       const searchParams = new URLSearchParams();
@@ -327,6 +375,7 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
       }
       setDomNodes((payload as PreviewDomResponse).nodes);
     } catch (error) {
+      domLoadFailureCountRef.current += 1;
       setCommandError(error instanceof Error ? error.message : "Failed to inspect DOM");
       setDomNodes([]);
     } finally {
@@ -343,7 +392,7 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
 
     (async () => {
       try {
-        await loadStatus();
+        await loadStatus("initial");
       } catch (error) {
         if (mounted) {
           setCommandError(error instanceof Error ? error.message : "Failed to load preview");
@@ -358,7 +407,7 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
     const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
     const pollInterval = isMobile ? STATUS_POLL_INTERVAL_MS * 2 : STATUS_POLL_INTERVAL_MS;
     const intervalId = window.setInterval(() => {
-      void loadStatus().catch((error: unknown) => {
+      void loadStatus("poll").catch((error: unknown) => {
         if (mounted) {
           setCommandError(error instanceof Error ? error.message : "Failed to refresh preview");
         }
@@ -404,14 +453,69 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
     }
 
     autoConnectRef.current = { candidate, attemptedAt: now };
+    autoConnectAttemptCountRef.current += 1;
     void runCommand({ command: "connect", url: candidate }).catch((error: unknown) => {
       setCommandError(error instanceof Error ? error.message : "Failed to connect preview");
     });
   }, [autoConnectCandidate, runCommand, shouldRunPreview, status?.connected]);
 
   useEffect(() => {
+    if (status?.connected) {
+      const now = Date.now();
+      lastConnectedAtRef.current = now;
+      if (firstConnectedAtRef.current === null) {
+        firstConnectedAtRef.current = now;
+      }
+    }
     onConnectionChange?.(Boolean(shouldRunPreview && status?.connected && status?.screenshotKey));
   }, [onConnectionChange, shouldRunPreview, status?.connected, status?.screenshotKey]);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "development") return;
+
+    window.__conductorSessionPreviewDebug = {
+      sessionId,
+      getState: () => ({
+        sessionId,
+        active,
+        pageVisible,
+        shouldRunPreview,
+        connected: Boolean(status?.connected),
+        screenshotReady: Boolean(status?.screenshotKey),
+        previewMode,
+        inspectorTab: previewInspectorTab,
+        domNodes: domNodes.length,
+        metrics: {
+          mountedAt: new Date(mountedAtRef.current).toISOString(),
+          mountedAgeMs: Date.now() - mountedAtRef.current,
+          firstStatusLoadLatencyMs: firstStatusLoadedAtRef.current === null
+            ? null
+            : firstStatusLoadedAtRef.current - mountedAtRef.current,
+          firstConnectedLatencyMs: firstConnectedAtRef.current === null
+            ? null
+            : firstConnectedAtRef.current - mountedAtRef.current,
+          lastConnectedAt: lastConnectedAtRef.current === null
+            ? null
+            : new Date(lastConnectedAtRef.current).toISOString(),
+          statusLoadCount: statusLoadCountRef.current,
+          statusLoadFailureCount: statusLoadFailureCountRef.current,
+          statusPollCount: statusPollCountRef.current,
+          commandCount: commandCountRef.current,
+          commandFailureCount: commandFailureCountRef.current,
+          domLoadCount: domLoadCountRef.current,
+          domLoadFailureCount: domLoadFailureCountRef.current,
+          autoConnectAttemptCount: autoConnectAttemptCountRef.current,
+          screenshotLoadCount: screenshotLoadCountRef.current,
+        },
+      }),
+    };
+
+    return () => {
+      if (window.__conductorSessionPreviewDebug?.sessionId === sessionId) {
+        delete window.__conductorSessionPreviewDebug;
+      }
+    };
+  }, [active, domNodes.length, pageVisible, previewInspectorTab, previewMode, sessionId, shouldRunPreview, status?.connected, status?.screenshotKey]);
 
   const screenshotUrl = useMemo(() => (
     status?.connected
@@ -807,7 +911,7 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
               <Button
                 type="button"
                 variant="outline"
-                onClick={() => void loadStatus().catch((error: unknown) => {
+                onClick={() => void loadStatus("manual").catch((error: unknown) => {
                   setCommandError(error instanceof Error ? error.message : "Failed to refresh preview");
                 })}
                 disabled={loading || busy}
@@ -942,6 +1046,7 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
                     onClick={(event) => void handleImageClick(event)}
                     onDoubleClick={(event) => void handleImageDoubleClick(event)}
                     onLoad={(event) => {
+                      screenshotLoadCountRef.current += 1;
                       const target = event.currentTarget;
                       setImageMetrics({
                         naturalWidth: target.naturalWidth,

--- a/packages/web/src/components/sessions/SessionPreview.tsx
+++ b/packages/web/src/components/sessions/SessionPreview.tsx
@@ -23,12 +23,11 @@ import {
   Send,
   TerminalSquare,
   Waypoints,
-  X,
 } from "lucide-react";
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
-import { Card, CardContent, CardHeader } from "@/components/ui/Card";
 import { ScrollArea } from "@/components/ui/ScrollArea";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/Tabs";
 import { cn } from "@/lib/cn";
 import { selectPreviewAutoConnectCandidate } from "@/lib/previewAutoConnect";
 import type {
@@ -206,6 +205,7 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
   const [sendSuccess, setSendSuccess] = useState<string | null>(null);
   const [sendingTarget, setSendingTarget] = useState<PreviewSendTarget | null>(null);
   const [previewMode, setPreviewMode] = useState<PreviewInteractionMode>("navigate");
+  const [previewInspectorTab, setPreviewInspectorTab] = useState<"elements" | "console" | "network">("elements");
   const [selectionComposer, setSelectionComposer] = useState<SelectionComposerState | null>(null);
   const [urlInput, setUrlInput] = useState("");
   const [imageMetrics, setImageMetrics] = useState({
@@ -372,8 +372,11 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
   }, [loadStatus, shouldRunPreview]);
 
   useEffect(() => {
-    if (!shouldRunPreview || !status?.connected) {
+    if (!status?.connected) {
       setDomNodes([]);
+      return;
+    }
+    if (!shouldRunPreview) {
       return;
     }
     void loadDom(status.activeFrameId);
@@ -467,6 +470,9 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
 
   const handlePreviewModeChange = useCallback((mode: PreviewInteractionMode) => {
     setPreviewMode(mode);
+    if (mode === "inspect") {
+      setPreviewInspectorTab("elements");
+    }
     setSelectionComposer(null);
     setSendError(null);
     setSendSuccess(null);
@@ -756,103 +762,75 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
   }, [status?.selectedElement?.selector]);
 
   return (
-    <div className="flex h-full min-h-0 flex-col gap-2 overflow-auto">
-      <Card>
-        <CardHeader className="flex flex-col items-start gap-2 lg:flex-row lg:items-center lg:justify-between">
-          <div className="flex items-center gap-2">
-            <Globe className="h-4 w-4 text-[var(--vk-text-muted)]" />
-            <span className="text-[13px] font-medium text-[var(--vk-text-normal)]">Dev preview browser</span>
+    <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-[8px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)]">
+      <div className="border-b border-[var(--vk-border)] px-3 py-3">
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="flex items-center gap-2">
+              <Globe className="h-4 w-4 text-[var(--vk-text-muted)]" />
+              <span className="text-[13px] font-medium text-[var(--vk-text-normal)]">Preview browser</span>
+            </div>
             {status?.connected
               ? <Badge variant="success">connected</Badge>
               : <Badge variant="outline">idle</Badge>}
             {activeFrame
               ? <Badge variant="outline">{activeFrame.isMain ? "main frame" : "nested frame"}</Badge>
               : null}
-          </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => void loadStatus().catch((error: unknown) => {
-                setCommandError(error instanceof Error ? error.message : "Failed to refresh preview");
-              })}
-              disabled={loading || busy}
-            >
-              <RefreshCw className={cn("h-3.5 w-3.5", busy && "animate-spin")} />
-              Refresh
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => void runCommand({ command: "reload" }).catch((error: unknown) => {
-                setCommandError(error instanceof Error ? error.message : "Failed to reload preview");
-              })}
-              disabled={!status?.connected || busy}
-            >
-              <Waypoints className="h-3.5 w-3.5" />
-              Reload page
-            </Button>
-          </div>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          <div className="flex flex-col gap-2 sm:flex-row">
-            <input
-              value={urlInput}
-              onChange={(event) => setUrlInput(event.target.value)}
-              placeholder={preferredUrlInputCandidate ?? "http://127.0.0.1:3000"}
-              className="h-9 min-w-0 flex-1 rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] px-3 text-[13px] text-[var(--vk-text-normal)] outline-none focus:border-[var(--vk-orange)]"
-            />
-            <Button
-              type="button"
-              variant="primary"
-              onClick={() => void handleConnect()}
-              disabled={busy || !urlInput.trim()}
-            >
-              {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <MousePointerClick className="h-4 w-4" />}
-              Connect
-            </Button>
+            {status?.title
+              ? <Badge variant="outline">{truncate(status.title, 40)}</Badge>
+              : null}
+            {selectionComposer?.pending
+              ? <Badge variant="warning">selecting element…</Badge>
+              : null}
           </div>
 
-          {status?.candidateUrls.length ? (
+          <div className="flex flex-col gap-2 lg:flex-row lg:items-center">
+            <div className="flex min-w-0 flex-1 items-center gap-2 rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-3">
+              <Globe className="h-3.5 w-3.5 shrink-0 text-[var(--vk-text-muted)]" />
+              <input
+                value={urlInput}
+                onChange={(event) => setUrlInput(event.target.value)}
+                placeholder={preferredUrlInputCandidate ?? "http://127.0.0.1:3000"}
+                className="h-10 min-w-0 flex-1 bg-transparent text-[13px] text-[var(--vk-text-normal)] outline-none placeholder:text-[var(--vk-text-muted)]"
+              />
+            </div>
             <div className="flex flex-wrap items-center gap-2">
-              {status.candidateUrls.map((candidate) => (
-                <button
-                  key={candidate}
-                  type="button"
-                  className="inline-flex max-w-full items-center gap-1 rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-2 py-1 text-left text-[11px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] hover:text-[var(--vk-text-normal)]"
-                  onClick={() => {
-                    setUrlInput(candidate);
-                    void runCommand({ command: "connect", url: candidate }).catch((error: unknown) => {
-                      setCommandError(error instanceof Error ? error.message : "Failed to connect preview");
-                    });
-                  }}
-                >
-                  <Globe className="h-3 w-3 shrink-0" />
-                  <span className="truncate">{candidate}</span>
-                </button>
-              ))}
+              <Button
+                type="button"
+                variant="primary"
+                onClick={() => void handleConnect()}
+                disabled={busy || !urlInput.trim()}
+              >
+                {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <MousePointerClick className="h-4 w-4" />}
+                Connect
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => void loadStatus().catch((error: unknown) => {
+                  setCommandError(error instanceof Error ? error.message : "Failed to refresh preview");
+                })}
+                disabled={loading || busy}
+              >
+                <RefreshCw className={cn("h-3.5 w-3.5", busy && "animate-spin")} />
+                Refresh
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => void runCommand({ command: "reload" }).catch((error: unknown) => {
+                  setCommandError(error instanceof Error ? error.message : "Failed to reload preview");
+                })}
+                disabled={!status?.connected || busy}
+              >
+                <Waypoints className="h-3.5 w-3.5" />
+                Reload
+              </Button>
             </div>
-          ) : null}
-
-          {commandError || status?.lastError ? (
-            <div className="flex items-start gap-2 rounded-[4px] border border-[color:color-mix(in_srgb,var(--vk-red)_45%,transparent)] bg-[color:color-mix(in_srgb,var(--vk-red)_12%,transparent)] px-3 py-2 text-[12px] text-[var(--vk-red)]">
-              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-              <span>{commandError ?? status?.lastError}</span>
-            </div>
-          ) : null}
-        </CardContent>
-      </Card>
-
-      <Card className="min-h-0 shrink-0 overflow-hidden">
-        <CardHeader className="flex flex-col items-start gap-2 lg:flex-row lg:items-center lg:justify-between">
-          <div className="flex items-center gap-2">
-            <Eye className="h-4 w-4 text-[var(--vk-text-muted)]" />
-            <span className="text-[13px] font-medium text-[var(--vk-text-normal)]">Preview</span>
           </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <div className="flex items-center gap-1 rounded-[4px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] p-1">
+
+          <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex items-center gap-1 rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] p-1">
               <Button
                 type="button"
                 size="sm"
@@ -872,293 +850,331 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
                 Inspect
               </Button>
             </div>
-            <div className="flex flex-wrap items-center gap-2 text-[11px] text-[var(--vk-text-muted)]">
-              <Badge variant="outline">{status?.title ? truncate(status.title, 40) : "Untitled page"}</Badge>
-              <Badge variant="outline">
-                {previewMode === "navigate"
-                  ? "navigate mode: clicks interact with the page"
-                  : canSelectByPoint
-                    ? "inspect mode: click once to select, double-click to queue for terminal input"
-                    : "inspect mode: use DOM list for this frame"}
-              </Badge>
+            <div className="text-[11px] text-[var(--vk-text-muted)]">
+              {previewMode === "navigate"
+                ? "Navigate mode sends clicks and typing into the running app."
+                : canSelectByPoint
+                  ? "Inspect mode lets you click once to inspect, double-click to queue for terminal input."
+                  : "Inspect mode is limited to the frame DOM list for nested frames."}
             </div>
           </div>
-        </CardHeader>
-        <CardContent className="min-h-0">
-          <div className="flex h-[56vh] min-h-[200px] max-h-[620px] items-center justify-center overflow-auto rounded-[6px] border border-[var(--vk-border)] bg-[#111] p-2 sm:h-[72vh] sm:min-h-[360px] sm:max-h-[760px] sm:p-3">
-            {loading ? (
-              <div className="flex items-center gap-2 text-[13px] text-[var(--vk-text-muted)]">
-                <Loader2 className="h-4 w-4 animate-spin" />
-                Loading preview…
-              </div>
-            ) : screenshotUrl ? (
-              <div
-                ref={previewSurfaceRef}
-                tabIndex={status?.connected ? 0 : -1}
-                onKeyDown={handlePreviewKeyDown}
-                onPaste={handlePreviewPaste}
-                className="relative flex max-h-full max-w-full items-start justify-center overflow-auto rounded-[6px] outline-none focus-visible:ring-2 focus-visible:ring-[var(--vk-orange)] focus-visible:ring-offset-2 focus-visible:ring-offset-[#111]"
-              >
-                <img
-                  ref={imageRef}
-                  src={screenshotUrl}
-                  alt="Session preview"
-                  className={cn(
-                    "max-h-full max-w-full rounded-[4px] object-contain shadow-[0_18px_36px_rgba(0,0,0,0.28)]",
-                    previewMode === "navigate"
-                      ? "cursor-pointer"
-                      : canSelectByPoint
-                        ? "cursor-crosshair"
-                        : "cursor-default",
-                  )}
-                  onClick={(event) => void handleImageClick(event)}
-                  onDoubleClick={(event) => void handleImageDoubleClick(event)}
-                  onLoad={(event) => {
-                    const target = event.currentTarget;
-                    setImageMetrics({
-                      naturalWidth: target.naturalWidth,
-                      naturalHeight: target.naturalHeight,
-                      renderedWidth: target.clientWidth,
-                      renderedHeight: target.clientHeight,
-                    });
-                  }}
-                />
-                {previewMode === "inspect" && selectionOverlayStyle ? (
-                  <div
-                    className="pointer-events-none absolute border-2 border-[var(--vk-orange)] bg-[color:color-mix(in_srgb,var(--vk-orange)_18%,transparent)] shadow-[0_0_0_1px_rgba(0,0,0,0.5)]"
-                    style={selectionOverlayStyle}
-                  />
-                ) : null}
-                {previewMode === "inspect" && selectionComposer && selectionComposerStyle ? (
-                  <div
-                    className="pointer-events-auto absolute z-20 flex flex-col overflow-hidden rounded-[10px] border border-[var(--vk-border)] bg-[color:color-mix(in_srgb,var(--vk-bg-panel)_94%,black_6%)] shadow-[0_20px_44px_rgba(0,0,0,0.42)] backdrop-blur"
-                    style={selectionComposerStyle}
-                  >
-                    <div className="flex items-start justify-between gap-3 border-b border-[var(--vk-border)] px-3 py-3">
-                      <div className="min-w-0">
-                        <div className="text-[10px] uppercase tracking-[0.16em] text-[var(--vk-text-muted)]">Terminal input</div>
-                        <div className="mt-1 text-[13px] font-medium text-[var(--vk-text-normal)]">
-                          {selectionComposer.pending ? "Selecting element…" : "Queue selection for the terminal"}
-                        </div>
-                      </div>
-                      <div className="flex items-center gap-1">
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => void handleCopySelector()}
-                          disabled={selectionComposer.pending || !status?.selectedElement}
-                        >
-                          <Copy className="h-3.5 w-3.5" />
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => setSelectionComposer(null)}
-                        >
-                          <X className="h-3.5 w-3.5" />
-                        </Button>
-                      </div>
-                    </div>
-                    <div className="flex-1 space-y-3 overflow-y-auto px-3 py-3">
-                      {selectionComposer.pending ? (
-                        <div className="flex items-center gap-2 rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-3 py-3 text-[12px] text-[var(--vk-text-muted)]">
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                          Capturing the selected element from the preview…
-                        </div>
-                      ) : status?.selectedElement ? (
-                        <>
-                          <div className="rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-3 py-2">
-                            <div className="flex items-center gap-2">
-                              <span className="font-mono text-[12px] text-[var(--vk-text-normal)]">{status.selectedElement.tag}</span>
-                              {status.selectedElement.role ? <Badge variant="outline">{status.selectedElement.role}</Badge> : null}
-                            </div>
-                            <div className="mt-2 text-[12px] text-[var(--vk-text-normal)]">
-                              {truncate(status.selectedElement.name || status.selectedElement.text || "Selected element", 140)}
-                            </div>
-                            <div className="mt-2 break-all font-mono text-[11px] text-[var(--vk-text-muted)]">
-                              {status.selectedElement.selector}
-                            </div>
-                          </div>
-                          <div className="rounded-[6px] border border-dashed border-[var(--vk-border)] px-3 py-2 text-[12px] text-[var(--vk-text-muted)]">
-                            Double-click the element in the preview to queue it immediately, or use the button below. The text is inserted into terminal input instead of being sent to the agent, so you can add more context before submitting.
-                          </div>
-                          {sendError ? (
-                            <div className="text-[12px] text-[var(--vk-red)]">{sendError}</div>
-                          ) : null}
-                          <Button
-                            type="button"
-                            variant="primary"
-                            className="w-full"
-                            onClick={() => void handleSendContext("selection")}
-                            disabled={sending || !status.selectedElement}
-                          >
-                            {sendingTarget === "selection" ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
-                            Queue for terminal input
-                          </Button>
-                        </>
-                      ) : (
-                        <div className="rounded-[6px] border border-dashed border-[var(--vk-border)] px-3 py-3 text-[12px] text-[var(--vk-text-muted)]">
-                          Single-click an element to inspect it here. Double-click to queue it for terminal input.
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                ) : null}
-              </div>
-            ) : (
-              <div className="max-w-md text-center text-[13px] text-[var(--vk-text-muted)]">
-                Connect a local dev URL or explicit preview URL to start the preview browser. In Navigate mode, click the preview first, then type directly into the running app. Switch to Inspect mode to select UI elements and queue browser context into terminal input.
-              </div>
-            )}
-          </div>
-        </CardContent>
-      </Card>
 
-      {sendSuccess ? (
-        <div className="rounded-[6px] border border-[color:color-mix(in_srgb,var(--vk-green)_35%,transparent)] bg-[color:color-mix(in_srgb,var(--vk-green)_10%,transparent)] px-3 py-2 text-[12px] text-[var(--vk-green)]">
-          {sendSuccess}
-        </div>
-      ) : null}
-      {!selectionComposer && sendError ? (
-        <div className="rounded-[6px] border border-[color:color-mix(in_srgb,var(--vk-red)_35%,transparent)] bg-[color:color-mix(in_srgb,var(--vk-red)_10%,transparent)] px-3 py-2 text-[12px] text-[var(--vk-red)]">
-          {sendError}
-        </div>
-      ) : null}
-
-      <div className="grid gap-2">
-        <Card className="min-h-0">
-          <CardHeader className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <Boxes className="h-4 w-4 text-[var(--vk-text-muted)]" />
-              <span className="text-[13px] font-medium text-[var(--vk-text-normal)]">Frames and DOM</span>
-              <Badge variant="outline">{previewMode === "inspect" ? "inspect" : "read-only in navigate mode"}</Badge>
-            </div>
-            <Button
-              type="button"
-              variant={interactiveOnly ? "primary" : "outline"}
-              size="sm"
-              onClick={() => setInteractiveOnly((current) => !current)}
-            >
-              {interactiveOnly ? "Interactive only" : "All nodes"}
-            </Button>
-          </CardHeader>
-          <CardContent className="grid gap-2 xl:grid-cols-[220px_minmax(0,1fr)]">
-            <div className="space-y-2">
-              {status?.frames.map((frame) => (
+          {!status?.connected && status?.candidateUrls.length ? (
+            <div className="flex flex-wrap items-center gap-2">
+              {status.candidateUrls.map((candidate) => (
                 <button
-                  key={frame.id}
+                  key={candidate}
                   type="button"
+                  className="inline-flex max-w-full items-center gap-1 rounded-[4px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-2.5 py-1.5 text-left text-[11px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] hover:text-[var(--vk-text-normal)]"
                   onClick={() => {
-                    void runCommand({ command: "selectFrame", frameId: frame.id }).catch((error: unknown) => {
-                      setCommandError(error instanceof Error ? error.message : "Failed to select frame");
+                    setUrlInput(candidate);
+                    void runCommand({ command: "connect", url: candidate }).catch((error: unknown) => {
+                      setCommandError(error instanceof Error ? error.message : "Failed to connect preview");
                     });
                   }}
-                  className={cn(
-                    "flex w-full flex-col items-start gap-1 rounded-[4px] border px-2 py-2 text-left transition-colors",
-                    status.activeFrameId === frame.id
-                      ? "border-[var(--vk-orange)] bg-[color:color-mix(in_srgb,var(--vk-orange)_10%,transparent)]"
-                      : "border-[var(--vk-border)] bg-[var(--vk-bg-main)] hover:bg-[var(--vk-bg-hover)]",
-                  )}
                 >
-                  <div className="flex items-center gap-2">
-                    <Badge variant="outline">{frame.isMain ? "main" : "frame"}</Badge>
-                    <span className="truncate text-[12px] text-[var(--vk-text-normal)]">{frame.name}</span>
-                  </div>
-                  <span className="w-full truncate text-[11px] text-[var(--vk-text-muted)]">
-                    {frame.url || "about:blank"}
-                  </span>
+                  <Globe className="h-3 w-3 shrink-0" />
+                  <span className="truncate">{candidate}</span>
                 </button>
               ))}
             </div>
+          ) : null}
 
-            <div className="rounded-[4px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)]">
-              <ScrollArea className="h-[200px] sm:h-[300px] xl:h-[360px]">
-                <div className="space-y-1 p-2">
-                  {previewMode === "navigate" ? (
-                    <div className="rounded-[4px] border border-dashed border-[var(--vk-border)] px-2 py-2 text-[11px] text-[var(--vk-text-muted)]">
-                      Switch to Inspect mode to pick DOM nodes. Single-click selects a node. Double-click queues it for terminal input.
+          {commandError || status?.lastError ? (
+            <div className="flex items-start gap-2 rounded-[6px] border border-[color:color-mix(in_srgb,var(--vk-red)_45%,transparent)] bg-[color:color-mix(in_srgb,var(--vk-red)_12%,transparent)] px-3 py-2 text-[12px] text-[var(--vk-red)]">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>{commandError ?? status?.lastError}</span>
+            </div>
+          ) : null}
+          {sendSuccess ? (
+            <div className="rounded-[6px] border border-[color:color-mix(in_srgb,var(--vk-green)_35%,transparent)] bg-[color:color-mix(in_srgb,var(--vk-green)_10%,transparent)] px-3 py-2 text-[12px] text-[var(--vk-green)]">
+              {sendSuccess}
+            </div>
+          ) : null}
+          {sendError ? (
+            <div className="rounded-[6px] border border-[color:color-mix(in_srgb,var(--vk-red)_35%,transparent)] bg-[color:color-mix(in_srgb,var(--vk-red)_10%,transparent)] px-3 py-2 text-[12px] text-[var(--vk-red)]">
+              {sendError}
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="grid min-h-0 flex-1 lg:grid-cols-[minmax(0,1.55fr)_minmax(320px,0.95fr)]">
+        <div className="flex min-h-0 flex-col border-b border-[var(--vk-border)] lg:border-b-0 lg:border-r">
+          <div className="flex items-center justify-between gap-2 border-b border-[var(--vk-border)] px-3 py-2 text-[11px] text-[var(--vk-text-muted)]">
+            <div className="min-w-0">
+              <div className="truncate text-[var(--vk-text-normal)]">
+                {status?.currentUrl ?? preferredUrlInputCandidate ?? "No active preview URL yet"}
+              </div>
+            </div>
+            {status?.connected ? (
+              <Badge variant="outline">{status?.frames.length ?? 0} frame{(status?.frames.length ?? 0) === 1 ? "" : "s"}</Badge>
+            ) : null}
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-auto bg-[#0f1012] p-3">
+            <div className="flex h-full min-h-[260px] items-center justify-center">
+              {loading ? (
+                <div className="flex items-center gap-2 text-[13px] text-[var(--vk-text-muted)]">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Loading preview…
+                </div>
+              ) : screenshotUrl ? (
+                <div
+                  ref={previewSurfaceRef}
+                  tabIndex={status?.connected ? 0 : -1}
+                  onKeyDown={handlePreviewKeyDown}
+                  onPaste={handlePreviewPaste}
+                  className="relative flex max-h-full max-w-full items-start justify-center overflow-auto rounded-[10px] outline-none focus-visible:ring-2 focus-visible:ring-[var(--vk-orange)] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1012]"
+                >
+                  <img
+                    ref={imageRef}
+                    src={screenshotUrl}
+                    alt="Session preview"
+                    className={cn(
+                      "max-h-full max-w-full rounded-[8px] object-contain shadow-[0_18px_36px_rgba(0,0,0,0.28)]",
+                      previewMode === "navigate"
+                        ? "cursor-pointer"
+                        : canSelectByPoint
+                          ? "cursor-crosshair"
+                          : "cursor-default",
+                    )}
+                    onClick={(event) => void handleImageClick(event)}
+                    onDoubleClick={(event) => void handleImageDoubleClick(event)}
+                    onLoad={(event) => {
+                      const target = event.currentTarget;
+                      setImageMetrics({
+                        naturalWidth: target.naturalWidth,
+                        naturalHeight: target.naturalHeight,
+                        renderedWidth: target.clientWidth,
+                        renderedHeight: target.clientHeight,
+                      });
+                    }}
+                  />
+                  {previewMode === "inspect" && selectionOverlayStyle ? (
+                    <div
+                      className="pointer-events-none absolute border-2 border-[var(--vk-orange)] bg-[color:color-mix(in_srgb,var(--vk-orange)_18%,transparent)] shadow-[0_0_0_1px_rgba(0,0,0,0.5)]"
+                      style={selectionOverlayStyle}
+                    />
+                  ) : null}
+                  {previewMode === "inspect" && selectionComposer && selectionComposerStyle ? (
+                    <div
+                      className="pointer-events-none absolute z-20 rounded-[10px] border border-[var(--vk-border)] bg-[color:color-mix(in_srgb,var(--vk-bg-panel)_94%,black_6%)] px-3 py-2 text-[11px] text-[var(--vk-text-normal)] shadow-[0_16px_40px_rgba(0,0,0,0.35)] backdrop-blur"
+                      style={selectionComposerStyle}
+                    >
+                      {selectionComposer.pending
+                        ? "Selecting element…"
+                        : status?.selectedElement
+                          ? `${status.selectedElement.tag} · ${truncate(status.selectedElement.selector, 120)}`
+                          : "Selection ready"}
                     </div>
                   ) : null}
-                  {domLoading ? (
-                    <div className="flex items-center gap-2 px-2 py-2 text-[12px] text-[var(--vk-text-muted)]">
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                      Inspecting frame DOM…
-                    </div>
-                  ) : domNodes.length ? (
-                    domNodes.map((node, index) => (
-                      <button
-                        key={`${node.id ?? "node"}-${index}-${node.selector}-${node.tag}-${node.text}`}
-                        type="button"
-                        className={cn(
-                          "w-full rounded-[4px] border border-[transparent] px-2 py-2 text-left",
-                          previewMode === "inspect"
-                            ? "hover:border-[var(--vk-border)] hover:bg-[var(--vk-bg-hover)]"
-                            : "cursor-not-allowed opacity-60",
-                        )}
-                        disabled={previewMode !== "inspect"}
-                        onClick={() => {
-                          setSelectionComposer(null);
-                          setSendError(null);
-                          setSendSuccess(null);
-                          void selectDomNode(node.selector, status?.activeFrameId)
-                            .catch((error: unknown) => {
-                              setCommandError(error instanceof Error ? error.message : "Failed to select DOM node");
-                            });
-                        }}
-                        onDoubleClick={() => {
-                          setSendError(null);
-                          setSendSuccess(null);
-                          void selectDomNode(node.selector, status?.activeFrameId)
-                            .then((nextStatus) => {
-                              if (!nextStatus.selectedElement) {
-                                throw new Error("Failed to resolve the selected DOM node");
-                              }
-                              queueContextInsert(buildSelectionInsert(nextStatus.selectedElement, nextStatus.currentUrl));
-                            })
-                            .catch((error: unknown) => {
-                              setCommandError(error instanceof Error ? error.message : "Failed to queue DOM node");
-                            });
-                        }}
-                      >
-                        <div className="flex items-center gap-2">
-                          <span className="font-mono text-[12px] text-[var(--vk-text-normal)]">{node.tag}</span>
-                          {node.interactive ? <Badge variant="warning">interactive</Badge> : null}
-                          {node.role ? <Badge variant="outline">{node.role}</Badge> : null}
-                        </div>
-                        <div className="mt-1 break-all font-mono text-[11px] text-[var(--vk-text-muted)]">
-                          {node.selector}
-                        </div>
-                        {node.text ? (
-                          <div className="mt-1 text-[12px] text-[var(--vk-text-normal)]">
-                            {truncate(node.text, 180)}
-                          </div>
-                        ) : null}
-                      </button>
-                    ))
-                  ) : (
-                    <div className="px-2 py-3 text-[12px] text-[var(--vk-text-muted)]">
-                      No DOM nodes to show for the current frame yet.
-                    </div>
-                  )}
                 </div>
-              </ScrollArea>
+              ) : (
+                <div className="max-w-md text-center text-[13px] text-[var(--vk-text-muted)]">
+                  Connect a local dev URL or explicit preview URL to start the preview browser. Navigate mode lets you interact with the running app. Inspect mode lets you capture UI context and queue it into terminal input.
+                </div>
+              )}
             </div>
-          </CardContent>
-        </Card>
+          </div>
+        </div>
 
-        <div className="grid gap-2 lg:grid-cols-2">
-          <Card className="min-h-0">
-            <CardHeader className="flex items-center justify-between gap-2">
-              <div className="flex items-center gap-2">
-                <TerminalSquare className="h-4 w-4 text-[var(--vk-text-muted)]" />
-                <span className="text-[13px] font-medium text-[var(--vk-text-normal)]">Console</span>
+        <Tabs
+          value={previewInspectorTab}
+          onValueChange={(value) => setPreviewInspectorTab(value as "elements" | "console" | "network")}
+          className="flex min-h-0 flex-1 flex-col overflow-hidden"
+        >
+          <div className="border-b border-[var(--vk-border)] px-2 py-2">
+            <TabsList className="w-full justify-start border-0 bg-transparent p-0">
+              <TabsTrigger value="elements">
+                <Boxes className="h-3.5 w-3.5" />
+                Elements
+              </TabsTrigger>
+              <TabsTrigger value="console">
+                <TerminalSquare className="h-3.5 w-3.5" />
+                Console
                 <Badge variant="outline">{status?.consoleLogs.length ?? 0}</Badge>
+              </TabsTrigger>
+              <TabsTrigger value="network">
+                <FileJson2 className="h-3.5 w-3.5" />
+                Network
+                <Badge variant="outline">{status?.networkLogs.length ?? 0}</Badge>
+              </TabsTrigger>
+            </TabsList>
+          </div>
+
+          <TabsContent value="elements" className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden">
+            <div className="border-b border-[var(--vk-border)] px-3 py-3">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <div className="text-[12px] font-medium text-[var(--vk-text-normal)]">Selected element</div>
+                  <div className="text-[11px] text-[var(--vk-text-muted)]">
+                    {previewMode === "inspect"
+                      ? "Single-click to inspect. Double-click to queue the element for terminal input."
+                      : "Switch to Inspect mode to capture element context from the preview."}
+                  </div>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    type="button"
+                    variant={interactiveOnly ? "primary" : "outline"}
+                    size="sm"
+                    onClick={() => setInteractiveOnly((current) => !current)}
+                  >
+                    {interactiveOnly ? "Interactive only" : "All nodes"}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => void handleCopySelector()}
+                    disabled={!status?.selectedElement}
+                  >
+                    <Copy className="h-3.5 w-3.5" />
+                    Copy selector
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="primary"
+                    size="sm"
+                    onClick={() => void handleSendContext("selection")}
+                    disabled={sending || !status?.selectedElement}
+                  >
+                    {sendingTarget === "selection" ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Send className="h-3.5 w-3.5" />}
+                    Queue for terminal
+                  </Button>
+                </div>
+              </div>
+
+              {status?.selectedElement ? (
+                <div className="mt-3 rounded-[8px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-3 py-3">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-mono text-[12px] text-[var(--vk-text-normal)]">{status.selectedElement.tag}</span>
+                    {status.selectedElement.role ? <Badge variant="outline">{status.selectedElement.role}</Badge> : null}
+                    {status.selectedElement.frameName ? <Badge variant="outline">{status.selectedElement.frameName}</Badge> : null}
+                  </div>
+                  <div className="mt-2 text-[12px] text-[var(--vk-text-normal)]">
+                    {truncate(status.selectedElement.name || status.selectedElement.text || "Selected element", 180)}
+                  </div>
+                  <div className="mt-2 break-all font-mono text-[11px] text-[var(--vk-text-muted)]">
+                    {status.selectedElement.selector}
+                  </div>
+                  {status.selectedElement.htmlPreview ? (
+                    <div className="mt-2 rounded-[6px] border border-dashed border-[var(--vk-border)] px-2.5 py-2 text-[11px] text-[var(--vk-text-muted)]">
+                      {truncate(status.selectedElement.htmlPreview, 260)}
+                    </div>
+                  ) : null}
+                </div>
+              ) : (
+                <div className="mt-3 rounded-[8px] border border-dashed border-[var(--vk-border)] px-3 py-3 text-[12px] text-[var(--vk-text-muted)]">
+                  No element selected yet.
+                </div>
+              )}
+
+              {status?.frames.length ? (
+                <div className="mt-3 flex flex-wrap items-center gap-2">
+                  {status.frames.map((frame) => (
+                    <button
+                      key={frame.id}
+                      type="button"
+                      onClick={() => {
+                        void runCommand({ command: "selectFrame", frameId: frame.id }).catch((error: unknown) => {
+                          setCommandError(error instanceof Error ? error.message : "Failed to select frame");
+                        });
+                      }}
+                      className={cn(
+                        "inline-flex max-w-full items-center gap-2 rounded-[5px] border px-2.5 py-1.5 text-[11px]",
+                        status.activeFrameId === frame.id
+                          ? "border-[var(--vk-orange)] bg-[color:color-mix(in_srgb,var(--vk-orange)_10%,transparent)] text-[var(--vk-text-normal)]"
+                          : "border-[var(--vk-border)] bg-[var(--vk-bg-main)] text-[var(--vk-text-muted)] hover:text-[var(--vk-text-normal)]",
+                      )}
+                    >
+                      <Badge variant="outline">{frame.isMain ? "main" : "frame"}</Badge>
+                      <span className="truncate">{frame.name}</span>
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+
+            <ScrollArea className="min-h-0 flex-1">
+              <div className="space-y-1 p-3">
+                {domLoading ? (
+                  <div className="flex items-center gap-2 rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-3 py-3 text-[12px] text-[var(--vk-text-muted)]">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Inspecting frame DOM…
+                  </div>
+                ) : domNodes.length ? (
+                  domNodes.map((node, index) => (
+                    <button
+                      key={`${node.id ?? "node"}-${index}-${node.selector}-${node.tag}-${node.text}`}
+                      type="button"
+                      className={cn(
+                        "w-full rounded-[6px] border px-3 py-2.5 text-left transition-colors",
+                        previewMode === "inspect"
+                          ? "border-[var(--vk-border)] bg-[var(--vk-bg-main)] hover:bg-[var(--vk-bg-hover)]"
+                          : "cursor-not-allowed border-[var(--vk-border)] bg-[var(--vk-bg-main)] opacity-60",
+                      )}
+                      disabled={previewMode !== "inspect"}
+                      onClick={() => {
+                        setSelectionComposer(null);
+                        setSendError(null);
+                        setSendSuccess(null);
+                        void selectDomNode(node.selector, status?.activeFrameId)
+                          .catch((error: unknown) => {
+                            setCommandError(error instanceof Error ? error.message : "Failed to select DOM node");
+                          });
+                      }}
+                      onDoubleClick={() => {
+                        setSendError(null);
+                        setSendSuccess(null);
+                        void selectDomNode(node.selector, status?.activeFrameId)
+                          .then((nextStatus) => {
+                            if (!nextStatus.selectedElement) {
+                              throw new Error("Failed to resolve the selected DOM node");
+                            }
+                            queueContextInsert(buildSelectionInsert(nextStatus.selectedElement, nextStatus.currentUrl));
+                          })
+                          .catch((error: unknown) => {
+                            setCommandError(error instanceof Error ? error.message : "Failed to queue DOM node");
+                          });
+                      }}
+                    >
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-mono text-[12px] text-[var(--vk-text-normal)]">{node.tag}</span>
+                        {node.interactive ? <Badge variant="warning">interactive</Badge> : null}
+                        {node.role ? <Badge variant="outline">{node.role}</Badge> : null}
+                      </div>
+                      <div className="mt-1 break-all font-mono text-[11px] text-[var(--vk-text-muted)]">
+                        {node.selector}
+                      </div>
+                      {node.text ? (
+                        <div className="mt-1 text-[12px] text-[var(--vk-text-normal)]">
+                          {truncate(node.text, 180)}
+                        </div>
+                      ) : null}
+                    </button>
+                  ))
+                ) : (
+                  <div className="rounded-[8px] border border-dashed border-[var(--vk-border)] px-3 py-3 text-[12px] text-[var(--vk-text-muted)]">
+                    {previewMode === "inspect"
+                      ? "No DOM nodes to show for the current frame yet."
+                      : "Switch to Inspect mode to browse the current frame DOM."}
+                  </div>
+                )}
+              </div>
+            </ScrollArea>
+          </TabsContent>
+
+          <TabsContent value="console" className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden">
+            <div className="flex items-center justify-between gap-2 border-b border-[var(--vk-border)] px-3 py-3">
+              <div>
+                <div className="text-[12px] font-medium text-[var(--vk-text-normal)]">Console output</div>
+                <div className="text-[11px] text-[var(--vk-text-muted)]">Live browser console events from the preview worker.</div>
               </div>
               <Button
                 type="button"
-                variant="ghost"
+                variant="primary"
                 size="sm"
                 onClick={() => void handleSendContext("console")}
                 disabled={sending || !status?.consoleLogs.length}
@@ -1166,43 +1182,40 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
                 {sendingTarget === "console" ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Send className="h-3.5 w-3.5" />}
                 Queue for terminal
               </Button>
-            </CardHeader>
-            <CardContent>
-              <ScrollArea className="h-[180px] sm:h-[260px] rounded-[4px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)]">
-                <div className="space-y-1 p-2">
-                  {status?.consoleLogs.length ? status.consoleLogs.map((entry) => (
-                    <div
-                      key={entry.id}
-                      className="rounded-[3px] px-2 py-1.5 text-[11px] text-[var(--vk-text-normal)]"
-                    >
-                      <div className="flex items-center gap-2 text-[10px] uppercase tracking-wide text-[var(--vk-text-muted)]">
-                        <span>{entry.level}</span>
-                        <span>{formatTime(entry.timestamp)}</span>
-                      </div>
-                      <div className="mt-1 whitespace-pre-wrap break-all font-mono">
-                        {entry.message}
-                      </div>
+            </div>
+            <ScrollArea className="min-h-0 flex-1">
+              <div className="space-y-1 p-3">
+                {status?.consoleLogs.length ? status.consoleLogs.map((entry) => (
+                  <div
+                    key={entry.id}
+                    className="rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-3 py-2.5 text-[11px] text-[var(--vk-text-normal)]"
+                  >
+                    <div className="flex flex-wrap items-center gap-2 text-[10px] uppercase tracking-wide text-[var(--vk-text-muted)]">
+                      <span>{entry.level}</span>
+                      <span>{formatTime(entry.timestamp)}</span>
                     </div>
-                  )) : (
-                    <div className="px-2 py-3 text-[12px] text-[var(--vk-text-muted)]">
-                      Console output appears here once the page loads.
+                    <div className="mt-1 whitespace-pre-wrap break-all font-mono">
+                      {entry.message}
                     </div>
-                  )}
-                </div>
-              </ScrollArea>
-            </CardContent>
-          </Card>
+                  </div>
+                )) : (
+                  <div className="rounded-[8px] border border-dashed border-[var(--vk-border)] px-3 py-3 text-[12px] text-[var(--vk-text-muted)]">
+                    Console output appears here once the page loads.
+                  </div>
+                )}
+              </div>
+            </ScrollArea>
+          </TabsContent>
 
-          <Card className="min-h-0">
-            <CardHeader className="flex items-center justify-between gap-2">
-              <div className="flex items-center gap-2">
-                <FileJson2 className="h-4 w-4 text-[var(--vk-text-muted)]" />
-                <span className="text-[13px] font-medium text-[var(--vk-text-normal)]">Network</span>
-                <Badge variant="outline">{status?.networkLogs.length ?? 0}</Badge>
+          <TabsContent value="network" className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden">
+            <div className="flex items-center justify-between gap-2 border-b border-[var(--vk-border)] px-3 py-3">
+              <div>
+                <div className="text-[12px] font-medium text-[var(--vk-text-normal)]">Network requests</div>
+                <div className="text-[11px] text-[var(--vk-text-muted)]">Recent requests captured by the preview worker.</div>
               </div>
               <Button
                 type="button"
-                variant="ghost"
+                variant="primary"
                 size="sm"
                 onClick={() => void handleSendContext("network")}
                 disabled={sending || !status?.networkLogs.length}
@@ -1210,33 +1223,31 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
                 {sendingTarget === "network" ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Send className="h-3.5 w-3.5" />}
                 Queue for terminal
               </Button>
-            </CardHeader>
-            <CardContent>
-              <ScrollArea className="h-[180px] sm:h-[260px] rounded-[4px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)]">
-                <div className="space-y-1 p-2">
-                  {status?.networkLogs.length ? status.networkLogs.map((entry) => (
-                    <div
-                      key={entry.id}
-                      className="rounded-[3px] px-2 py-1.5 text-[11px] text-[var(--vk-text-normal)]"
-                    >
-                      <div className="flex items-center gap-2 text-[10px] uppercase tracking-wide text-[var(--vk-text-muted)]">
-                        <span>{entry.method ?? "GET"}</span>
-                        {typeof entry.status === "number" ? <span>{entry.status}</span> : null}
-                        {entry.resourceType ? <span>{entry.resourceType}</span> : null}
-                        <span>{formatTime(entry.timestamp)}</span>
-                      </div>
-                      <div className="mt-1 break-all font-mono">{entry.url ?? entry.message}</div>
+            </div>
+            <ScrollArea className="min-h-0 flex-1">
+              <div className="space-y-1 p-3">
+                {status?.networkLogs.length ? status.networkLogs.map((entry) => (
+                  <div
+                    key={entry.id}
+                    className="rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-3 py-2.5 text-[11px] text-[var(--vk-text-normal)]"
+                  >
+                    <div className="flex flex-wrap items-center gap-2 text-[10px] uppercase tracking-wide text-[var(--vk-text-muted)]">
+                      <span>{entry.method ?? "GET"}</span>
+                      {typeof entry.status === "number" ? <span>{entry.status}</span> : null}
+                      {entry.resourceType ? <span>{entry.resourceType}</span> : null}
+                      <span>{formatTime(entry.timestamp)}</span>
                     </div>
-                  )) : (
-                    <div className="px-2 py-3 text-[12px] text-[var(--vk-text-muted)]">
-                      Network requests appear here after the preview loads.
-                    </div>
-                  )}
-                </div>
-              </ScrollArea>
-            </CardContent>
-          </Card>
-        </div>
+                    <div className="mt-1 break-all font-mono">{entry.url ?? entry.message}</div>
+                  </div>
+                )) : (
+                  <div className="rounded-[8px] border border-dashed border-[var(--vk-border)] px-3 py-3 text-[12px] text-[var(--vk-text-muted)]">
+                    Network requests appear here after the preview loads.
+                  </div>
+                )}
+              </div>
+            </ScrollArea>
+          </TabsContent>
+        </Tabs>
       </div>
     </div>
   );

--- a/packages/web/src/components/sessions/SessionTerminal.tsx
+++ b/packages/web/src/components/sessions/SessionTerminal.tsx
@@ -1099,15 +1099,30 @@ function sessionTerminalPropsEqual(
   previous: SessionTerminalProps,
   next: SessionTerminalProps,
 ): boolean {
+  const previousPanelVisible = previous.panelVisible ?? true;
+  const nextPanelVisible = next.panelVisible ?? true;
+
+  if (
+    previous.sessionId !== next.sessionId
+    || previous.projectId !== next.projectId
+    || previous.bridgeId !== next.bridgeId
+    || previousPanelVisible !== nextPanelVisible
+    || !arePendingInsertRequestsEqual(previous.pendingInsert, next.pendingInsert)
+  ) {
+    return false;
+  }
+
+  // Lunel-style behavior: once a terminal surface is inactive, stop re-rendering it on
+  // background session-status churn. Apply the latest runtime/status only when it becomes
+  // visible again.
+  if (!previousPanelVisible && !nextPanelVisible) {
+    return true;
+  }
+
   return (
-    previous.sessionId === next.sessionId
-    && previous.projectId === next.projectId
-    && previous.bridgeId === next.bridgeId
-    && previous.sessionState === next.sessionState
+    previous.sessionState === next.sessionState
     && previous.runtimeMode === next.runtimeMode
     && previous.immersiveMobileMode === next.immersiveMobileMode
-    && (previous.panelVisible ?? true) === (next.panelVisible ?? true)
-    && arePendingInsertRequestsEqual(previous.pendingInsert, next.pendingInsert)
   );
 }
 

--- a/packages/web/src/components/sessions/SessionTerminal.tsx
+++ b/packages/web/src/components/sessions/SessionTerminal.tsx
@@ -24,12 +24,12 @@ import type { SessionTerminalProps } from "./terminal/terminalTypes";
 const TERMINAL_CLOSED_STATUSES = new Set(["archived", "killed", "terminated", "restored"]);
 const TOKEN_REFRESH_LEAD_SECONDS = 30;
 const TTYD_AUTH_TOKEN_MESSAGE_TYPE = "conductor-ttyd-auth-token";
+const TTYD_AUTH_TOKEN_REQUEST_MESSAGE_TYPE = "conductor-ttyd-auth-token-request";
 const TERMINAL_RESIZE_DEBOUNCE_MS = 150;
 const TERMINAL_RESIZE_MESSAGE_TYPE = "conductor-terminal-resize";
 /** Staggered fits so xterm catches up after ttyd boot, layout, and fonts. */
 const TERMINAL_RESIZE_BURST_DELAYS_MS = [0, 50, 150, 400, 1000] as const;
 const TERMINAL_LIFECYCLE_REFRESH_THROTTLE_MS = 1_500;
-const TERMINAL_LIFECYCLE_REATTACH_THRESHOLD_MS = 1_800_000; // 30 minutes - only reload if hidden for 30+ minutes
 const TERMINAL_IFRAME_LOAD_TIMEOUT_MS = 25_000;
 
 function computeTokenRefreshDelayMs(expiresInSeconds: number | null | undefined): number | null {
@@ -258,6 +258,36 @@ function SessionTerminalView(props: SessionTerminalProps) {
     postTerminalAuthToken(iframe, token);
   }, [terminalLinkUrl]);
 
+  const requestSilentConnectionRefresh = useCallback((options?: {
+    force?: boolean;
+    resetResizeCache?: boolean;
+    syncCurrentToken?: boolean;
+  }) => {
+    if (!expectsLiveTerminal || typeof window === "undefined") {
+      return;
+    }
+
+    const now = window.Date.now();
+    const force = options?.force === true;
+    if (!force && now - lastLifecycleRefreshAtRef.current < TERMINAL_LIFECYCLE_REFRESH_THROTTLE_MS) {
+      return;
+    }
+
+    lastLifecycleRefreshAtRef.current = now;
+
+    if (options?.resetResizeCache) {
+      lastPostedTerminalHostSizeRef.current = null;
+      resizeSuppressUntilRef.current = now + 120;
+    }
+
+    if (options?.syncCurrentToken !== false) {
+      syncTerminalAuthToken();
+      scheduleTerminalResizeBurst();
+    }
+
+    setConnectionRefreshTick((current) => current + 1);
+  }, [expectsLiveTerminal, scheduleTerminalResizeBurst, syncTerminalAuthToken]);
+
   useEffect(() => {
     terminalUrlRef.current = terminalUrl;
   }, [terminalUrl]);
@@ -422,21 +452,13 @@ function SessionTerminalView(props: SessionTerminalProps) {
     if (!panelVisible) {
       return;
     }
-    // Radix keeps inactive tabs mounted but hidden (0×0). Cached host size would skip
-    // maybePostTerminalResize when the user returns — clear and refit after layout.
+    // When the terminal panel becomes visible again, silently refresh auth/cookie state
+    // instead of showing a blocking reload path. This keeps reconnects feeling attached
+    // to the same terminal surface.
     if (previous === false) {
-      lastPostedTerminalHostSizeRef.current = null;
-      if (typeof window !== "undefined") {
-        resizeSuppressUntilRef.current = window.Date.now() + 120;
-      }
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          syncTerminalAuthToken();
-          scheduleTerminalResizeBurst();
-        });
-      });
+      requestSilentConnectionRefresh({ resetResizeCache: true });
     }
-  }, [panelVisible, scheduleTerminalResizeBurst, syncTerminalAuthToken]);
+  }, [panelVisible, requestSilentConnectionRefresh]);
 
   const requestLifecycleRefresh = useCallback(() => {
     if (!expectsLiveTerminal || typeof window === "undefined") {
@@ -444,30 +466,16 @@ function SessionTerminalView(props: SessionTerminalProps) {
     }
 
     const now = window.Date.now();
-    if (now - lastLifecycleRefreshAtRef.current < TERMINAL_LIFECYCLE_REFRESH_THROTTLE_MS) {
-      return;
-    }
-    lastLifecycleRefreshAtRef.current = now;
-
     const hiddenDuration = pageHiddenAtRef.current === null
       ? 0
       : now - pageHiddenAtRef.current;
     pageHiddenAtRef.current = null;
 
-    // Do not bump connectionRefreshTick here: refetching the token endpoint on every
-    // focus/visibility event causes resolving-state flicker and fights the iframe.
-    // Token rotation stays on its timer; we only re-sync the known token and refit xterm.
-    syncTerminalAuthToken();
-    scheduleTerminalResizeBurst();
-    if (
-      hiddenDuration >= TERMINAL_LIFECYCLE_REATTACH_THRESHOLD_MS
-      && frameLoadedRef.current
-      && terminalUrlRef.current
-    ) {
-      forceTerminalReloadRef.current = true;
-      setConnectionRefreshTick((current) => current + 1);
-    }
-  }, [expectsLiveTerminal, scheduleTerminalResizeBurst, syncTerminalAuthToken]);
+    requestSilentConnectionRefresh({
+      force: hiddenDuration > 0,
+      resetResizeCache: hiddenDuration > 0,
+    });
+  }, [expectsLiveTerminal, requestSilentConnectionRefresh]);
 
   useEffect(() => {
     if (typeof window === "undefined" || typeof document === "undefined") {
@@ -494,8 +502,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
     };
 
     const handleOnline = () => {
-      // Network back: refresh token URL from the server (silent if already connected).
-      setConnectionRefreshTick((current) => current + 1);
+      requestLifecycleRefresh();
     };
 
     document.addEventListener("visibilitychange", handleVisibilityChange);
@@ -508,6 +515,31 @@ function SessionTerminalView(props: SessionTerminalProps) {
       window.removeEventListener("online", handleOnline);
     };
   }, [requestLifecycleRefresh]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleMessage = (event: MessageEvent) => {
+      if (!event.data || typeof event.data !== "object") {
+        return;
+      }
+      if ((event.data as { type?: string }).type !== TTYD_AUTH_TOKEN_REQUEST_MESSAGE_TYPE) {
+        return;
+      }
+      if (event.source !== ttydIframeRef.current?.contentWindow) {
+        return;
+      }
+
+      requestSilentConnectionRefresh();
+    };
+
+    window.addEventListener("message", handleMessage);
+    return () => {
+      window.removeEventListener("message", handleMessage);
+    };
+  }, [requestSilentConnectionRefresh]);
 
   useEffect(() => {
     if (!pendingInsert || pendingInsert.nonce <= lastAppliedInsertNonceRef.current) {

--- a/packages/web/src/components/sessions/SessionTerminal.tsx
+++ b/packages/web/src/components/sessions/SessionTerminal.tsx
@@ -262,6 +262,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
     force?: boolean;
     resetResizeCache?: boolean;
     syncCurrentToken?: boolean;
+    resolveConnection?: boolean;
   }) => {
     if (!expectsLiveTerminal || typeof window === "undefined") {
       return;
@@ -285,7 +286,9 @@ function SessionTerminalView(props: SessionTerminalProps) {
       scheduleTerminalResizeBurst();
     }
 
-    setConnectionRefreshTick((current) => current + 1);
+    if (options?.resolveConnection) {
+      setConnectionRefreshTick((current) => current + 1);
+    }
   }, [expectsLiveTerminal, scheduleTerminalResizeBurst, syncTerminalAuthToken]);
 
   useEffect(() => {
@@ -456,7 +459,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
     // instead of showing a blocking reload path. This keeps reconnects feeling attached
     // to the same terminal surface.
     if (previous === false) {
-      requestSilentConnectionRefresh({ resetResizeCache: true });
+      requestSilentConnectionRefresh({ resetResizeCache: true, resolveConnection: false });
     }
   }, [panelVisible, requestSilentConnectionRefresh]);
 
@@ -471,9 +474,13 @@ function SessionTerminalView(props: SessionTerminalProps) {
       : now - pageHiddenAtRef.current;
     pageHiddenAtRef.current = null;
 
+    // Passive lifecycle events should keep the current terminal identity hot without
+    // minting a brand-new ttyd/relay target. If the embedded terminal actually lost
+    // its websocket, the iframe shim will request an active refresh explicitly.
     requestSilentConnectionRefresh({
       force: hiddenDuration > 0,
       resetResizeCache: hiddenDuration > 0,
+      resolveConnection: false,
     });
   }, [expectsLiveTerminal, requestSilentConnectionRefresh]);
 
@@ -532,7 +539,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
         return;
       }
 
-      requestSilentConnectionRefresh();
+      requestSilentConnectionRefresh({ force: true, resetResizeCache: true, resolveConnection: true });
     };
 
     window.addEventListener("message", handleMessage);

--- a/packages/web/src/components/sessions/SessionTerminal.tsx
+++ b/packages/web/src/components/sessions/SessionTerminal.tsx
@@ -168,6 +168,14 @@ function SessionTerminalView(props: SessionTerminalProps) {
   const frameLoadedRef = useRef(false);
   const pageHiddenAtRef = useRef<number | null>(null);
   const lastLifecycleRefreshAtRef = useRef(0);
+  const mountedAtRef = useRef(Date.now());
+  const firstFrameLoadedAtRef = useRef<number | null>(null);
+  const lastFrameLoadedAtRef = useRef<number | null>(null);
+  const iframeLoadCountRef = useRef(0);
+  const silentRefreshCountRef = useRef(0);
+  const resolvingRefreshCountRef = useRef(0);
+  const iframeRefreshRequestCountRef = useRef(0);
+  const retryCountRef = useRef(0);
 
   const normalizedSessionStatus = useMemo(
     () => sessionState.trim().toLowerCase(),
@@ -287,7 +295,10 @@ function SessionTerminalView(props: SessionTerminalProps) {
     }
 
     if (options?.resolveConnection) {
+      resolvingRefreshCountRef.current += 1;
       setConnectionRefreshTick((current) => current + 1);
+    } else {
+      silentRefreshCountRef.current += 1;
     }
   }, [expectsLiveTerminal, scheduleTerminalResizeBurst, syncTerminalAuthToken]);
 
@@ -320,6 +331,14 @@ function SessionTerminalView(props: SessionTerminalProps) {
     lastLifecycleRefreshAtRef.current = 0;
     resizeSuppressUntilRef.current = 0;
     lastPostedTerminalHostSizeRef.current = null;
+    firstFrameLoadedAtRef.current = null;
+    lastFrameLoadedAtRef.current = null;
+    iframeLoadCountRef.current = 0;
+    silentRefreshCountRef.current = 0;
+    resolvingRefreshCountRef.current = 0;
+    iframeRefreshRequestCountRef.current = 0;
+    retryCountRef.current = 0;
+    mountedAtRef.current = Date.now();
     clearBurstResizeTimers();
   }, [clearBurstResizeTimers, expectsLiveTerminal, sessionId]);
 
@@ -539,6 +558,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
         return;
       }
 
+      iframeRefreshRequestCountRef.current += 1;
       requestSilentConnectionRefresh({ force: true, resetResizeCache: true, resolveConnection: true });
     };
 
@@ -817,6 +837,21 @@ function SessionTerminalView(props: SessionTerminalProps) {
         connectionError,
         promptError,
         queuedInsertError,
+        metrics: {
+          mountedAt: new Date(mountedAtRef.current).toISOString(),
+          mountedAgeMs: Date.now() - mountedAtRef.current,
+          firstFrameLoadLatencyMs: firstFrameLoadedAtRef.current === null
+            ? null
+            : firstFrameLoadedAtRef.current - mountedAtRef.current,
+          lastFrameLoadAt: lastFrameLoadedAtRef.current === null
+            ? null
+            : new Date(lastFrameLoadedAtRef.current).toISOString(),
+          iframeLoadCount: iframeLoadCountRef.current,
+          silentRefreshCount: silentRefreshCountRef.current,
+          resolvingRefreshCount: resolvingRefreshCountRef.current,
+          iframeRequestedRefreshCount: iframeRefreshRequestCountRef.current,
+          retryCount: retryCountRef.current,
+        },
       }),
     };
 
@@ -840,6 +875,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
   ]);
 
   const handleRetry = useCallback(() => {
+    retryCountRef.current += 1;
     setConnectionError(null);
     retryAttemptRef.current = 0;
     forceTerminalReloadRef.current = true;
@@ -968,6 +1004,12 @@ function SessionTerminalView(props: SessionTerminalProps) {
                 setConnectionError("Failed to load the terminal frame. Try reload or open in a new tab.");
               }}
               onLoad={() => {
+                const now = Date.now();
+                iframeLoadCountRef.current += 1;
+                lastFrameLoadedAtRef.current = now;
+                if (firstFrameLoadedAtRef.current === null) {
+                  firstFrameLoadedAtRef.current = now;
+                }
                 setFrameLoaded(true);
                 setConnectionError(null);
                 applyKeyboardAwareTerminalHeight();

--- a/packages/web/src/components/sessions/terminal/terminalTypes.ts
+++ b/packages/web/src/components/sessions/terminal/terminalTypes.ts
@@ -35,5 +35,13 @@ declare global {
       sessionId: string;
       getState: () => Record<string, unknown>;
     };
+    __conductorDispatcherDebug?: {
+      sessionId: string;
+      getState: () => Record<string, unknown>;
+    };
+    __conductorSessionPreviewDebug?: {
+      sessionId: string;
+      getState: () => Record<string, unknown>;
+    };
   }
 }

--- a/packages/web/src/features/dashboard/DashboardClient.tsx
+++ b/packages/web/src/features/dashboard/DashboardClient.tsx
@@ -2357,8 +2357,8 @@ export default function DashboardClient({
                 key={sessionId}
                 aria-hidden={!sessionActive}
                 className={sessionActive
-                  ? "relative h-full min-w-0"
-                  : "pointer-events-none absolute inset-0 overflow-hidden invisible"}
+                  ? "relative z-10 h-full min-w-0"
+                  : "pointer-events-none absolute inset-0 overflow-hidden opacity-0 select-none"}
               >
                 <SessionDetail
                   sessionId={sessionId}

--- a/packages/web/src/features/dashboard/DashboardClient.tsx
+++ b/packages/web/src/features/dashboard/DashboardClient.tsx
@@ -2252,15 +2252,33 @@ export default function DashboardClient({
               ) : null}
               {selectedSessionId ? (
                 dockedBoardSession ? (
-                  <SessionDetail
-                    key={selectedSessionId}
-                    sessionId={selectedSessionId}
-                    initialSession={dockedBoardSession}
-                    bridgeId={effectiveBridgeId}
-                    active
-                    suppressPreviewAutoOpen={launchpadSessionIdRef.current === selectedSessionId}
-                    immersiveMobileMode={immersiveMobileMode}
-                  />
+                  <div className="relative min-h-0 h-full min-w-0 flex-1 overflow-hidden">
+                    {mountedSessionIds.map((sessionId) => {
+                      const sessionActive = sessionId === selectedSessionId;
+                      const initialSession = sessionActive ? dockedBoardSession : sessionsById.get(sessionId) ?? null;
+                      if (!initialSession || initialSession.projectId !== selectedProject.id) {
+                        return null;
+                      }
+                      return (
+                        <div
+                          key={sessionId}
+                          aria-hidden={!sessionActive}
+                          className={sessionActive
+                            ? "relative z-10 h-full min-w-0"
+                            : "pointer-events-none absolute inset-0 overflow-hidden opacity-0 select-none"}
+                        >
+                          <SessionDetail
+                            sessionId={sessionId}
+                            initialSession={initialSession}
+                            bridgeId={effectiveBridgeId}
+                            active={sessionActive}
+                            suppressPreviewAutoOpen={sessionActive && launchpadSessionIdRef.current === sessionId}
+                            immersiveMobileMode={sessionActive && immersiveMobileMode}
+                          />
+                        </div>
+                      );
+                    })}
+                  </div>
                 ) : (
                   <div className="flex h-full items-center justify-center bg-[var(--vk-bg-panel)] text-[13px] text-[var(--vk-text-muted)]">
                     Loading session workspace...
@@ -2317,11 +2335,14 @@ export default function DashboardClient({
     dockedBoardSession,
     effectiveBridgeId,
     handleToggleDispatcherCollapsed,
+    immersiveMobileMode,
+    mountedSessionIds,
     navigateDashboard,
     resolvedCodingAgent,
     selectedProject,
     selectedProjectSessions,
     selectedSessionId,
+    sessionsById,
     wideBoardViewport,
     workspaceMainPanel,
     workspaceView,

--- a/packages/web/src/lib/bridgeTtyd.test.ts
+++ b/packages/web/src/lib/bridgeTtyd.test.ts
@@ -32,12 +32,16 @@ test("injectBridgeTtydRelayShim rewrites ttyd websocket connects through relay",
 
   assert.match(injected, /conductor-bridge-ttyd-relay-shim/);
   assert.match(injected, /RELAY_TTYD_WS_URL/);
+  assert.match(injected, /REQUEST_MESSAGE_TYPE = 'conductor-ttyd-auth-token-request'/);
+  assert.match(injected, /TOKEN_REQUEST_THROTTLE_MS = 1500/);
   assert.match(injected, /LOOPBACK_HOSTS/);
   assert.match(injected, /candidate\.hostname/);
   assert.match(injected, /candidate\.pathname === '\/'/);
   assert.match(injected, /candidate\.pathname === '\/ws'/);
   assert.match(injected, /candidate\.pathname\.endsWith\('\/ws'\)/);
   assert.match(injected, /normalizedUrl = RELAY_TTYD_WS_URL/);
+  assert.match(injected, /requestFreshRelay\('bridge-websocket-close'\)/);
+  assert.match(injected, /requestFreshRelay\('bridge-websocket-error'\)/);
   assert.ok(
     injected.indexOf("conductor-bridge-ttyd-relay-shim") < injected.indexOf("<script src=\"/refresh.js\">"),
     "relay shim should be injected before ttyd bootstrap scripts",

--- a/packages/web/src/lib/bridgeTtyd.ts
+++ b/packages/web/src/lib/bridgeTtyd.ts
@@ -375,9 +375,43 @@ export function injectBridgeTtydRelayShim(html: string, relayTtydWsUrl: string):
   const RELAY_TTYD_WS_URL = ${relayWsLiteral};
   if (!RELAY_TTYD_WS_URL) return;
 
+  const REQUEST_MESSAGE_TYPE = 'conductor-ttyd-auth-token-request';
+  const TOKEN_REQUEST_THROTTLE_MS = 1500;
   const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
   const previousWebSocket = window.WebSocket;
   if (typeof previousWebSocket !== 'function') return;
+
+  let lastTokenRequestAt = 0;
+  let unloading = false;
+
+  function requestFreshRelay(reason) {
+    if (unloading || !window.parent || window.parent === window) return;
+
+    const now = Date.now();
+    if (now - lastTokenRequestAt < TOKEN_REQUEST_THROTTLE_MS) return;
+    lastTokenRequestAt = now;
+
+    try {
+      window.parent.postMessage({
+        type: REQUEST_MESSAGE_TYPE,
+        reason,
+      }, '*');
+    } catch {
+    }
+  }
+
+  function attachSocketListeners(socket) {
+    if (!socket || socket.__conductorTokenRefreshHookAttached) return socket;
+
+    socket.__conductorTokenRefreshHookAttached = true;
+    socket.addEventListener('close', function() {
+      requestFreshRelay('bridge-websocket-close');
+    });
+    socket.addEventListener('error', function() {
+      requestFreshRelay('bridge-websocket-error');
+    });
+    return socket;
+  }
 
   const patchedWebSocket = function(url, protocols) {
     let normalizedUrl = String(url);
@@ -395,14 +429,18 @@ export function injectBridgeTtydRelayShim(html: string, relayTtydWsUrl: string):
     }
 
     if (arguments.length > 1) {
-      return new previousWebSocket(normalizedUrl, protocols);
+      return attachSocketListeners(new previousWebSocket(normalizedUrl, protocols));
     }
-    return new previousWebSocket(normalizedUrl);
+    return attachSocketListeners(new previousWebSocket(normalizedUrl));
   };
 
   Object.setPrototypeOf(patchedWebSocket, previousWebSocket);
   patchedWebSocket.prototype = previousWebSocket.prototype;
   window.WebSocket = patchedWebSocket;
+
+  window.addEventListener('beforeunload', function() {
+    unloading = true;
+  }, { once: true });
 })();
 </script>`;
 


### PR DESCRIPTION
## Summary

This PR hardens Conductor's workspace continuity across the terminal, dispatcher, and preview surfaces. It keeps terminal identity stable across tab switches, reconnects, and browser reattachs; reduces dispatcher stream churn and duplicate feed rows after reconnect; and refactors the preview workspace into a leaner browser-plus-inspector layout while preserving the underlying iframe/worker model.

Related: none

## User-Facing Release Notes

- Terminal sessions now stay stable more often when you switch tabs, switch sessions, return to the app, or recover from transient reconnects.
- Dispatcher chat streams are more resilient, with fewer duplicate rows and less chance of losing visible conversation state after a reconnect or refresh.
- The preview tab now stays mounted more reliably and uses a cleaner browser-style workspace with Elements, Console, and Network inspector tabs.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Plugin addition / modification
- [x] Documentation update
- [x] Refactor / chore

## Checklist

- [x] Equivalent root `bun run build` passes with no errors
- [x] Equivalent root `bun run typecheck` passes with no errors
- [x] No `any` types introduced without justification
- [ ] New plugins implement the appropriate `PluginModule` interface
- [x] No secrets or credentials committed
- [x] User-facing release notes are filled in plain English or marked internal-only
- [x] PR title follows conventional commits (`feat:`, `fix:`, `chore:`, etc.)

## Testing

```bash
# Commands I used to verify this works:
bun run typecheck
bun run build
bun run --cwd packages/web test
cargo test -p conductor-relay -- --nocapture
cargo test -p conductor-server inject_ttyd_auth_sync_shim -- --nocapture
```

## Screenshots / Demo

- Not included in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Terminal sessions preserve identity and can be reused after browser disconnects with a short reattach grace window.
  - Preview adds an inspector (elements/console/network) and keeps preview subtree mounted; dispatcher/components support an optional active prop and pause live updates when inactive/hidden.
  - Multiple session details are kept mounted in the dashboard to preserve live surfaces.

* **Bug Fixes**
  - More reliable token-refresh / silent reconnect on websocket close/error, unload, and visibility changes.
  - Missing-session preview responses now return a consistent disconnected status and trigger session cleanup.

* **Documentation**
  - Added terminal architecture review and workspace soak checklist.

* **Tests**
  - New tests for terminal reuse, grace-window behavior, session cleanup, preview missing-session handling, and dispatcher feed updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->