### PR TITLE
fix: clean up terminal action chrome

### DIFF
--- a/packages/web/src/components/sessions/SessionTerminal.tsx
+++ b/packages/web/src/components/sessions/SessionTerminal.tsx
@@ -19,7 +19,6 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState, type ChangeEve
 import { Button } from "@/components/ui/Button";
 import { uploadProjectAttachments } from "@/components/sessions/attachmentUploads";
 import { withBridgeQuery } from "@/lib/bridgeQuery";
-import { cn } from "@/lib/cn";
 import { LIVE_TERMINAL_STATUSES, RESUMABLE_STATUSES } from "./terminal/terminalConstants";
 import { resolveTerminalConnection } from "./terminal/terminalApi";
 import { extractTerminalAuthToken } from "./terminal/terminalToken";
@@ -948,7 +947,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
         ? "group/terminal relative flex min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden bg-[#060404]"
         : "group/terminal relative flex min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden rounded-none border-0 bg-[#060404] lg:rounded-[14px] lg:border lg:border-white/10 lg:shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]"}
     >
-      <div className="absolute right-2 top-2 z-10 flex items-center gap-2 sm:right-3 sm:top-3">
+      <div className="absolute right-2 top-2 z-20 flex items-center gap-2 sm:right-3 sm:top-3">
         <input
           ref={attachmentInputRef}
           type="file"
@@ -1028,38 +1027,6 @@ function SessionTerminalView(props: SessionTerminalProps) {
             ref={terminalHostRef}
             className="relative flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden rounded-[10px] bg-[#060404] pb-[env(safe-area-inset-bottom)]"
           >
-            <div className="relative z-20 flex items-center justify-between gap-2 border-b border-white/8 bg-[#0f0b0b]/92 px-3 py-2 text-[11px] text-[#c9c0b7]">
-              <div className="flex min-w-0 flex-wrap items-center gap-2">
-                <span className="rounded-[999px] border border-white/10 bg-[#181212] px-2 py-0.5 uppercase tracking-wide text-[#efe8e1]">
-                  {normalizedRuntimeMode ?? "agent"}
-                </span>
-                <span className={cn(
-                  "rounded-[999px] px-2 py-0.5 uppercase tracking-wide",
-                  resolvingConnection
-                    ? "bg-[color:color-mix(in_srgb,#f59e0b_18%,transparent)] text-[#f7c56f]"
-                    : frameLoaded
-                      ? "bg-[color:color-mix(in_srgb,#22c55e_18%,transparent)] text-[#7ce8a0]"
-                      : "bg-[color:color-mix(in_srgb,#94a3b8_16%,transparent)] text-[#c9c0b7]",
-                )}>
-                  {resolvingConnection ? "reconnecting" : frameLoaded ? "live" : "loading"}
-                </span>
-                {sessionState ? (
-                  <span className="truncate text-[#8f857d]">{sessionState}</span>
-                ) : null}
-              </div>
-              <div className="flex items-center gap-2">
-                {terminalLinkUrl ? (
-                  <a
-                    href={terminalLinkUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-[#c9c0b7] underline-offset-4 hover:text-[#efe8e1] hover:underline"
-                  >
-                    Open in new tab
-                  </a>
-                ) : null}
-              </div>
-            </div>
             {!frameLoaded ? (
               <div className="absolute inset-0 z-10 flex items-center justify-center bg-[#060404]">
                 <div className="flex items-center gap-2 rounded-full border border-white/10 bg-[#141010]/92 px-3 py-2 text-[12px] text-[#c9c0b7] backdrop-blur-sm">

--- a/packages/web/src/components/sessions/SessionTerminal.tsx
+++ b/packages/web/src/components/sessions/SessionTerminal.tsx
@@ -8,8 +8,9 @@
 import {
   AlertCircle,
   Clipboard,
+  ExternalLink,
+  FileUp,
   Loader2,
-  Link2,
   RefreshCw,
   Send,
   SquareStop,
@@ -974,9 +975,26 @@ function SessionTerminalView(props: SessionTerminalProps) {
           {attachmentUploading ? (
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
           ) : (
-            <Link2 className="h-3.5 w-3.5" />
+            <FileUp className="h-3.5 w-3.5" />
           )}
         </Button>
+        {terminalHref ? (
+          <Button
+            asChild
+            size="icon"
+            variant="ghost"
+            className="h-9 w-9 rounded-full border border-white/10 bg-[#141010]/92 text-[#c9c0b7] backdrop-blur-sm hover:bg-[#201818] sm:h-7 sm:w-7"
+          >
+            <a
+              href={terminalHref}
+              target="_blank"
+              rel="noreferrer"
+              aria-label="Open terminal in new tab"
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+          </Button>
+        ) : null}
         {typeof window !== "undefined" && window.matchMedia?.("(pointer: coarse)").matches ? (
           <Button
             type="button"


### PR DESCRIPTION
## Summary

This PR finishes the terminal chrome cleanup after the merged workspace polish PR. It removes the extra ttyd status banner row that was crowding the terminal pane, restores open-in-new-tab as a compact floating action, and switches the attachment control back to an upload-style icon.

## User-Facing Release Notes

- The terminal no longer shows an extra ttyd status banner row at the top.
- Open in new tab is now a compact floating external-link action next to the other terminal controls.
- The attachment control now uses an upload-style icon again instead of a link-style icon.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Plugin addition / modification
- [ ] Documentation update
- [ ] Refactor / chore

## Checklist

- [x] `bun run --cwd packages/web typecheck` passes with no errors
- [x] `bun run --cwd packages/web build` passes with no errors
- [x] No secrets or credentials committed
- [x] User-facing release notes are filled in plain English
- [x] PR title follows conventional commits (`fix:`)

## Testing

```bash
bun run --cwd packages/web typecheck
bun run --cwd packages/web build
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added button to open session terminal in a new browser tab.

* **UI Improvements**
  * Simplified terminal interface by removing header bar.
  * Updated attachment button icon styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->