### PR TITLE
fix(terminal): P2 terminal robustness — visibility, reconnect limits, protocol handling

### DIFF
--- a/crates/conductor-relay/src/relay.rs
+++ b/crates/conductor-relay/src/relay.rs
@@ -1411,39 +1411,31 @@ impl RelayState {
                     }
                     TTYD_CMD_RESUME => {
                         info!(%terminal_id, "relay terminal browser sent RESUME");
-                        // Collect buffered messages and clear pause state under one lock.
-                        let buffered = {
+                        // Collect buffered messages, replay them, and forward RESUME — all
+                        // orchestrated from a SINGLE lock acquisition to prevent bridge frames
+                        // from racing between the pause_buffer drain and the state change.
+                        let bridge_tx = {
                             let mut inner = self.inner.lock().await;
                             if let Some(session) = inner.terminal_sessions.get_mut(terminal_id) {
-                                session.browser_paused = false;
-                                std::mem::take(&mut session.pause_buffer)
-                            } else {
-                                Vec::new()
-                            }
-                        };
-                        // Replay buffered messages to the browser.
-                        let browser_tx = {
-                            let inner = self.inner.lock().await;
-                            inner
-                                .terminal_sessions
-                                .get(terminal_id)
-                                .and_then(|s| s.browser.as_ref().map(|r| r.tx.clone()))
-                        };
-                        if let Some(tx) = browser_tx {
-                            for buffered_msg in buffered {
-                                if tx.send(buffered_msg).is_err() {
-                                    break;
+                                let buffered = std::mem::take(&mut session.pause_buffer);
+                                let browser_tx = session.browser.as_ref().map(|r| r.tx.clone());
+                                // Replay buffered messages WHILE still holding the lock so no
+                                // bridge frame can overtake or sneak into the drained buffer.
+                                if let Some(ref tx) = browser_tx {
+                                    for buffered_msg in buffered {
+                                        if tx.send(buffered_msg).is_err() {
+                                            break;
+                                        }
+                                    }
                                 }
+                                // Only NOW mark as un-paused — after replay is complete.
+                                session.browser_paused = false;
+                                session.bridge.as_ref().map(|r| r.tx.clone())
+                            } else {
+                                None
                             }
-                        }
-                        // Forward RESUME to bridge so upstream can also resume if supported.
-                        let bridge_tx = {
-                            let inner = self.inner.lock().await;
-                            inner
-                                .terminal_sessions
-                                .get(terminal_id)
-                                .and_then(|s| s.bridge.as_ref().map(|r| r.tx.clone()))
                         };
+                        // Lock is dropped; safe to forward RESUME to bridge.
                         if let Some(tx) = bridge_tx {
                             let _ = tx.send(Message::Binary(vec![TTYD_CMD_RESUME].into()));
                         }
@@ -1472,17 +1464,16 @@ impl RelayState {
         }
 
         // When the browser is paused, buffer bridge→browser output instead of forwarding.
+        // Check browser_paused AND append in a single lock acquisition to prevent TOCTOU races
+        // where a bridge frame could arrive between the check and the append.
         if peer_kind == TerminalPeerKind::Bridge {
-            let should_buffer = {
-                let inner = self.inner.lock().await;
-                inner
-                    .terminal_sessions
-                    .get(terminal_id)
-                    .map(|s| s.browser_paused)
-                    .unwrap_or(false)
-            };
+            let mut inner = self.inner.lock().await;
+            let should_buffer = inner
+                .terminal_sessions
+                .get(terminal_id)
+                .map(|s| s.browser_paused)
+                .unwrap_or(false);
             if should_buffer {
-                let mut inner = self.inner.lock().await;
                 if let Some(session) = inner.terminal_sessions.get_mut(terminal_id) {
                     if let Some(cloned) = clone_websocket_message(message) {
                         if session.pause_buffer.len() >= TERMINAL_PAUSE_BUFFER_CAPACITY {

--- a/crates/conductor-relay/src/relay.rs
+++ b/crates/conductor-relay/src/relay.rs
@@ -1517,7 +1517,7 @@ impl RelayState {
     /// Returns the first byte for binary messages, or None for text/non-binary.
     fn extract_ttyd_command(message: &Message) -> Option<u8> {
         match message {
-            Message::Binary(data) if data.len() >= 1 => Some(data[0]),
+            Message::Binary(data) if !data.is_empty() => Some(data[0]),
             _ => None,
         }
     }

--- a/crates/conductor-relay/src/relay.rs
+++ b/crates/conductor-relay/src/relay.rs
@@ -1175,8 +1175,8 @@ impl RelayState {
                         bridge: None,
                         bridge_ready_waiters: vec![bridge_ready_tx],
                         browser_disconnected_at: None,
-                    browser_paused: false,
-                    pause_buffer: Vec::new(),
+                        browser_paused: false,
+                        pause_buffer: Vec::new(),
                     },
                 );
 
@@ -1399,7 +1399,9 @@ impl RelayState {
                         // Forward PAUSE to bridge so upstream can also pause if supported.
                         let bridge_tx = {
                             let inner = self.inner.lock().await;
-                            inner.terminal_sessions.get(terminal_id)
+                            inner
+                                .terminal_sessions
+                                .get(terminal_id)
                                 .and_then(|s| s.bridge.as_ref().map(|r| r.tx.clone()))
                         };
                         if let Some(tx) = bridge_tx {
@@ -1422,7 +1424,9 @@ impl RelayState {
                         // Replay buffered messages to the browser.
                         let browser_tx = {
                             let inner = self.inner.lock().await;
-                            inner.terminal_sessions.get(terminal_id)
+                            inner
+                                .terminal_sessions
+                                .get(terminal_id)
                                 .and_then(|s| s.browser.as_ref().map(|r| r.tx.clone()))
                         };
                         if let Some(tx) = browser_tx {
@@ -1435,7 +1439,9 @@ impl RelayState {
                         // Forward RESUME to bridge so upstream can also resume if supported.
                         let bridge_tx = {
                             let inner = self.inner.lock().await;
-                            inner.terminal_sessions.get(terminal_id)
+                            inner
+                                .terminal_sessions
+                                .get(terminal_id)
                                 .and_then(|s| s.bridge.as_ref().map(|r| r.tx.clone()))
                         };
                         if let Some(tx) = bridge_tx {
@@ -1448,10 +1454,14 @@ impl RelayState {
                         info!(%terminal_id, "relay terminal browser sent RESIZE");
                         let bridge_tx = {
                             let inner = self.inner.lock().await;
-                            inner.terminal_sessions.get(terminal_id)
+                            inner
+                                .terminal_sessions
+                                .get(terminal_id)
                                 .and_then(|s| s.bridge.as_ref().map(|r| r.tx.clone()))
                         };
-                        if let (Some(tx), Some(cloned)) = (bridge_tx, clone_websocket_message(message)) {
+                        if let (Some(tx), Some(cloned)) =
+                            (bridge_tx, clone_websocket_message(message))
+                        {
                             let _ = tx.send(cloned);
                         }
                         return;
@@ -1465,7 +1475,9 @@ impl RelayState {
         if peer_kind == TerminalPeerKind::Bridge {
             let should_buffer = {
                 let inner = self.inner.lock().await;
-                inner.terminal_sessions.get(terminal_id)
+                inner
+                    .terminal_sessions
+                    .get(terminal_id)
                     .map(|s| s.browser_paused)
                     .unwrap_or(false)
             };

--- a/crates/conductor-relay/src/relay.rs
+++ b/crates/conductor-relay/src/relay.rs
@@ -97,6 +97,11 @@ struct TerminalSessionRecord {
     bridge: Option<TerminalConnectionRecord>,
     bridge_ready_waiters: Vec<oneshot::Sender<()>>,
     browser_disconnected_at: Option<Instant>,
+    /// When true, the browser has sent a PAUSE frame and output from the bridge
+    /// should not be forwarded until a RESUME frame arrives.
+    browser_paused: bool,
+    /// Buffered output chunks received while the browser was paused, replayed on resume.
+    pause_buffer: Vec<Message>,
 }
 
 #[derive(Debug, Clone)]
@@ -130,6 +135,12 @@ struct ProxiedPreviewResponse {
 }
 
 const TERMINAL_SESSION_READY_TIMEOUT: Duration = Duration::from_secs(8);
+/// Maximum number of output chunks buffered while the browser peer is paused.
+const TERMINAL_PAUSE_BUFFER_CAPACITY: usize = 256;
+/// ttyd protocol command bytes (first byte of binary WebSocket message).
+const TTYD_CMD_RESIZE: u8 = b'1';
+const TTYD_CMD_PAUSE: u8 = b'2';
+const TTYD_CMD_RESUME: u8 = b'3';
 #[cfg(not(test))]
 const TERMINAL_BROWSER_REATTACH_GRACE: Duration = Duration::from_secs(15);
 #[cfg(test)]
@@ -1164,6 +1175,8 @@ impl RelayState {
                         bridge: None,
                         bridge_ready_waiters: vec![bridge_ready_tx],
                         browser_disconnected_at: None,
+                    browser_paused: false,
+                    pause_buffer: Vec::new(),
                     },
                 );
 
@@ -1372,6 +1385,105 @@ impl RelayState {
         peer_kind: TerminalPeerKind,
         message: &Message,
     ) {
+        // Handle PAUSE/RESUME control frames from the browser peer.
+        if peer_kind == TerminalPeerKind::Browser {
+            if let Some(cmd) = Self::extract_ttyd_command(message) {
+                match cmd {
+                    TTYD_CMD_PAUSE => {
+                        info!(%terminal_id, "relay terminal browser sent PAUSE");
+                        let mut inner = self.inner.lock().await;
+                        if let Some(session) = inner.terminal_sessions.get_mut(terminal_id) {
+                            session.browser_paused = true;
+                            session.pause_buffer.clear();
+                        }
+                        // Forward PAUSE to bridge so upstream can also pause if supported.
+                        let bridge_tx = {
+                            let inner = self.inner.lock().await;
+                            inner.terminal_sessions.get(terminal_id)
+                                .and_then(|s| s.bridge.as_ref().map(|r| r.tx.clone()))
+                        };
+                        if let Some(tx) = bridge_tx {
+                            let _ = tx.send(Message::Binary(vec![TTYD_CMD_PAUSE].into()));
+                        }
+                        return;
+                    }
+                    TTYD_CMD_RESUME => {
+                        info!(%terminal_id, "relay terminal browser sent RESUME");
+                        // Collect buffered messages and clear pause state under one lock.
+                        let buffered = {
+                            let mut inner = self.inner.lock().await;
+                            if let Some(session) = inner.terminal_sessions.get_mut(terminal_id) {
+                                session.browser_paused = false;
+                                std::mem::take(&mut session.pause_buffer)
+                            } else {
+                                Vec::new()
+                            }
+                        };
+                        // Replay buffered messages to the browser.
+                        let browser_tx = {
+                            let inner = self.inner.lock().await;
+                            inner.terminal_sessions.get(terminal_id)
+                                .and_then(|s| s.browser.as_ref().map(|r| r.tx.clone()))
+                        };
+                        if let Some(tx) = browser_tx {
+                            for buffered_msg in buffered {
+                                if tx.send(buffered_msg).is_err() {
+                                    break;
+                                }
+                            }
+                        }
+                        // Forward RESUME to bridge so upstream can also resume if supported.
+                        let bridge_tx = {
+                            let inner = self.inner.lock().await;
+                            inner.terminal_sessions.get(terminal_id)
+                                .and_then(|s| s.bridge.as_ref().map(|r| r.tx.clone()))
+                        };
+                        if let Some(tx) = bridge_tx {
+                            let _ = tx.send(Message::Binary(vec![TTYD_CMD_RESUME].into()));
+                        }
+                        return;
+                    }
+                    TTYD_CMD_RESIZE => {
+                        // Log and forward RESIZE frames from browser to bridge.
+                        info!(%terminal_id, "relay terminal browser sent RESIZE");
+                        let bridge_tx = {
+                            let inner = self.inner.lock().await;
+                            inner.terminal_sessions.get(terminal_id)
+                                .and_then(|s| s.bridge.as_ref().map(|r| r.tx.clone()))
+                        };
+                        if let (Some(tx), Some(cloned)) = (bridge_tx, clone_websocket_message(message)) {
+                            let _ = tx.send(cloned);
+                        }
+                        return;
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // When the browser is paused, buffer bridge→browser output instead of forwarding.
+        if peer_kind == TerminalPeerKind::Bridge {
+            let should_buffer = {
+                let inner = self.inner.lock().await;
+                inner.terminal_sessions.get(terminal_id)
+                    .map(|s| s.browser_paused)
+                    .unwrap_or(false)
+            };
+            if should_buffer {
+                let mut inner = self.inner.lock().await;
+                if let Some(session) = inner.terminal_sessions.get_mut(terminal_id) {
+                    if let Some(cloned) = clone_websocket_message(message) {
+                        if session.pause_buffer.len() >= TERMINAL_PAUSE_BUFFER_CAPACITY {
+                            session.pause_buffer.remove(0);
+                        }
+                        session.pause_buffer.push(cloned);
+                    }
+                }
+                return;
+            }
+        }
+
+        // Default: forward to the counterpart peer.
         let counterpart = {
             let inner = self.inner.lock().await;
             inner
@@ -1386,6 +1498,15 @@ impl RelayState {
 
         if let (Some(counterpart), Some(cloned)) = (counterpart, clone_websocket_message(message)) {
             let _ = counterpart.send(cloned);
+        }
+    }
+
+    /// Extract the ttyd command byte from a WebSocket message.
+    /// Returns the first byte for binary messages, or None for text/non-binary.
+    fn extract_ttyd_command(message: &Message) -> Option<u8> {
+        match message {
+            Message::Binary(data) if data.len() >= 1 => Some(data[0]),
+            _ => None,
         }
     }
 
@@ -3040,6 +3161,8 @@ mod tests {
                     }),
                     bridge_ready_waiters: vec![],
                     browser_disconnected_at: Some(Instant::now()),
+                    browser_paused: false,
+                    pause_buffer: Vec::new(),
                 },
             );
         }
@@ -3075,6 +3198,8 @@ mod tests {
                     bridge: Some(TerminalConnectionRecord { tx: bridge_tx }),
                     bridge_ready_waiters: vec![],
                     browser_disconnected_at: None,
+                    browser_paused: false,
+                    pause_buffer: Vec::new(),
                 },
             );
         }
@@ -3130,6 +3255,8 @@ mod tests {
                     bridge: Some(TerminalConnectionRecord { tx: bridge_tx }),
                     bridge_ready_waiters: vec![],
                     browser_disconnected_at: None,
+                    browser_paused: false,
+                    pause_buffer: Vec::new(),
                 },
             );
         }

--- a/crates/conductor-server/src/state/detached/ttyd_launcher.rs
+++ b/crates/conductor-server/src/state/detached/ttyd_launcher.rs
@@ -849,6 +849,9 @@ async fn run_ttyd_session_owner_with_retry(
                             "Terminal backend exhausted all reconnection attempts. The session may need to be restarted.".to_string()
                         ),
                     ).await;
+                    // Detach the terminal runtime so a subsequent restore_ttyd_runtime()
+                    // can create a fresh owner instead of finding a stale attachment.
+                    state.detach_terminal_runtime(sid).await;
                     return Ok(());
                 }
                 let delay = owner_reconnect_delay(attempt);

--- a/crates/conductor-server/src/state/detached/ttyd_launcher.rs
+++ b/crates/conductor-server/src/state/detached/ttyd_launcher.rs
@@ -36,7 +36,12 @@ const TTYD_OWNER_ATTACH_TIMEOUT: std::time::Duration = std::time::Duration::from
 const TTYD_OWNER_CONNECT_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(50);
 const TTYD_OWNER_RECONNECT_BASE_DELAY: std::time::Duration = std::time::Duration::from_millis(500);
 const TTYD_OWNER_RECONNECT_MAX_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
-const TTYD_OWNER_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(90);
+/// Maximum silence before considering the ttyd connection dead.
+/// ttyd sends pings every 30s (via --ping-interval), so 5 minutes of silence
+/// means ~10 missed pings, which is a clear sign the connection is gone.
+/// This replaces the old 90s read timeout which caused false disconnects
+/// during normal interactive idle periods.
+const TTYD_OWNER_SILENCE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
 /// Maximum reconnect attempts before giving up permanently.
 /// Prevents unbounded retry loops and output consumer task leaks.
 const TTYD_OWNER_RECONNECT_MAX_ATTEMPTS: u32 = 20;
@@ -836,6 +841,14 @@ async fn run_ttyd_session_owner_with_retry(
                         attempts = attempt,
                         "ttyd session owner exceeded max reconnect attempts, giving up"
                     );
+                    // Notify all connected frontend clients that the terminal backend
+                    // has failed, instead of silently dying and leaving a frozen terminal.
+                    state.emit_terminal_stream_event(
+                        sid,
+                        crate::state::types::TerminalStreamEvent::Error(
+                            "Terminal backend exhausted all reconnection attempts. The session may need to be restarted.".to_string()
+                        ),
+                    ).await;
                     return Ok(());
                 }
                 let delay = owner_reconnect_delay(attempt);
@@ -927,9 +940,23 @@ async fn run_ttyd_session_owner(
         }
     };
     let (mut w, mut r) = ws.split();
+    // Use the last-known terminal dimensions from the state store instead of
+    // hardcoded 160x48. This prevents a jarring resize flash on reconnect.
+    let (init_cols, init_rows) = state
+        .terminal_hosts
+        .get(sid)
+        .await
+        .and_then(|handle| {
+            handle
+                .terminal_store
+                .lock()
+                .ok()
+                .map(|store| store.dimensions())
+        })
+        .unwrap_or((160, 48));
     if let Err(err) = w
         .send(WsMessage::Binary(
-            ttyd_protocol::encode_handshake(160, 48).into(),
+            ttyd_protocol::encode_handshake(init_cols, init_rows).into(),
         ))
         .await
     {
@@ -954,7 +981,7 @@ async fn run_ttyd_session_owner(
     let mut batch_flush_interval = tokio::time::interval(std::time::Duration::from_millis(16));
     batch_flush_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     let mut batch_dirty = false;
-    let mut read_deadline = tokio::time::Instant::now() + TTYD_OWNER_READ_TIMEOUT;
+    let mut last_activity = tokio::time::Instant::now();
 
     loop {
         tokio::select! {
@@ -966,10 +993,10 @@ async fn run_ttyd_session_owner(
                         .await
                         .context("ttyd session owner pong send failed")?;
                     tracing::debug!(session_id = %sid, "ttyd session owner sent pong");
-                    read_deadline = tokio::time::Instant::now() + TTYD_OWNER_READ_TIMEOUT;
+                    last_activity = tokio::time::Instant::now();
                 }
                 Some(Ok(WsMessage::Binary(data))) if data.len() > 1 && data[0] == ttyd_protocol::CMD_OUTPUT => {
-                    read_deadline = tokio::time::Instant::now() + TTYD_OWNER_READ_TIMEOUT;
+                    last_activity = tokio::time::Instant::now();
                     let payload = &data[1..];
                     state.emit_terminal_bytes(sid, payload).await;
                     match std::str::from_utf8(payload) {
@@ -995,14 +1022,18 @@ async fn run_ttyd_session_owner(
                     }
                 }
                 Some(Ok(WsMessage::Binary(_))) | Some(Ok(WsMessage::Text(_))) | Some(Ok(WsMessage::Pong(_))) | Some(Ok(WsMessage::Frame(_))) => {
-                    read_deadline = tokio::time::Instant::now() + TTYD_OWNER_READ_TIMEOUT;
+                    last_activity = tokio::time::Instant::now();
                 }
                 Some(Ok(WsMessage::Close(_))) | None => break,
                 Some(Err(err)) => return Err(err.into()),
             },
-            _ = tokio::time::sleep_until(read_deadline) => {
-                tracing::info!(session_id = %sid, timeout_secs = TTYD_OWNER_READ_TIMEOUT.as_secs(), "ttyd session owner detected a stale connection");
-                return Err(anyhow!("ttyd session owner read timeout"));
+            _ = tokio::time::sleep_until(last_activity + TTYD_OWNER_SILENCE_TIMEOUT) => {
+                tracing::warn!(
+                    session_id = %sid,
+                    silence_secs = TTYD_OWNER_SILENCE_TIMEOUT.as_secs(),
+                    "ttyd session owner detected prolonged silence (no pings or data), connection likely dead"
+                );
+                return Err(anyhow!("ttyd session owner silence timeout"));
             },
             input = channels.input_rx.recv(), if !input_closed => match input {
                 Some(input) => {

--- a/crates/conductor-server/src/state/types.rs
+++ b/crates/conductor-server/src/state/types.rs
@@ -235,6 +235,10 @@ impl TerminalStateStore {
         }
     }
 
+    pub fn dimensions(&self) -> (u16, u16) {
+        (self.cols, self.rows)
+    }
+
     pub fn hydrate_from_snapshot(&mut self, snapshot: &TerminalRestoreSnapshot) {
         let mut next = Self::with_size(snapshot.rows, snapshot.cols);
         let bytes = snapshot.full_render_bytes();

--- a/packages/web/src/components/sessions/RemoteSessionTerminalImpl.tsx
+++ b/packages/web/src/components/sessions/RemoteSessionTerminalImpl.tsx
@@ -27,7 +27,9 @@ import {
 const TERMINAL_CLOSED_STATUSES = new Set(["archived", "killed", "terminated", "restored"]);
 const CMD_OUTPUT = "0".charCodeAt(0);
 const CMD_RESIZE = "1".charCodeAt(0);
+const CMD_SET_WINDOW_TITLE = "2".charCodeAt(0);
 const RECONNECT_MAX_DELAY_MS = 4_000;
+const MAX_RECONNECT_ATTEMPTS = 10;
 type TerminalSyncMode = "resize" | "handshake";
 
 const TERMINAL_THEME = {
@@ -380,11 +382,15 @@ export function RemoteSessionTerminal({
     if (!expectsRelayTerminal) {
       return;
     }
+    if (retryAttemptRef.current >= MAX_RECONNECT_ATTEMPTS) {
+      setError("Max reconnect attempts reached. Click the reload button to retry manually.");
+      return;
+    }
     if (reconnectTimerRef.current !== null) {
       window.clearTimeout(reconnectTimerRef.current);
     }
     const delay = Math.min(RECONNECT_MAX_DELAY_MS, 500 * 2 ** retryAttemptRef.current);
-    retryAttemptRef.current = Math.min(retryAttemptRef.current + 1, 3);
+    retryAttemptRef.current += 1;
     reconnectTimerRef.current = window.setTimeout(() => {
       setConnectionTick((value) => value + 1);
     }, delay);
@@ -781,6 +787,11 @@ export function RemoteSessionTerminal({
                   }
                   setHasOutput(true);
                 }
+                break;
+              }
+              case CMD_SET_WINDOW_TITLE: {
+                // Server-set window title — currently ignored but handled
+                // to avoid falling through to default on legitimate frames.
                 break;
               }
               default:

--- a/packages/web/src/components/sessions/RemoteSessionTerminalImpl.tsx
+++ b/packages/web/src/components/sessions/RemoteSessionTerminalImpl.tsx
@@ -398,8 +398,12 @@ export function RemoteSessionTerminal({
     console.debug(
       `[conductor:terminal] relay reconnect attempt ${attempt}/${MAX_RECONNECT_ATTEMPTS} in ${delay}ms`,
     );
-    retryAttemptRef.current = attempt;
     reconnectTimerRef.current = window.setTimeout(() => {
+      // Only increment the attempt counter when the reconnect actually fires,
+      // not when it is scheduled — otherwise hide/show cycles with cancelled
+      // timers exhaust the budget without ever hitting the network.
+      retryAttemptRef.current = attempt;
+      reconnectTimerRef.current = null;
       setConnectionTick((value) => value + 1);
     }, delay);
   }, [expectsRelayTerminal]);
@@ -672,7 +676,10 @@ export function RemoteSessionTerminal({
         // closed, trigger a reconnect attempt.
         const socket = socketRef.current;
         if (hiddenAt !== null && (!socket || socket.readyState !== WebSocket.OPEN)) {
-          setConnectionTick((value) => value + 1);
+          // Only reconnect if we haven't already exhausted the budget.
+          if (retryAttemptRef.current < MAX_RECONNECT_ATTEMPTS) {
+            setConnectionTick((value) => value + 1);
+          }
         }
         hiddenAt = null;
       }

--- a/packages/web/src/components/sessions/RemoteSessionTerminalImpl.tsx
+++ b/packages/web/src/components/sessions/RemoteSessionTerminalImpl.tsx
@@ -29,7 +29,7 @@ const CMD_OUTPUT = "0".charCodeAt(0);
 const CMD_RESIZE = "1".charCodeAt(0);
 const CMD_SET_WINDOW_TITLE = "2".charCodeAt(0);
 const RECONNECT_MAX_DELAY_MS = 4_000;
-const MAX_RECONNECT_ATTEMPTS = 10;
+const MAX_RECONNECT_ATTEMPTS = 20;
 type TerminalSyncMode = "resize" | "handshake";
 
 const TERMINAL_THEME = {
@@ -390,7 +390,11 @@ export function RemoteSessionTerminal({
       window.clearTimeout(reconnectTimerRef.current);
     }
     const delay = Math.min(RECONNECT_MAX_DELAY_MS, 500 * 2 ** retryAttemptRef.current);
-    retryAttemptRef.current += 1;
+    const attempt = retryAttemptRef.current + 1;
+    console.debug(
+      `[conductor:terminal] relay reconnect attempt ${attempt}/${MAX_RECONNECT_ATTEMPTS} in ${delay}ms`,
+    );
+    retryAttemptRef.current = attempt;
     reconnectTimerRef.current = window.setTimeout(() => {
       setConnectionTick((value) => value + 1);
     }, delay);
@@ -644,9 +648,29 @@ export function RemoteSessionTerminal({
         applyGeometry();
       });
     const visualViewport = typeof window === "undefined" ? null : window.visualViewport;
+    let hiddenAt: number | null = null;
     const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        hiddenAt = window.Date.now();
+        // Pause reconnect timer while the tab is hidden to avoid unnecessary
+        // reconnection attempts when the user isn't looking at the terminal.
+        if (reconnectTimerRef.current !== null) {
+          window.clearTimeout(reconnectTimerRef.current);
+          reconnectTimerRef.current = null;
+        }
+        return;
+      }
       if (document.visibilityState === "visible") {
         refreshTerminalLayout();
+        // If we were previously disconnected, schedule a reconnect now that
+        // the tab is visible again. Use the connection quality to decide:
+        // if the socket is still open, just refresh layout; if offline or
+        // closed, trigger a reconnect attempt.
+        const socket = socketRef.current;
+        if (hiddenAt !== null && (!socket || socket.readyState !== WebSocket.OPEN)) {
+          setConnectionTick((value) => value + 1);
+        }
+        hiddenAt = null;
       }
     };
     const fontSet = typeof document === "undefined" ? null : document.fonts;

--- a/packages/web/src/components/sessions/RemoteSessionTerminalImpl.tsx
+++ b/packages/web/src/components/sessions/RemoteSessionTerminalImpl.tsx
@@ -25,9 +25,13 @@ import {
 } from "@/lib/clipboardImage";
 
 const TERMINAL_CLOSED_STATUSES = new Set(["archived", "killed", "terminated", "restored"]);
-const CMD_OUTPUT = "0".charCodeAt(0);
-const CMD_RESIZE = "1".charCodeAt(0);
-const CMD_SET_WINDOW_TITLE = "2".charCodeAt(0);
+// Server→client command bytes (ttyd binary protocol).
+// See crates/conductor-server/src/routes/ttyd_protocol.rs for the authoritative list.
+const CMD_OUTPUT = "0".charCodeAt(0);            // 0x30 – terminal output
+const CMD_SET_WINDOW_TITLE = "1".charCodeAt(0);  // 0x31 – server-set window title
+const CMD_SET_PREFERENCES = "2".charCodeAt(0);   // 0x32 – server-set preferences
+// Client→server command bytes (used for encoding outgoing frames).
+const CMD_RESIZE = "1".charCodeAt(0);            // 0x31 – resize terminal
 const RECONNECT_MAX_DELAY_MS = 4_000;
 const MAX_RECONNECT_ATTEMPTS = 20;
 type TerminalSyncMode = "resize" | "handshake";
@@ -814,8 +818,35 @@ export function RemoteSessionTerminal({
                 break;
               }
               case CMD_SET_WINDOW_TITLE: {
-                // Server-set window title — currently ignored but handled
-                // to avoid falling through to default on legitimate frames.
+                // ttyd sends the terminal title as UTF-8 after the command byte.
+                // Update document.title so the browser tab reflects the session.
+                const titleBytes = frame.slice(1);
+                if (titleBytes.length > 0) {
+                  try {
+                    const title = new TextDecoder().decode(titleBytes);
+                    if (title.trim()) {
+                      document.title = title.trim();
+                    }
+                  } catch {
+                    // Ignore malformed title payloads.
+                  }
+                }
+                break;
+              }
+              case CMD_SET_PREFERENCES: {
+                // The server sends JSON preferences (e.g. { bellSound: "" }).
+                // Decode and acknowledge; the frontend owns the terminal theme
+                // and font sizing so we intentionally skip applying those fields.
+                const prefBytes = frame.slice(1);
+                if (prefBytes.length > 0) {
+                  try {
+                    const _prefs = JSON.parse(new TextDecoder().decode(prefBytes));
+                    // Preferences acknowledged. Terminal theme and font sizing are
+                    // managed by the frontend via resolveSessionTerminalViewportOptions.
+                  } catch {
+                    // Ignore malformed preference payloads.
+                  }
+                }
                 break;
               }
               default:

--- a/packages/web/src/components/sessions/SessionTerminal.tsx
+++ b/packages/web/src/components/sessions/SessionTerminal.tsx
@@ -381,6 +381,11 @@ function SessionTerminalView(props: SessionTerminalProps) {
   // Debounced so rapid SSE status flickers don't tear down/rebuild the terminal connection.
   useEffect(() => {
     const timer = window.setTimeout(() => {
+      // Seed the ref on the very first invocation so the debounce logic
+      // always has a valid previous value to compare against.
+      if (prevExpectsLiveTerminalRef.current === null || prevExpectsLiveTerminalRef.current === undefined) {
+        prevExpectsLiveTerminalRef.current = expectsLiveTerminal;
+      }
       const prev = prevExpectsLiveTerminalRef.current;
       prevExpectsLiveTerminalRef.current = expectsLiveTerminal;
       if (!expectsLiveTerminal && prev === true) {
@@ -603,6 +608,10 @@ function SessionTerminalView(props: SessionTerminalProps) {
         // Let layout settle (Radix tabs, split view, embedded webviews) before xterm fit.
         resizeSuppressUntilRef.current = window.Date.now() + 200;
         requestLifecycleRefresh();
+        // Bump connectionRefreshTick to force a fresh token resolve and
+        // re-establish the proactive refresh schedule that was cancelled
+        // when the page went hidden.
+        setConnectionRefreshTick((current) => current + 1);
       }
     };
     const handlePageShow = () => {

--- a/packages/web/src/components/sessions/SessionTerminal.tsx
+++ b/packages/web/src/components/sessions/SessionTerminal.tsx
@@ -182,6 +182,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
   const resolvingRefreshCountRef = useRef(0);
   const iframeRefreshRequestCountRef = useRef(0);
   const retryCountRef = useRef(0);
+  const refreshTimerRef = useRef<number | null>(null);
 
   const normalizedSessionStatus = useMemo(
     () => sessionState.trim().toLowerCase(),
@@ -377,17 +378,21 @@ function SessionTerminalView(props: SessionTerminalProps) {
   }, [clearBurstResizeTimers]);
 
   // When the session stops being live, abort token fetch; when it becomes live again, refetch.
+  // Debounced so rapid SSE status flickers don't tear down/rebuild the terminal connection.
   useEffect(() => {
-    const prev = prevExpectsLiveTerminalRef.current;
-    prevExpectsLiveTerminalRef.current = expectsLiveTerminal;
-    if (!expectsLiveTerminal && prev === true) {
-      terminalTokenFetchAbortRef.current?.abort();
-      setResolvingConnection(false);
-      setConnectionError(null);
-    }
-    if (expectsLiveTerminal && prev === false) {
-      setConnectionRefreshTick((current) => current + 1);
-    }
+    const timer = window.setTimeout(() => {
+      const prev = prevExpectsLiveTerminalRef.current;
+      prevExpectsLiveTerminalRef.current = expectsLiveTerminal;
+      if (!expectsLiveTerminal && prev === true) {
+        terminalTokenFetchAbortRef.current?.abort();
+        setResolvingConnection(false);
+        setConnectionError(null);
+      }
+      if (expectsLiveTerminal && prev === false) {
+        setConnectionRefreshTick((current) => current + 1);
+      }
+    }, 500);
+    return () => window.clearTimeout(timer);
   }, [expectsLiveTerminal]);
 
   useEffect(() => {
@@ -456,8 +461,10 @@ function SessionTerminalView(props: SessionTerminalProps) {
           const delayMs = computeTokenRefreshDelayMs(connection.expiresInSeconds);
           if (delayMs !== null) {
             refreshTimer = window.setTimeout(() => {
+              refreshTimerRef.current = null;
               setConnectionRefreshTick((current) => current + 1);
             }, delayMs);
+            refreshTimerRef.current = refreshTimer;
           }
           return;
         }
@@ -508,6 +515,10 @@ function SessionTerminalView(props: SessionTerminalProps) {
       }
       if (refreshTimer !== null) {
         window.clearTimeout(refreshTimer);
+      }
+      if (refreshTimerRef.current !== null) {
+        window.clearTimeout(refreshTimerRef.current);
+        refreshTimerRef.current = null;
       }
     };
   }, [bridgeId, connectionRefreshTick, sessionId]);
@@ -580,6 +591,11 @@ function SessionTerminalView(props: SessionTerminalProps) {
         // Suppress resize to avoid ResizeObserver fitting while the browser/webview
         // reports zero or intermediate sizes during tab or window transitions.
         resizeSuppressUntilRef.current = window.Date.now() + 320;
+        // Pause token refresh while the page is hidden to avoid wasted fetches.
+        if (refreshTimerRef.current !== null) {
+          window.clearTimeout(refreshTimerRef.current);
+          refreshTimerRef.current = null;
+        }
         return;
       }
 


### PR DESCRIPTION
## User-Facing Release Notes

- Terminals now pause reconnection attempts when the browser tab is hidden and resume automatically when visible again, reducing unnecessary network traffic
- Terminal sessions show a clear error with a reload button after 20 failed reconnect attempts instead of silently dying
- Terminal relay now properly handles PAUSE, RESUME, and RESIZE protocol frames for smoother remote session behavior
- Browser tab title updates to reflect the terminal session name when the server sends SET_WINDOW_TITLE

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Plugin Addition / Modification
- [ ] Documentation Update
- [x] Refactor / Chore

## Summary

Completes all remaining items from the terminal robustness spec. Builds on the P0/P1 fixes already on main.

### Frontend (`packages/web`)
- **Pause reconnect when tab hidden** — `visibilitychange` listener clears reconnect timer when hidden, triggers reconnect on visible
- **Max reconnect attempts bumped to 20** — matches backend `TTYD_OWNER_RECONNECT_MAX_ATTEMPTS`, shows permanent error with reload button after exhaustion
- **Debounce `expectsLiveTerminal`** — 500ms debounce prevents rapid SSE status flickers from tearing down/rebuilding the terminal
- **SET_WINDOW_TITLE handling** — fixed command byte from 0x32 to correct 0x31, updates `document.title`
- **SET_PREFERENCES handling** — added constant and handler for preferences frames

### Backend (`crates/conductor-relay`)
- **PAUSE/RESUME frames** — buffers output in 256-capacity ring when paused, replays on resume
- **RESIZE frame** — forwards dimension changes to bridge peer with logging
- **Stored dimensions** — reconnect reads `TerminalStateStore::dimensions()` instead of hardcoded 160×48

## Verification
- `cargo check -p conductor-relay -p conductor-server` — clean
- `npx tsc --noEmit` in `packages/web` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal pause/resume with buffering and replay so output isn’t lost while the browser is paused.
  * Terminal can set the browser tab title from the session stream.

* **Bug Fixes**
  * Extended inactivity timeout to ~5 minutes to reduce premature disconnects.
  * Frontend notified when reconnection is permanently abandoned.

* **Improvements**
  * Reconnect attempts capped at 20 and paused while the tab is hidden.
  * Token refresh and visibility transitions are debounced to avoid stale actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->