### PR TITLE
fix(web): dashboard Review tab routing and Preview layout

### DIFF
--- a/packages/web/src/components/sessions/SessionDetail.tsx
+++ b/packages/web/src/components/sessions/SessionDetail.tsx
@@ -4,6 +4,7 @@ import dynamic from "next/dynamic";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
+  GitCompare,
   Globe,
   LayoutDashboard,
   Puzzle,
@@ -46,6 +47,18 @@ const SessionPreview = dynamic(
   },
 );
 
+const SessionDiff = dynamic(
+  () => import("./SessionDiff").then((mod) => mod.SessionDiff),
+  {
+    loading: () => (
+      <div className="flex h-full min-h-[240px] items-center justify-center text-[13px] text-[var(--vk-text-muted)]">
+        Loading review…
+      </div>
+    ),
+    ssr: false,
+  },
+);
+
 const SessionSkills = dynamic(
   () => import("./SessionSkills").then((mod) => mod.SessionSkills),
   {
@@ -78,7 +91,7 @@ interface SessionDetailProps {
   onOpenSidebar?: () => void;
 }
 
-type SessionTab = "overview" | "dispatcher" | "terminal" | "preview" | "skills";
+type SessionTab = "overview" | "diff" | "dispatcher" | "terminal" | "preview" | "skills";
 
 const STANDARD_TAB_PANEL_CLASS_NAME = "min-h-0 h-full min-w-0 w-full overflow-hidden focus-visible:outline-none [&[hidden]]:block data-[state=inactive]:pointer-events-none data-[state=inactive]:absolute data-[state=inactive]:inset-0 data-[state=inactive]:invisible data-[state=inactive]:opacity-0";
 // Keep terminal-like surfaces painted with opacity only. `visibility:hidden` was causing browser-level
@@ -90,7 +103,7 @@ function resolveSessionTab(
   session: Pick<DashboardSession, "metadata"> | null | undefined,
 ): SessionTab {
   const defaultTab = getDefaultSessionPrimaryTab(session);
-  if (value === "overview" || value === "preview" || value === "skills") {
+  if (value === "overview" || value === "preview" || value === "skills" || value === "diff") {
     return value;
   }
   if (value === "dispatcher") {
@@ -278,6 +291,7 @@ export function SessionDetail({
   const showProjectOpenMenu = status !== "queued" && status !== "spawning";
   const immersiveTerminalActive = active && immersiveMobileMode && activeTab === "terminal";
   const previewTabActive = active && activeTab === "preview";
+  const reviewTabActive = active && activeTab === "diff";
   const tabTriggerClass = "min-h-[38px] gap-1.5 px-2.5 text-[12px] sm:min-h-0 sm:px-3";
   const compactDisplaySessionId = useMemo(
     () => getDisplaySessionId(sessionId).slice(0, 7),
@@ -289,6 +303,10 @@ export function SessionDetail({
       <TabsTrigger value="overview" className={tabTriggerClass}>
         <LayoutDashboard className="h-3.5 w-3.5" />
         Overview
+      </TabsTrigger>
+      <TabsTrigger value="diff" className={tabTriggerClass}>
+        <GitCompare className="h-3.5 w-3.5" />
+        Review
       </TabsTrigger>
       {dispatcherSession ? (
         <TabsTrigger value="dispatcher" className={tabTriggerClass}>
@@ -372,6 +390,13 @@ export function SessionDetail({
             <SessionOverview session={session} sessionId={sessionId} active={active && activeTab === "overview"} />
           </TabsContent>
 
+          <TabsContent
+            value="diff"
+            className={`${STANDARD_TAB_PANEL_CLASS_NAME} flex min-h-0 flex-col`}
+          >
+            <SessionDiff sessionId={sessionId} active={reviewTabActive} />
+          </TabsContent>
+
           {dispatcherSession ? (
             <TabsContent
               value="dispatcher"
@@ -410,7 +435,7 @@ export function SessionDetail({
           <TabsContent
             value="preview"
             forceMount
-            className={PRESERVE_LIVE_SURFACE_TAB_PANEL_CLASS_NAME}
+            className={`${PRESERVE_LIVE_SURFACE_TAB_PANEL_CLASS_NAME} flex min-h-0 flex-col`}
           >
             <SessionPreview
               key={sessionId}

--- a/packages/web/src/components/sessions/SessionDiff.tsx
+++ b/packages/web/src/components/sessions/SessionDiff.tsx
@@ -1032,7 +1032,7 @@ export function SessionDiff({ sessionId, active }: SessionDiffProps) {
   }, [isMobileViewport]);
 
   const listPane = (
-    <div className="min-h-0 overflow-y-auto overscroll-contain lg:border-r lg:border-[var(--vk-border)]">
+    <div className="flex min-h-0 h-full max-h-full flex-col overflow-y-auto overscroll-contain lg:border-r lg:border-[var(--vk-border)]">
       <div className="py-1">
         {visibleEntries.map((entry) => {
           const isSelected = entry.fileKey === selectedFileKey;

--- a/packages/web/src/components/sessions/SessionOverview.tsx
+++ b/packages/web/src/components/sessions/SessionOverview.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import dynamic from "next/dynamic";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ArrowLeft,
@@ -21,18 +20,6 @@ import {
 import type { DashboardSession } from "@/lib/types";
 import { AgentTileIcon } from "@/components/AgentTileIcon";
 
-const SessionDiff = dynamic(
-  () => import("./SessionDiff").then((mod) => mod.SessionDiff),
-  {
-    loading: () => (
-      <div className="flex h-32 items-center justify-center text-[12px] text-[var(--vk-text-muted)]">
-        Loading changes…
-      </div>
-    ),
-    ssr: false,
-  },
-);
-
 type SessionData = DashboardSession & {
   agent?: string;
   worktree?: string | null;
@@ -48,8 +35,6 @@ interface SessionOverviewProps {
   sessionId: string;
   active: boolean;
 }
-
-type OverviewTab = "changes" | "files";
 
 /* ─── File tree types ───────────────────────────────────────────────── */
 
@@ -754,8 +739,6 @@ function FilesBrowser({ sessionId, active }: { sessionId: string; active: boolea
 /* ─── Main Overview component ───────────────────────────────────────── */
 
 export function SessionOverview({ session, sessionId, active }: SessionOverviewProps) {
-  const [innerTab, setInnerTab] = useState<OverviewTab>("changes");
-
   const prompt = useMemo(
     () => (
       pickMetadata(session, "task")
@@ -842,39 +825,15 @@ export function SessionOverview({ session, sessionId, active }: SessionOverviewP
         ) : null}
       </div>
 
-      {/* Inner tab switcher: Changes | Files */}
-      <div className="flex shrink-0 items-center gap-0 border-b border-white/8 px-2">
-        <button
-          type="button"
-          onClick={() => setInnerTab("changes")}
-          className={`px-3 py-2 text-[12px] font-medium transition-colors ${
-            innerTab === "changes"
-              ? "border-b-2 border-[var(--vk-orange)] text-[var(--vk-text-strong)]"
-              : "border-b-2 border-transparent text-[var(--vk-text-muted)] hover:text-[var(--vk-text-normal)]"
-          }`}
-        >
-          Changes
-        </button>
-        <button
-          type="button"
-          onClick={() => setInnerTab("files")}
-          className={`px-3 py-2 text-[12px] font-medium transition-colors ${
-            innerTab === "files"
-              ? "border-b-2 border-[var(--vk-orange)] text-[var(--vk-text-strong)]"
-              : "border-b-2 border-transparent text-[var(--vk-text-muted)] hover:text-[var(--vk-text-normal)]"
-          }`}
-        >
-          Files
-        </button>
-      </div>
-
-      {/* Tab content */}
-      <div className="min-h-0 min-w-0 flex-1 overflow-y-auto overscroll-contain">
-        {innerTab === "changes" ? (
-          <SessionDiff key={sessionId} sessionId={sessionId} active={active} />
-        ) : (
-          <FilesBrowser sessionId={sessionId} active={active && innerTab === "files"} />
-        )}
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden border-t border-white/8">
+        <div className="shrink-0 border-b border-white/8 px-3 py-2">
+          <p className="text-[11px] font-medium uppercase tracking-wide text-[var(--vk-text-muted)]">
+            Workspace files
+          </p>
+        </div>
+        <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
+          <FilesBrowser sessionId={sessionId} active={active} />
+        </div>
       </div>
     </div>
   );

--- a/packages/web/src/components/sessions/SessionPreview.tsx
+++ b/packages/web/src/components/sessions/SessionPreview.tsx
@@ -866,8 +866,8 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
   }, [status?.selectedElement?.selector]);
 
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-[8px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)]">
-      <div className="border-b border-[var(--vk-border)] px-3 py-3">
+    <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-[8px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)]">
+      <div className="shrink-0 border-b border-[var(--vk-border)] px-3 py-3">
         <div className="flex flex-col gap-3">
           <div className="flex flex-wrap items-center gap-2">
             <div className="flex items-center gap-2">
@@ -1003,8 +1003,8 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
         </div>
       </div>
 
-      <div className="grid min-h-0 flex-1 lg:grid-cols-[minmax(0,1.55fr)_minmax(320px,0.95fr)]">
-        <div className="flex min-h-0 flex-col border-b border-[var(--vk-border)] lg:border-b-0 lg:border-r">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden lg:grid lg:min-h-0 lg:grid-cols-[minmax(0,1.55fr)_minmax(320px,0.95fr)] lg:overflow-hidden">
+        <div className="flex min-h-0 min-w-0 flex-[1.25] flex-col overflow-hidden border-b border-[var(--vk-border)] lg:flex-1 lg:border-b-0 lg:border-r">
           <div className="flex items-center justify-between gap-2 border-b border-[var(--vk-border)] px-3 py-2 text-[11px] text-[var(--vk-text-muted)]">
             <div className="min-w-0">
               <div className="truncate text-[var(--vk-text-normal)]">
@@ -1016,8 +1016,8 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
             ) : null}
           </div>
 
-          <div className="min-h-0 flex-1 overflow-auto bg-[#0f1012] p-3">
-            <div className="flex h-full min-h-[260px] items-center justify-center">
+          <div className="min-h-0 flex-1 overflow-auto overscroll-contain bg-[#0f1012] p-3">
+            <div className="flex h-full min-h-[min(200px,45vh)] w-full items-center justify-center lg:min-h-[260px]">
               {loading ? (
                 <div className="flex items-center gap-2 text-[13px] text-[var(--vk-text-muted)]">
                   <Loader2 className="h-4 w-4 animate-spin" />
@@ -1087,7 +1087,7 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
         <Tabs
           value={previewInspectorTab}
           onValueChange={(value) => setPreviewInspectorTab(value as "elements" | "console" | "network")}
-          className="flex min-h-0 flex-1 flex-col overflow-hidden"
+          className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden lg:min-h-0"
         >
           <div className="border-b border-[var(--vk-border)] px-2 py-2">
             <TabsList className="w-full justify-start border-0 bg-transparent p-0">

--- a/packages/web/src/components/sessions/sessionDetailBehavior.test.ts
+++ b/packages/web/src/components/sessions/sessionDetailBehavior.test.ts
@@ -36,4 +36,15 @@ test("shouldAutoOpenPreviewTab only opens preview for active terminal sessions",
     }),
     false,
   );
+
+  assert.equal(
+    shouldAutoOpenPreviewTab({
+      active: true,
+      activeTab: "diff",
+      alreadyOpened: false,
+      connected: true,
+      suppressAutoOpen: false,
+    }),
+    false,
+  );
 });


### PR DESCRIPTION
## Summary
- **Review (`tab=diff`)**: Session detail now exposes a dedicated **Review** tab wired to `SessionDiff`, so deep links and the sidebar diff control land on the real review UI instead of falling through to terminal/dispatcher.
- **Overview**: Removes the nested Changes/Files toggle; Overview is task metadata plus **Workspace files**. Code review lives on **Review**.
- **Preview tab**: Adds a proper flex/`min-h-0` height chain from `SessionDetail` into `SessionPreview`, and adjusts the browser vs inspector split so the preview panel scrolls and fills correctly on mobile and desktop.
- **Tests**: `sessionDetailBehavior` test asserts preview auto-open does not run when `activeTab === "diff"`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## User-Facing Release Notes
- Fixed session **Review** (`?tab=diff`) so it opens the diff/review panel instead of ignoring the tab parameter.
- **Overview** now focuses on the task summary and file browser; use the **Review** tab for change lists and diffs.
- **Preview** tab layout is more reliable (correct height, better split between screenshot and inspector on small and large screens).


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Review" tab to session details for viewing session changes.

* **Refactor**
  * Simplified session overview by consolidating "Changes vs Files" tabs into a single "Workspace files" panel.

* **Style**
  * Improved flex layout, sizing, and overflow behavior across session detail components.

* **Tests**
  * Added test coverage for the new review tab functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->