### PR TITLE
fix: windows bridge reconnect setup

### DIFF
--- a/bridge-cmd/install/install.go
+++ b/bridge-cmd/install/install.go
@@ -34,6 +34,15 @@ func resolveLaunchdPath(home string) string {
 	)
 }
 
+func bridgeBinaryName(goos string) string {
+	switch goos {
+	case "windows":
+		return "conductor-bridge.exe"
+	default:
+		return "conductor-bridge"
+	}
+}
+
 func Install(binaryPath string) error {
 	if binaryPath == "" {
 		// Find our own binary
@@ -54,7 +63,7 @@ func Install(binaryPath string) error {
 		return fmt.Errorf("create install dir: %w", err)
 	}
 
-	destPath := filepath.Join(installDir, "conductor-bridge")
+	destPath := filepath.Join(installDir, bridgeBinaryName(runtime.GOOS))
 	if binaryPath != destPath {
 		if err := copyFile(binaryPath, destPath); err != nil {
 			return fmt.Errorf("copy binary: %w", err)

--- a/bridge-cmd/install/install_test.go
+++ b/bridge-cmd/install/install_test.go
@@ -6,6 +6,15 @@ import (
 	"testing"
 )
 
+func TestBridgeBinaryName(t *testing.T) {
+	if got := bridgeBinaryName("windows"); got != "conductor-bridge.exe" {
+		t.Fatalf("bridgeBinaryName(windows) = %q, want %q", got, "conductor-bridge.exe")
+	}
+	if got := bridgeBinaryName("darwin"); got != "conductor-bridge" {
+		t.Fatalf("bridgeBinaryName(darwin) = %q, want %q", got, "conductor-bridge")
+	}
+}
+
 func TestBuildRestartCommandDarwin(t *testing.T) {
 	cmd, err := buildRestartCommand("darwin", "/Users/test user")
 	if err != nil {

--- a/packages/web/src/app/bridge/install.ps1/route.test.ts
+++ b/packages/web/src/app/bridge/install.ps1/route.test.ts
@@ -20,6 +20,8 @@ test("GET includes concrete reconnect guidance for the PowerShell installer", as
     /Bridge service installed\. Future reconnects can use: conductor-bridge connect --dashboard-url \$DashboardUrl/,
   );
   assert.match(body, /Installing conductor-oss CLI via npm/);
+  assert.match(body, /Configure-UserPath/);
+  assert.match(body, /SetEnvironmentVariable\("Path", \(\$updatedEntries -join ";"\), "User"\)/);
   assert.match(body, /Conductor CLI installed for local backend/);
   assert.match(body, /conductor-bridge\.exe/);
 });

--- a/packages/web/src/app/bridge/install.ps1/route.ts
+++ b/packages/web/src/app/bridge/install.ps1/route.ts
@@ -29,6 +29,7 @@ $SourceArchiveUrl = "${sourceArchiveUrl}"
 $ConductorHome = Join-Path $HOME ".conductor"
 $InstallBinDir = Join-Path $ConductorHome "bin"
 $ConductorNpmPrefix = Join-Path $ConductorHome "npm"
+$ConductorNpmBinDir = Join-Path $ConductorNpmPrefix "bin"
 $BridgeBin = Join-Path $InstallBinDir "conductor-bridge.exe"
 $LocalGoRoot = Join-Path $ConductorHome "go"
 
@@ -68,6 +69,55 @@ function Ensure-Go {
       Remove-Item -Recurse -Force $tempRoot
     }
   }
+}
+
+function Test-PathEntryPresent([string[]]$Entries, [string]$Candidate) {
+  $normalizedCandidate = $Candidate.Trim().TrimEnd("\\")
+  foreach ($entry in $Entries) {
+    if ($null -eq $entry) {
+      continue
+    }
+    $normalizedEntry = $entry.Trim().TrimEnd("\\")
+    if ($normalizedEntry -and $normalizedEntry.Equals($normalizedCandidate, [System.StringComparison]::OrdinalIgnoreCase)) {
+      return $true
+    }
+  }
+  return $false
+}
+
+function Ensure-UserPathEntry([string]$PathEntry) {
+  if (-not $PathEntry) {
+    return
+  }
+
+  New-Item -ItemType Directory -Force -Path $PathEntry | Out-Null
+
+  $currentUserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+  $userEntries = @()
+  if ($currentUserPath) {
+    $userEntries = $currentUserPath -split ";" | Where-Object { $_ -and $_.Trim() }
+  }
+  if (-not (Test-PathEntryPresent $userEntries $PathEntry)) {
+    $updatedEntries = @($userEntries + $PathEntry) | Where-Object { $_ -and $_.Trim() }
+    [Environment]::SetEnvironmentVariable("Path", ($updatedEntries -join ";"), "User")
+  }
+
+  $sessionEntries = @()
+  if ($env:PATH) {
+    $sessionEntries = $env:PATH -split ";" | Where-Object { $_ -and $_.Trim() }
+  }
+  if (-not (Test-PathEntryPresent $sessionEntries $PathEntry)) {
+    $env:PATH = if ([string]::IsNullOrWhiteSpace($env:PATH)) {
+      $PathEntry
+    } else {
+      "$PathEntry;$env:PATH"
+    }
+  }
+}
+
+function Configure-UserPath {
+  Ensure-UserPathEntry $InstallBinDir
+  Ensure-UserPathEntry $ConductorNpmBinDir
 }
 
 function Build-Bridge($goExe) {
@@ -196,6 +246,7 @@ function Run-Connect {
 $goExe = Ensure-Go
 Build-Bridge $goExe
 Ensure-ConductorCli
+Configure-UserPath
 Write-Host "Installing bridge background service..."
 & $BridgeBin install
 if ($LASTEXITCODE -ne 0) {

--- a/packages/web/src/features/bridge/BridgeConnectClient.tsx
+++ b/packages/web/src/features/bridge/BridgeConnectClient.tsx
@@ -238,12 +238,12 @@ export default function BridgeConnectClient({
     [setupInstallUrl, setupPlatform],
   );
   const connectCommand = useMemo(
-    () => buildBridgeConnectCommand(dashboardUrl, relayUrl),
-    [dashboardUrl, relayUrl],
+    () => buildBridgeConnectCommand(dashboardUrl, relayUrl, setupPlatform),
+    [dashboardUrl, relayUrl, setupPlatform],
   );
   const manualCommand = useMemo(
-    () => buildBridgeManualPairCommand(pairingCode, relayUrl),
-    [pairingCode, relayUrl],
+    () => buildBridgeManualPairCommand(pairingCode, relayUrl, setupPlatform),
+    [pairingCode, relayUrl, setupPlatform],
   );
   const connectedDevices = devices.filter((device) => device.connected);
   const claimedDeviceRecord = useMemo(
@@ -282,6 +282,10 @@ export default function BridgeConnectClient({
       selectedDeviceInstallPlatform,
     ),
     [dashboardUrl, installPowerShellUrl, installScriptUrl, relayUrl, selectedDeviceInstallPlatform, selectedDeviceSetupInstallUrl],
+  );
+  const selectedDeviceConnectCommand = useMemo(
+    () => buildBridgeConnectCommand(dashboardUrl, relayUrl, selectedDeviceInstallPlatform),
+    [dashboardUrl, relayUrl, selectedDeviceInstallPlatform],
   );
   const readyDevice = useMemo(
     () => (claimedDeviceRecord?.connected ? claimedDeviceRecord : null)
@@ -1240,7 +1244,7 @@ export default function BridgeConnectClient({
                           Open the same laptop and run the reconnect command below. If Conductor Bridge is missing or broken on that machine, use the full setup command instead.
                         </p>
                         <pre className="mt-3 overflow-x-auto whitespace-pre-wrap break-all rounded-[14px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-4 py-3 font-mono text-sm leading-6 text-[var(--vk-text-normal)]">
-                          {connectCommand}
+                          {selectedDeviceConnectCommand}
                         </pre>
                         <div className="mt-3 flex flex-wrap gap-2">
                           <Button
@@ -1248,7 +1252,7 @@ export default function BridgeConnectClient({
                             variant="primary"
                             size="md"
                             onClick={() => {
-                              void handleCopyCommand(connectCommand, "connect");
+                              void handleCopyCommand(selectedDeviceConnectCommand, "connect");
                             }}
                           >
                             {copiedCommand === "connect" ? <CheckCircle2 className="h-4 w-4" /> : <Copy className="h-4 w-4" />}

--- a/packages/web/src/lib/bridgeOnboarding.test.ts
+++ b/packages/web/src/lib/bridgeOnboarding.test.ts
@@ -64,10 +64,28 @@ test("buildBridgeConnectCommand includes dashboard and relay arguments", () => {
   );
 });
 
+test("buildBridgeConnectCommand uses the installed bridge path on windows", () => {
+  assert.equal(
+    buildBridgeConnectCommand(
+      "https://preview.conductross.com",
+      "https://relay.conductross.com",
+      "windows",
+    ),
+    "& (Join-Path $HOME '.conductor\\bin\\conductor-bridge.exe') connect --dashboard-url https://preview.conductross.com --relay-url https://relay.conductross.com",
+  );
+});
+
 test("buildBridgeManualPairCommand includes relay arguments for both steps", () => {
   assert.equal(
     buildBridgeManualPairCommand("ABC123", "https://relay.conductross.com"),
     "conductor-bridge pair --code ABC123 --relay-url https://relay.conductross.com\nconductor-bridge daemon --relay-url https://relay.conductross.com",
+  );
+});
+
+test("buildBridgeManualPairCommand uses the installed bridge path on windows", () => {
+  assert.equal(
+    buildBridgeManualPairCommand("ABC123", "https://relay.conductross.com", "windows"),
+    "& (Join-Path $HOME '.conductor\\bin\\conductor-bridge.exe') pair --code ABC123 --relay-url https://relay.conductross.com\n& (Join-Path $HOME '.conductor\\bin\\conductor-bridge.exe') daemon --relay-url https://relay.conductross.com",
   );
 });
 

--- a/packages/web/src/lib/bridgeOnboarding.ts
+++ b/packages/web/src/lib/bridgeOnboarding.ts
@@ -19,6 +19,33 @@ function powerShellQuote(value: string): string {
   return `'${value.replace(/'/g, "''")}'`;
 }
 
+function powerShellArg(value: string): string {
+  if (/^[A-Za-z0-9_./:=@%+\\-]+$/.test(value)) {
+    return value;
+  }
+
+  return powerShellQuote(value);
+}
+
+function formatPowerShellCommand(invocation: string, args: string[]): string {
+  return [invocation, ...args.map(powerShellArg)].join(" ");
+}
+
+function buildWindowsBridgeInvocation(): string {
+  return "& (Join-Path $HOME '.conductor\\bin\\conductor-bridge.exe')";
+}
+
+function buildBridgeCliCommand(
+  args: string[],
+  platform: BridgeInstallPlatform = "unix",
+): string {
+  if (platform === "windows") {
+    return formatPowerShellCommand(buildWindowsBridgeInvocation(), args);
+  }
+
+  return formatCommand(["conductor-bridge", ...args]);
+}
+
 export function resolveBridgeInstallPlatform(os: string | null | undefined): BridgeInstallPlatform {
   const normalized = os?.trim().toLowerCase() ?? "";
   return normalized.startsWith("windows") ? "windows" : "unix";
@@ -89,26 +116,28 @@ export function buildBridgeBootstrapConnectCommand(
 export function buildBridgeConnectCommand(
   dashboardUrl: string,
   relayUrl?: string | null,
+  platform: BridgeInstallPlatform = "unix",
 ): string {
-  const parts = ["conductor-bridge", "connect", "--dashboard-url", dashboardUrl];
+  const parts = ["connect", "--dashboard-url", dashboardUrl];
   if (relayUrl?.trim()) {
     parts.push("--relay-url", relayUrl.trim());
   }
-  return formatCommand(parts);
+  return buildBridgeCliCommand(parts, platform);
 }
 
 export function buildBridgeManualPairCommand(
   pairingCode: string | null | undefined,
   relayUrl?: string | null,
+  platform: BridgeInstallPlatform = "unix",
 ): string {
   const resolvedPairingCode = pairingCode?.trim() || "ABC123";
-  const pairParts = ["conductor-bridge", "pair", "--code", resolvedPairingCode];
-  const daemonParts = ["conductor-bridge", "daemon"];
+  const pairParts = ["pair", "--code", resolvedPairingCode];
+  const daemonParts = ["daemon"];
 
   if (relayUrl?.trim()) {
     pairParts.push("--relay-url", relayUrl.trim());
     daemonParts.push("--relay-url", relayUrl.trim());
   }
 
-  return `${formatCommand(pairParts)}\n${formatCommand(daemonParts)}`;
+  return `${buildBridgeCliCommand(pairParts, platform)}\n${buildBridgeCliCommand(daemonParts, platform)}`;
 }


### PR DESCRIPTION
## User-Facing Release Notes

- Windows users can reconnect Conductor Bridge even when the bridge binary is not already on PATH.
- The Windows installer now adds the bridge command to PATH for future shells.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Plugin addition / modification
- [ ] Documentation update
- [ ] Refactor / chore

## Summary
- fix Windows reconnect and manual pair commands to call the installed bridge executable directly instead of assuming `conductor-bridge` is on PATH
- update the PowerShell installer to add the Conductor bin directories to the user PATH for future shells
- preserve the `.exe` suffix when installing the bridge binary on Windows and cover the new behavior with tests

## Testing
- bun run --cwd packages/web test
- bun run --cwd packages/web typecheck
- go test ./install
