### PR TITLE
fix: harden iframe terminal lifecycle and bridge relay refresh

### DIFF
--- a/crates/conductor-server/src/routes/terminal.rs
+++ b/crates/conductor-server/src/routes/terminal.rs
@@ -635,6 +635,7 @@ const TTYD_AUTH_SYNC_SHIM: &str = r#"
     const LEGACY_STORAGE_KEY = 'conductor.ttyd.token';
     const MESSAGE_TYPE = 'conductor-ttyd-auth-token';
     const REQUEST_MESSAGE_TYPE = 'conductor-ttyd-auth-token-request';
+    const READY_MESSAGE_TYPE = 'conductor-ttyd-ready';
     const TOKEN_REQUEST_THROTTLE_MS = 1500;
     const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
 
@@ -704,6 +705,17 @@ const TTYD_AUTH_SYNC_SHIM: &str = r#"
         }
     };
 
+    const notifyReady = () => {
+        if (unloading || !window.parent || window.parent === window) {
+            return;
+        }
+
+        try {
+            window.parent.postMessage({ type: READY_MESSAGE_TYPE }, '*');
+        } catch {
+        }
+    };
+
     const requestFreshToken = (reason) => {
         if (unloading || !window.parent || window.parent === window) {
             return;
@@ -754,6 +766,9 @@ const TTYD_AUTH_SYNC_SHIM: &str = r#"
         }
 
         socket.__conductorTokenRefreshHookAttached = true;
+        socket.addEventListener('open', () => {
+            notifyReady();
+        });
         socket.addEventListener('close', () => {
             requestFreshToken('websocket-close');
         });
@@ -2609,6 +2624,7 @@ mod tests {
         assert!(
             injected.contains("const REQUEST_MESSAGE_TYPE = 'conductor-ttyd-auth-token-request';")
         );
+        assert!(injected.contains("const READY_MESSAGE_TYPE = 'conductor-ttyd-ready';"));
         assert!(injected.contains("const TOKEN_REQUEST_THROTTLE_MS = 1500;"));
         assert!(
             injected.contains("const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);")
@@ -2617,8 +2633,12 @@ mod tests {
         assert!(injected.contains("const resolveProxyWebSocketUrl = () => {"));
         assert!(injected.contains("window.__conductorTtydWebSocketPatched"));
         assert!(injected.contains("const nativeWebSocket = window.WebSocket;"));
+        assert!(injected.contains("const notifyReady = () => {"));
+        assert!(injected.contains("window.parent.postMessage({ type: READY_MESSAGE_TYPE }, '*');"));
         assert!(injected.contains("const requestFreshToken = (reason) => {"));
         assert!(injected.contains("const attachSocketListeners = (socket) => {"));
+        assert!(injected.contains("socket.addEventListener('open', () => {"));
+        assert!(injected.contains("notifyReady();"));
         assert!(injected.contains("requestFreshToken('websocket-close');"));
         assert!(injected.contains("requestFreshToken('websocket-error');"));
         assert!(injected.contains("const normalizeWebSocketUrl = (value) => {"));

--- a/crates/conductor-server/src/state/detached/ttyd_launcher.rs
+++ b/crates/conductor-server/src/state/detached/ttyd_launcher.rs
@@ -780,6 +780,25 @@ async fn run_ttyd_session_owner_with_retry(
         match &result {
             Ok(()) => return Ok(()),
             Err(err) => {
+                if session_exceeded_max_duration(err) {
+                    tracing::info!(
+                        session_id = %sid,
+                        error = %err,
+                        "ttyd session reached maximum duration, shutting down without reconnect"
+                    );
+                    state
+                        .emit_terminal_stream_event(
+                            sid,
+                            crate::state::types::TerminalStreamEvent::Error(
+                                "Terminal session reached its maximum lifetime and was closed."
+                                    .to_string(),
+                            ),
+                        )
+                        .await;
+                    state.detach_terminal_runtime(sid).await;
+                    return Ok(());
+                }
+
                 // Check if the ttyd process is still alive before reconnecting.
                 // We verify not just that the PID exists but that it is actually a ttyd process.
                 let session = state.get_session(sid).await;
@@ -1090,6 +1109,11 @@ async fn run_ttyd_session_owner(
         let _ = channels.output_tx.send(ExecutorOutput::Stdout(buf)).await;
     }
     Err(anyhow!("ttyd session owner disconnected"))
+}
+
+fn session_exceeded_max_duration(err: &anyhow::Error) -> bool {
+    err.to_string()
+        .contains("session exceeded maximum duration")
 }
 
 fn owner_reconnect_delay(attempt: u32) -> std::time::Duration {

--- a/crates/conductor-server/src/state/detached/ttyd_launcher.rs
+++ b/crates/conductor-server/src/state/detached/ttyd_launcher.rs
@@ -59,6 +59,23 @@ struct TtydSessionOwnerChannels {
     ready_tx: Option<oneshot::Sender<Result<()>>>,
 }
 
+#[derive(Debug)]
+struct SessionExceededMaxDurationError {
+    max_duration_secs: u64,
+}
+
+impl std::fmt::Display for SessionExceededMaxDurationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "session exceeded maximum duration of {} seconds",
+            self.max_duration_secs
+        )
+    }
+}
+
+impl std::error::Error for SessionExceededMaxDurationError {}
+
 fn candidate_ttyd_paths(workspace_path: &Path) -> Vec<PathBuf> {
     let mut candidates = Vec::new();
 
@@ -1094,10 +1111,10 @@ async fn run_ttyd_session_owner(
                 max_duration_secs = TTYD_MAX_SESSION_DURATION.as_secs(),
                 "session exceeded maximum duration during active connection"
             );
-            return Err(anyhow!(
-                "session exceeded maximum duration of {} seconds",
-                TTYD_MAX_SESSION_DURATION.as_secs()
-            ));
+            return Err(SessionExceededMaxDurationError {
+                max_duration_secs: TTYD_MAX_SESSION_DURATION.as_secs(),
+            }
+            .into());
         }
     }
     // Flush any remaining batched output before disconnecting.
@@ -1112,8 +1129,11 @@ async fn run_ttyd_session_owner(
 }
 
 fn session_exceeded_max_duration(err: &anyhow::Error) -> bool {
-    err.to_string()
-        .contains("session exceeded maximum duration")
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<SessionExceededMaxDurationError>()
+            .is_some()
+    })
 }
 
 fn owner_reconnect_delay(attempt: u32) -> std::time::Duration {

--- a/packages/web/src/app/api/sessions/[id]/terminal/token/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/terminal/token/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import { guardAndProxy } from "@/lib/guardedRustProxy";
-import { buildBridgeTtydProxyUrl, ensureBridgeTtydSession, resolveBridgeSessionTarget } from "@/lib/bridgeTtyd";
+import {
+  buildStableBridgeTtydProxyUrl,
+  ensureBridgeTtydSession,
+  resolveBridgeSessionTarget,
+} from "@/lib/bridgeTtyd";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -35,12 +39,12 @@ export async function GET(
   return NextResponse.json({
     required: false,
     expiresInSeconds: null,
-    ttydHttpUrl: buildBridgeTtydProxyUrl(
+    ttydHttpUrl: buildStableBridgeTtydProxyUrl(
       ensured.routeSessionId,
       ensured.bridgeId,
-      ensured.relayTtydWsUrl,
     ),
     ttydWsUrl: ensured.relayTtydWsUrl,
+    relayTtydWsUrl: ensured.relayTtydWsUrl,
     tunnelUrl,
   });
 }

--- a/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
@@ -4,6 +4,7 @@ import { proxyToBridgeDevice } from "@/lib/bridgeApiProxy";
 import { proxyToRustOrUnavailable } from "@/lib/rustBackendProxy";
 import {
   BRIDGE_TTYD_RELAY_WS_QUERY_PARAM,
+  buildPatchedTtydHtmlResponse,
   createBridgeTtydRelayWebSocketUrl,
   injectBridgeTtydRelayShim,
   injectTtydResizeShim,
@@ -17,30 +18,37 @@ type RouteContext = {
   params: Promise<{ id: string }>;
 };
 
-/**
- * Inject the resize coordination shim into a proxied HTML response.
- * Falls back to the original response if the content is not HTML or
- * reading the body fails.
- */
-async function injectResizeShimIntoResponse(proxied: Response): Promise<Response> {
+const MAX_TTYD_HTML_RESPONSE_BYTES = 512 * 1024;
+
+async function readTtydHtmlResponse(proxied: Response): Promise<string | null> {
   const contentType = proxied.headers.get("content-type")?.toLowerCase() ?? "";
   if (!contentType.startsWith("text/html")) {
+    return null;
+  }
+
+  const contentLength = Number.parseInt(proxied.headers.get("content-length") ?? "", 10);
+  if (Number.isFinite(contentLength) && contentLength > MAX_TTYD_HTML_RESPONSE_BYTES) {
+    throw new Error("ttyd frontend response is too large");
+  }
+
+  const html = await proxied.text();
+  if (html.length > MAX_TTYD_HTML_RESPONSE_BYTES) {
+    throw new Error("ttyd frontend response is too large");
+  }
+  return html;
+}
+
+/**
+ * Inject the resize coordination shim into a proxied HTML response.
+ * Falls back to the original response if the content is not HTML.
+ */
+async function injectResizeShimIntoResponse(proxied: Response): Promise<Response> {
+  const html = await readTtydHtmlResponse(proxied);
+  if (html === null) {
     return proxied;
   }
 
-  let html: string;
-  try {
-    html = await proxied.text();
-  } catch {
-    return proxied;
-  }
-
-  const patched = injectTtydResizeShim(html);
-  return new Response(patched, {
-    status: proxied.status,
-    statusText: proxied.statusText,
-    headers: new Headers(proxied.headers),
-  });
+  return buildPatchedTtydHtmlResponse(proxied, injectTtydResizeShim(html));
 }
 
 export async function GET(
@@ -82,11 +90,6 @@ export async function GET(
     },
   );
 
-  const contentType = proxied.headers.get("content-type")?.toLowerCase() ?? "";
-  if (!contentType.startsWith("text/html")) {
-    return proxied;
-  }
-
   let relayTtydWsUrl = new URL(request.url).searchParams.get(BRIDGE_TTYD_RELAY_WS_QUERY_PARAM)?.trim() ?? "";
   if (!relayTtydWsUrl) {
     relayTtydWsUrl = await createBridgeTtydRelayWebSocketUrl(
@@ -96,13 +99,14 @@ export async function GET(
     );
   }
 
-  let html = await proxied.text();
-  html = injectBridgeTtydRelayShim(html, relayTtydWsUrl);
-  html = injectTtydResizeShim(html);
+  const html = await readTtydHtmlResponse(proxied);
+  if (html === null) {
+    return proxied;
+  }
 
-  return new Response(html, {
-    status: proxied.status,
-    statusText: proxied.statusText,
-    headers: new Headers(proxied.headers),
-  });
+  const patchedHtml = injectTtydResizeShim(
+    injectBridgeTtydRelayShim(html, relayTtydWsUrl),
+  );
+
+  return buildPatchedTtydHtmlResponse(proxied, patchedHtml);
 }

--- a/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
@@ -31,10 +31,28 @@ async function readTtydHtmlResponse(proxied: Response): Promise<string | null> {
     throw new Error("ttyd frontend response is too large");
   }
 
-  const html = await proxied.text();
-  if (html.length > MAX_TTYD_HTML_RESPONSE_BYTES) {
-    throw new Error("ttyd frontend response is too large");
+  const reader = proxied.body?.getReader();
+  if (!reader) {
+    return null;
   }
+
+  const decoder = new TextDecoder();
+  let totalBytes = 0;
+  let html = "";
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    totalBytes += value.byteLength;
+    if (totalBytes > MAX_TTYD_HTML_RESPONSE_BYTES) {
+      throw new Error("ttyd frontend response is too large");
+    }
+    html += decoder.decode(value, { stream: true });
+  }
+
+  html += decoder.decode();
   return html;
 }
 

--- a/packages/web/src/components/sessions/SessionDetail.tsx
+++ b/packages/web/src/components/sessions/SessionDetail.tsx
@@ -23,6 +23,7 @@ import { SessionOverview } from "./SessionOverview";
 import { SessionProjectOpenMenu } from "./SessionProjectOpenMenu";
 import type { TerminalInsertRequest } from "./terminalInsert";
 import { shouldAutoOpenPreviewTab } from "./sessionDetailBehavior";
+import { getSessionDetailRootClassName } from "./sessionMobileScroll";
 import {
   loadSessionTerminalComponent,
   SESSION_TERMINAL_IMPLEMENTATION,
@@ -329,11 +330,7 @@ export function SessionDetail({
 
   return (
     <div
-      className={`flex h-full min-h-0 min-w-0 w-full flex-col ${
-        immersiveTerminalActive
-          ? "overflow-hidden bg-[#060404]"
-          : "overflow-y-auto overscroll-contain lg:overflow-hidden"
-      }`}
+      className={getSessionDetailRootClassName(immersiveTerminalActive)}
       data-conductor-session-terminal={SESSION_TERMINAL_IMPLEMENTATION}
     >
       <Tabs

--- a/packages/web/src/components/sessions/SessionDiff.tsx
+++ b/packages/web/src/components/sessions/SessionDiff.tsx
@@ -15,6 +15,7 @@ import { Badge } from "@/components/ui/Badge";
 import { cn } from "@/lib/cn";
 import { subscribeToSnapshotEvents } from "@/lib/liveEvents";
 import { TERMINAL_STATUSES, type SSESessionEvent } from "@/lib/types";
+import { MOBILE_MOMENTUM_SCROLL_CLASS_NAME } from "./sessionMobileScroll";
 import {
   type ChangedFileSummary,
   type DiffCategory,
@@ -647,7 +648,7 @@ function DiffFileDetail({
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-auto px-4 py-4">
+      <div className={`min-h-0 flex-1 overflow-auto px-4 py-4 ${MOBILE_MOMENTUM_SCROLL_CLASS_NAME}`}>
         {selectedState.loading ? (
           <div className="flex h-full min-h-[240px] items-center justify-center gap-2 text-[13px] text-[var(--vk-text-muted)]">
             <LoaderCircle className="h-4 w-4 animate-spin" />
@@ -1032,7 +1033,7 @@ export function SessionDiff({ sessionId, active }: SessionDiffProps) {
   }, [isMobileViewport]);
 
   const listPane = (
-    <div className="flex min-h-0 h-full max-h-full flex-col overflow-y-auto overscroll-contain lg:border-r lg:border-[var(--vk-border)]">
+    <div className={`flex min-h-0 h-full max-h-full flex-col overflow-y-auto lg:border-r lg:border-[var(--vk-border)] ${MOBILE_MOMENTUM_SCROLL_CLASS_NAME}`}>
       <div className="py-1">
         {visibleEntries.map((entry) => {
           const isSelected = entry.fileKey === selectedFileKey;

--- a/packages/web/src/components/sessions/SessionOverview.tsx
+++ b/packages/web/src/components/sessions/SessionOverview.tsx
@@ -19,6 +19,7 @@ import {
 } from "lucide-react";
 import type { DashboardSession } from "@/lib/types";
 import { AgentTileIcon } from "@/components/AgentTileIcon";
+import { MOBILE_MOMENTUM_SCROLL_CLASS_NAME } from "./sessionMobileScroll";
 
 type SessionData = DashboardSession & {
   agent?: string;
@@ -526,7 +527,7 @@ function FileContentViewer({ sessionId, filePath }: { sessionId: string; filePat
           File truncated{fileSize > 0 ? ` (${formatBytes(fileSize)} total)` : ""}
         </div>
       ) : null}
-      <div className="min-h-0 min-w-0 flex-1 overflow-auto overscroll-contain touch-pan-x touch-pan-y py-2">
+      <div className={`min-h-0 min-w-0 flex-1 overflow-auto py-2 touch-pan-x ${MOBILE_MOMENTUM_SCROLL_CLASS_NAME}`}>
         <HighlightedCode code={textContent} lang={lang} />
       </div>
     </div>
@@ -657,7 +658,7 @@ function FilesBrowser({ sessionId, active }: { sessionId: string; active: boolea
   ) : null;
 
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-y-auto overscroll-contain lg:overflow-hidden">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
       {/* Mobile: if a file is selected, show preview full-width instead of tree */}
       {mobileFilePreview}
 
@@ -693,7 +694,7 @@ function FilesBrowser({ sessionId, active }: { sessionId: string; active: boolea
       {/* Desktop: side-by-side tree + preview.  Mobile: tree only (preview shown above) */}
       <div className={`min-h-0 flex-1 lg:flex lg:flex-row ${selectedPath ? "hidden lg:flex" : "flex flex-col"}`}>
         {/* File tree */}
-        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain py-1 lg:max-w-[320px] lg:border-r lg:border-white/8">
+        <div className={`min-h-0 flex-1 overflow-y-auto py-1 lg:max-w-[320px] lg:border-r lg:border-white/8 ${MOBILE_MOMENTUM_SCROLL_CLASS_NAME}`}>
           {filtered.length === 0 ? (
             <div className="px-3 py-6 text-center text-[12px] text-[var(--vk-text-muted)]">
               {search ? "No files match your search." : "No files in workspace."}
@@ -782,7 +783,7 @@ export function SessionOverview({ session, sessionId, active }: SessionOverviewP
   }, [queueDepth, queuePosition, recoveryState, session.status]);
 
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-y-auto overscroll-contain lg:overflow-hidden">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
       {/* Recovery / queue banner */}
       {recoveryBanner ? (
         <div className="shrink-0 border-b border-amber-500/20 bg-amber-500/8 px-3 py-2">

--- a/packages/web/src/components/sessions/SessionPreview.tsx
+++ b/packages/web/src/components/sessions/SessionPreview.tsx
@@ -33,6 +33,7 @@ import { ScrollArea } from "@/components/ui/ScrollArea";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/Tabs";
 import { cn } from "@/lib/cn";
 import { selectPreviewAutoConnectCandidate } from "@/lib/previewAutoConnect";
+import { MOBILE_MOMENTUM_SCROLL_CLASS_NAME } from "./sessionMobileScroll";
 import type {
   PreviewCommandRequest,
   PreviewDomNode,
@@ -1845,7 +1846,7 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
             ) : null}
           </div>
 
-          <div className="min-h-0 flex-1 overflow-auto overscroll-contain bg-[#0f1012] p-3">
+          <div className={`min-h-0 flex-1 overflow-auto bg-[#0f1012] p-3 ${MOBILE_MOMENTUM_SCROLL_CLASS_NAME}`}>
             <div className="flex h-full min-h-[min(200px,45vh)] w-full items-center justify-center lg:min-h-[260px]">
               {loading ? (
                 <div className="flex items-center gap-2 text-[13px] text-[var(--vk-text-muted)]">
@@ -1858,7 +1859,7 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
                   tabIndex={status?.connected ? 0 : -1}
                   onKeyDown={handlePreviewKeyDown}
                   onPaste={handlePreviewPaste}
-                  className="relative flex max-h-full max-w-full items-start justify-center overflow-auto rounded-[10px] outline-none focus-visible:ring-2 focus-visible:ring-[var(--vk-orange)] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1012]"
+                  className={`relative flex max-h-full max-w-full items-start justify-center overflow-auto rounded-[10px] outline-none focus-visible:ring-2 focus-visible:ring-[var(--vk-orange)] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1012] ${MOBILE_MOMENTUM_SCROLL_CLASS_NAME}`}
                 >
                   <img
                     ref={imageRef}

--- a/packages/web/src/components/sessions/SessionSkills.tsx
+++ b/packages/web/src/components/sessions/SessionSkills.tsx
@@ -39,6 +39,7 @@ import type {
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
 import { Card, CardContent, CardHeader } from "@/components/ui/Card";
+import { MOBILE_MOMENTUM_SCROLL_CLASS_NAME } from "./sessionMobileScroll";
 
 type SessionSkillsProps = {
   session: DashboardSession;
@@ -354,7 +355,7 @@ export function SessionSkills({ session, sessionId, active }: SessionSkillsProps
 
   return (
     <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
-      <div className="min-h-0 min-w-0 flex-1 overflow-y-auto overscroll-contain pb-4 touch-pan-y lg:overflow-hidden lg:pb-0">
+      <div className={`min-h-0 min-w-0 flex-1 overflow-y-auto pb-4 lg:overflow-hidden lg:pb-0 ${MOBILE_MOMENTUM_SCROLL_CLASS_NAME}`}>
         <div className="flex min-h-full min-w-0 flex-col gap-3">
           <Card className="min-w-0">
             <CardHeader className="flex flex-col items-stretch gap-3">

--- a/packages/web/src/components/sessions/SessionTerminal.tsx
+++ b/packages/web/src/components/sessions/SessionTerminal.tsx
@@ -32,6 +32,8 @@ const TERMINAL_CLOSED_STATUSES = new Set(["archived", "killed", "terminated", "r
 const TOKEN_REFRESH_LEAD_SECONDS = 30;
 const TTYD_AUTH_TOKEN_MESSAGE_TYPE = "conductor-ttyd-auth-token";
 const TTYD_AUTH_TOKEN_REQUEST_MESSAGE_TYPE = "conductor-ttyd-auth-token-request";
+const TTYD_READY_MESSAGE_TYPE = "conductor-ttyd-ready";
+const TTYD_RELAY_URL_MESSAGE_TYPE = "conductor-ttyd-relay-url";
 const TERMINAL_RESIZE_DEBOUNCE_MS = 150;
 const TERMINAL_RESIZE_MESSAGE_TYPE = "conductor-terminal-resize";
 /** Staggered fits so xterm catches up after ttyd boot, layout, and fonts. */
@@ -152,6 +154,34 @@ function postTerminalResizeMessage(iframe: HTMLIFrameElement | null | undefined)
   }
 }
 
+function postBridgeRelayUrl(
+  iframe: HTMLIFrameElement | null | undefined,
+  relayTtydWsUrl: string | null,
+): void {
+  if (!iframe?.contentWindow || !relayTtydWsUrl) {
+    return;
+  }
+
+  let targetOrigin: string;
+  try {
+    targetOrigin = new URL(iframe.src).origin;
+  } catch {
+    targetOrigin = typeof window !== "undefined" ? window.location.origin : "";
+  }
+  if (!targetOrigin || targetOrigin === "null") {
+    return;
+  }
+
+  try {
+    iframe.contentWindow.postMessage(
+      { type: TTYD_RELAY_URL_MESSAGE_TYPE, relayTtydWsUrl },
+      targetOrigin,
+    );
+  } catch {
+    // Iframe may have navigated or origin may be opaque.
+  }
+}
+
 function SessionTerminalView(props: SessionTerminalProps) {
   const {
     sessionId,
@@ -205,6 +235,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
 
   const [terminalUrl, setTerminalUrl] = useState<string | null>(null);
   const [terminalLinkUrl, setTerminalLinkUrl] = useState<string | null>(null);
+  const [terminalRelayWsUrl, setTerminalRelayWsUrl] = useState<string | null>(null);
   const [resolvingConnection, setResolvingConnection] = useState(expectsLiveTerminal);
   const [connectionError, setConnectionError] = useState<string | null>(null);
   const [frameLoaded, setFrameLoaded] = useState(false);
@@ -217,6 +248,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
   const [attachmentUploading, setAttachmentUploading] = useState(false);
   const [keyboardVisible, setKeyboardVisible] = useState(false);
   const terminalUrlRef = useRef<string | null>(null);
+  const terminalRelayWsUrlRef = useRef<string | null>(null);
   const forceTerminalReloadRef = useRef(false);
   const resizeSuppressUntilRef = useRef(0);
   /** Last host box we told the ttyd iframe to fit to — avoids spamming resize (xterm refit jumps scroll). */
@@ -280,6 +312,11 @@ function SessionTerminalView(props: SessionTerminalProps) {
     postTerminalAuthToken(iframe, token);
   }, [terminalLinkUrl]);
 
+  const syncBridgeRelayUrl = useCallback(() => {
+    const iframe = ttydIframeRef.current;
+    postBridgeRelayUrl(iframe, terminalRelayWsUrl);
+  }, [terminalRelayWsUrl]);
+
   const requestSilentConnectionRefresh = useCallback((options?: {
     force?: boolean;
     resetResizeCache?: boolean;
@@ -305,6 +342,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
 
     if (options?.syncCurrentToken !== false) {
       syncTerminalAuthToken();
+      syncBridgeRelayUrl();
       scheduleTerminalResizeBurst();
     }
 
@@ -314,11 +352,15 @@ function SessionTerminalView(props: SessionTerminalProps) {
     } else {
       silentRefreshCountRef.current += 1;
     }
-  }, [expectsLiveTerminal, scheduleTerminalResizeBurst, syncTerminalAuthToken]);
+  }, [expectsLiveTerminal, scheduleTerminalResizeBurst, syncBridgeRelayUrl, syncTerminalAuthToken]);
 
   useEffect(() => {
     terminalUrlRef.current = terminalUrl;
   }, [terminalUrl]);
+
+  useEffect(() => {
+    terminalRelayWsUrlRef.current = terminalRelayWsUrl;
+  }, [terminalRelayWsUrl]);
 
   useEffect(() => {
     frameLoadedRef.current = frameLoaded;
@@ -332,6 +374,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
     retryAttemptRef.current = 0;
     setTerminalUrl(null);
     setTerminalLinkUrl(null);
+    setTerminalRelayWsUrl(null);
     setResolvingConnection(expectsLiveTerminal);
     setConnectionError(null);
     setFrameLoaded(false);
@@ -365,6 +408,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
     }
     setTerminalUrl(null);
     setTerminalLinkUrl(null);
+    setTerminalRelayWsUrl(null);
     setFrameLoaded(false);
     setConnectionError(null);
     forceTerminalReloadRef.current = false;
@@ -427,39 +471,45 @@ function SessionTerminalView(props: SessionTerminalProps) {
         if (cancelled || !expectsLiveTerminalRef.current) return;
         retryAttemptRef.current = 0;
         if (connection.interactive && connection.terminalUrl) {
+          const nextTerminalLinkUrl = connection.terminalLinkUrl ?? connection.terminalUrl;
+          const nextRelayTtydWsUrl = connection.relayTtydWsUrl ?? null;
+          const relayUrlChanged = terminalRelayWsUrlRef.current !== nextRelayTtydWsUrl;
           const shouldReloadTerminal =
             forceTerminalReloadRef.current ||
             terminalUrlNeedsReload(terminalUrlRef.current, connection.terminalUrl);
           forceTerminalReloadRef.current = false;
 
-          // Always update the external link URL
-          setTerminalLinkUrl(connection.terminalUrl);
+          // Always update the external link URL and relay metadata.
+          setTerminalLinkUrl(nextTerminalLinkUrl);
+          setTerminalRelayWsUrl(nextRelayTtydWsUrl);
 
-          // Check if only the token changed - we can sync without iframe reload
+          // Check if only the token changed - we can sync without iframe reload.
           const onlyTokenChanged = !shouldReloadTerminal &&
             terminalUrlRef.current &&
             isOnlyTokenChanged(terminalUrlRef.current, connection.terminalUrl);
 
           if (shouldReloadTerminal || !terminalUrlRef.current) {
-            // Full reload needed - either first load, forced reload, or structural URL change
+            // Full reload needed - either first load, forced reload, or structural URL change.
             if (!terminalUrlRef.current) {
               setFrameLoaded(false);
             }
             setTerminalUrl(connection.terminalUrl);
-          } else if (onlyTokenChanged) {
-            // Token-only refresh: sync via postMessage without reloading iframe
-            const newToken = (() => {
-              try {
-                return new URL(connection.terminalUrl).searchParams.get("token");
-              } catch {
-                return null;
-              }
-            })();
-            if (newToken) {
-              const iframe = ttydIframeRef.current;
-              if (iframe) {
+          } else {
+            const iframe = ttydIframeRef.current;
+            if (onlyTokenChanged && iframe) {
+              const newToken = (() => {
+                try {
+                  return new URL(connection.terminalUrl).searchParams.get("token");
+                } catch {
+                  return null;
+                }
+              })();
+              if (newToken) {
                 postTerminalAuthToken(iframe, newToken);
               }
+            }
+            if (relayUrlChanged && iframe) {
+              postBridgeRelayUrl(iframe, nextRelayTtydWsUrl);
             }
           }
           setConnectionError(null);
@@ -479,6 +529,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
         if (!terminalUrlRef.current) {
           setTerminalUrl(null);
           setTerminalLinkUrl(null);
+          setTerminalRelayWsUrl(null);
           setFrameLoaded(false);
         }
         setConnectionError(connection.reason ?? "Live ttyd terminal is unavailable.");
@@ -492,6 +543,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
         if (!hasTerminal) {
           setTerminalUrl(null);
           setTerminalLinkUrl(null);
+          setTerminalRelayWsUrl(null);
           setFrameLoaded(false);
         }
         setConnectionError(
@@ -663,10 +715,19 @@ function SessionTerminalView(props: SessionTerminalProps) {
       if (!event.data || typeof event.data !== "object") {
         return;
       }
-      if ((event.data as { type?: string }).type !== TTYD_AUTH_TOKEN_REQUEST_MESSAGE_TYPE) {
+      if (event.source !== ttydIframeRef.current?.contentWindow) {
         return;
       }
-      if (event.source !== ttydIframeRef.current?.contentWindow) {
+
+      const type = (event.data as { type?: string }).type;
+      if (type === TTYD_READY_MESSAGE_TYPE) {
+        setFrameLoaded(true);
+        setConnectionError(null);
+        scheduleTerminalResizeBurst();
+        maybePostTerminalResize();
+        return;
+      }
+      if (type !== TTYD_AUTH_TOKEN_REQUEST_MESSAGE_TYPE) {
         return;
       }
 
@@ -678,7 +739,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
     return () => {
       window.removeEventListener("message", handleMessage);
     };
-  }, [requestSilentConnectionRefresh]);
+  }, [maybePostTerminalResize, requestSilentConnectionRefresh, scheduleTerminalResizeBurst]);
 
   useEffect(() => {
     if (!pendingInsert || pendingInsert.nonce <= lastAppliedInsertNonceRef.current) {
@@ -718,7 +779,8 @@ function SessionTerminalView(props: SessionTerminalProps) {
     }
 
     syncTerminalAuthToken();
-  }, [frameLoaded, syncTerminalAuthToken]);
+    syncBridgeRelayUrl();
+  }, [frameLoaded, syncBridgeRelayUrl, syncTerminalAuthToken]);
 
   useEffect(() => {
     if (!expectsLiveTerminal || !terminalUrl || frameLoaded) {
@@ -944,6 +1006,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
         ttydBacked,
         terminalUrl,
         terminalLinkUrl,
+        terminalRelayWsUrl,
         frameLoaded,
         resolvingConnection,
         connectionError,
@@ -983,6 +1046,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
     sessionId,
     terminalUrl,
     terminalLinkUrl,
+    terminalRelayWsUrl,
     ttydBacked,
   ]);
 
@@ -1140,10 +1204,11 @@ function SessionTerminalView(props: SessionTerminalProps) {
                 if (firstFrameLoadedAtRef.current === null) {
                   firstFrameLoadedAtRef.current = now;
                 }
-                setFrameLoaded(true);
+                setFrameLoaded(false);
                 setConnectionError(null);
                 applyKeyboardAwareTerminalHeight();
                 syncTerminalAuthToken();
+                syncBridgeRelayUrl();
                 scheduleTerminalResizeBurst();
               }}
             />

--- a/packages/web/src/components/sessions/SessionTerminal.tsx
+++ b/packages/web/src/components/sessions/SessionTerminal.tsx
@@ -8,7 +8,6 @@
 import {
   AlertCircle,
   Clipboard,
-  ExternalLink,
   FileUp,
   Loader2,
   RefreshCw,
@@ -1111,23 +1110,6 @@ function SessionTerminalView(props: SessionTerminalProps) {
             <FileUp className="h-3.5 w-3.5" />
           )}
         </Button>
-        {terminalDirectHref ? (
-          <Button
-            asChild
-            size="icon"
-            variant="ghost"
-            className="h-9 w-9 rounded-full border border-white/10 bg-[#141010]/92 text-[#c9c0b7] backdrop-blur-sm hover:bg-[#201818] sm:h-7 sm:w-7"
-          >
-            <a
-              href={terminalSessionHref}
-              target="_blank"
-              rel="noreferrer"
-              aria-label="Open full terminal page in new tab"
-            >
-              <ExternalLink className="h-3.5 w-3.5" />
-            </a>
-          </Button>
-        ) : null}
         {typeof window !== "undefined" && window.matchMedia?.("(pointer: coarse)").matches ? (
           <Button
             type="button"

--- a/packages/web/src/components/sessions/sessionMobileScroll.test.ts
+++ b/packages/web/src/components/sessions/sessionMobileScroll.test.ts
@@ -13,6 +13,13 @@ test("non-immersive session detail keeps tab panes as the only mobile scroll con
   assert.doesNotMatch(className, /overflow-y-auto/);
 });
 
+test("immersive session detail keeps overflow clipped while applying the terminal backdrop", () => {
+  const className = getSessionDetailRootClassName(true);
+
+  assert.match(className, /overflow-hidden/);
+  assert.match(className, /bg-\[#060404\]/);
+});
+
 test("mobile momentum scroll helper opts into touch-friendly vertical scrolling", () => {
   assert.match(MOBILE_MOMENTUM_SCROLL_CLASS_NAME, /overscroll-contain/);
   assert.match(MOBILE_MOMENTUM_SCROLL_CLASS_NAME, /touch-pan-y/);

--- a/packages/web/src/components/sessions/sessionMobileScroll.test.ts
+++ b/packages/web/src/components/sessions/sessionMobileScroll.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  MOBILE_MOMENTUM_SCROLL_CLASS_NAME,
+  getSessionDetailRootClassName,
+} from "./sessionMobileScroll";
+
+test("non-immersive session detail keeps tab panes as the only mobile scroll containers", () => {
+  const className = getSessionDetailRootClassName(false);
+
+  assert.match(className, /overflow-hidden/);
+  assert.doesNotMatch(className, /overflow-y-auto/);
+});
+
+test("mobile momentum scroll helper opts into touch-friendly vertical scrolling", () => {
+  assert.match(MOBILE_MOMENTUM_SCROLL_CLASS_NAME, /overscroll-contain/);
+  assert.match(MOBILE_MOMENTUM_SCROLL_CLASS_NAME, /touch-pan-y/);
+  assert.match(MOBILE_MOMENTUM_SCROLL_CLASS_NAME, /-webkit-overflow-scrolling:touch/);
+});

--- a/packages/web/src/components/sessions/sessionMobileScroll.ts
+++ b/packages/web/src/components/sessions/sessionMobileScroll.ts
@@ -1,0 +1,10 @@
+export const MOBILE_MOMENTUM_SCROLL_CLASS_NAME = "overscroll-contain touch-pan-y [-webkit-overflow-scrolling:touch]";
+
+export function getSessionDetailRootClassName(immersiveTerminalActive: boolean): string {
+  return [
+    "flex h-full min-h-0 min-w-0 w-full flex-col",
+    immersiveTerminalActive
+      ? "overflow-hidden bg-[#060404]"
+      : "overflow-hidden",
+  ].join(" ");
+}

--- a/packages/web/src/components/sessions/terminal/terminalApi.test.ts
+++ b/packages/web/src/components/sessions/terminal/terminalApi.test.ts
@@ -217,6 +217,30 @@ test("resolveTerminalConnection keeps the embedded iframe on the proxied ttyd pa
   );
 });
 
+test("resolveTerminalConnection keeps direct terminal links on the proxy origin when auth is cookie-scoped", async () => {
+  setWindowLocation("https://dashboard.example.com/sessions/session-cookie");
+  setBackendOriginMeta("https://api.example.com/internal");
+  setFetchResponse({
+    required: true,
+    ttydHttpUrl: "/api/sessions/session-cookie/terminal/ttyd",
+    ttydWsUrl: "/api/sessions/session-cookie/terminal/ttyd/ws",
+    tunnelUrl: "https://violet-waterfall.trycloudflare.com",
+    expiresInSeconds: 3600,
+  });
+
+  const connection = await resolveTerminalConnection("session-cookie");
+
+  assert.equal(connection.interactive, true);
+  assert.equal(
+    connection.terminalUrl,
+    "https://dashboard.example.com/api/sessions/session-cookie/terminal/ttyd",
+  );
+  assert.equal(
+    connection.terminalLinkUrl,
+    "https://dashboard.example.com/api/sessions/session-cookie/terminal/ttyd",
+  );
+});
+
 test("resolveTerminalConnection keeps bridge iframe urls stable and exposes relay websocket refresh metadata", async () => {
   setWindowLocation("https://app.conductross.com/sessions/bridge-session");
   setBackendOriginMeta("https://api.conductross.com");

--- a/packages/web/src/components/sessions/terminal/terminalApi.test.ts
+++ b/packages/web/src/components/sessions/terminal/terminalApi.test.ts
@@ -193,3 +193,53 @@ test("resolveTerminalConnection preserves bridge scope on proxied ttyd routes", 
     "https://app.conductross.com/api/sessions/session-bridge/terminal/ttyd?bridgeId=bridge-prod",
   );
 });
+
+test("resolveTerminalConnection keeps the embedded iframe on the proxied ttyd path even when a tunnel url exists", async () => {
+  setWindowLocation("https://dashboard.example.com/sessions/session-4");
+  setBackendOriginMeta("https://api.example.com/internal");
+  setFetchResponse({
+    required: true,
+    ttydHttpUrl: "/api/sessions/session-4/terminal/ttyd?token=proxy-token",
+    ttydWsUrl: "/api/sessions/session-4/terminal/ttyd/ws?token=proxy-token",
+    tunnelUrl: "https://violet-waterfall.trycloudflare.com",
+  });
+
+  const connection = await resolveTerminalConnection("session-4");
+
+  assert.equal(connection.interactive, true);
+  assert.equal(
+    connection.terminalUrl,
+    "https://dashboard.example.com/api/sessions/session-4/terminal/ttyd?token=proxy-token",
+  );
+  assert.equal(
+    connection.terminalLinkUrl,
+    "https://violet-waterfall.trycloudflare.com/?token=proxy-token",
+  );
+});
+
+test("resolveTerminalConnection keeps bridge iframe urls stable and exposes relay websocket refresh metadata", async () => {
+  setWindowLocation("https://app.conductross.com/sessions/bridge-session");
+  setBackendOriginMeta("https://api.conductross.com");
+  setFetchResponse({
+    required: true,
+    ttydHttpUrl: "/api/sessions/bridge%3Adevice-1%3Asession-9/terminal/ttyd?bridgeId=device-1",
+    ttydWsUrl: "wss://relay.example.com/terminal/old/browser?jwt=old",
+    relayTtydWsUrl: "wss://relay.example.com/terminal/new/browser?jwt=new",
+  });
+
+  const connection = await resolveTerminalConnection("bridge:device-1:session-9", { bridgeId: "device-1" });
+
+  assert.equal(connection.interactive, true);
+  assert.equal(
+    connection.terminalUrl,
+    "https://app.conductross.com/api/sessions/bridge%3Adevice-1%3Asession-9/terminal/ttyd?bridgeId=device-1",
+  );
+  assert.equal(
+    connection.terminalLinkUrl,
+    "https://app.conductross.com/api/sessions/bridge%3Adevice-1%3Asession-9/terminal/ttyd?bridgeId=device-1",
+  );
+  assert.equal(
+    connection.relayTtydWsUrl,
+    "wss://relay.example.com/terminal/new/browser?jwt=new",
+  );
+});

--- a/packages/web/src/components/sessions/terminal/terminalApi.ts
+++ b/packages/web/src/components/sessions/terminal/terminalApi.ts
@@ -94,9 +94,17 @@ type TerminalTokenResult =
     ttydHttpUrl: string | null;
     ttydWsUrl: string | null;
     tunnelUrl: string | null;
+    relayTtydWsUrl: string | null;
     expiresInSeconds: number | null;
   }
-  | { interactive: false; ttydHttpUrl: null; ttydWsUrl: null; tunnelUrl: null; reason: string | null };
+  | {
+    interactive: false;
+    ttydHttpUrl: null;
+    ttydWsUrl: null;
+    tunnelUrl: null;
+    relayTtydWsUrl: null;
+    reason: string | null;
+  };
 
 function resolveProvidedTtydHttpUrl(
   ttydHttpUrl: string | null,
@@ -180,6 +188,7 @@ async function fetchTerminalToken(
       ttydHttpUrl?: string;
       ttydWsUrl?: string;
       tunnelUrl?: string;
+      relayTtydWsUrl?: string;
       expiresInSeconds?: number | string | null;
       error?: string;
     }
@@ -195,6 +204,10 @@ async function fetchTerminalToken(
   const tunnelUrl =
     typeof data?.tunnelUrl === "string" && data.tunnelUrl.trim().length > 0
       ? data.tunnelUrl.trim()
+      : null;
+  const relayTtydWsUrl =
+    typeof data?.relayTtydWsUrl === "string" && data.relayTtydWsUrl.trim().length > 0
+      ? data.relayTtydWsUrl.trim()
       : null;
   const expiresInSeconds = (() => {
     const raw = data?.expiresInSeconds;
@@ -216,6 +229,7 @@ async function fetchTerminalToken(
       ttydHttpUrl: null,
       ttydWsUrl: null,
       tunnelUrl: null,
+      relayTtydWsUrl: null,
       reason: data?.error ?? "Terminal access denied",
     };
   }
@@ -226,6 +240,7 @@ async function fetchTerminalToken(
       ttydHttpUrl: null,
       ttydWsUrl: null,
       tunnelUrl: null,
+      relayTtydWsUrl: null,
       reason: data?.error ?? "Terminal unavailable",
     };
   }
@@ -235,8 +250,42 @@ async function fetchTerminalToken(
     ttydHttpUrl,
     ttydWsUrl,
     tunnelUrl,
+    relayTtydWsUrl,
     expiresInSeconds,
   };
+}
+
+function extractResolvedTerminalToken(terminalUrl: string | null): string | null {
+  if (!terminalUrl) {
+    return null;
+  }
+
+  try {
+    return new URL(terminalUrl).searchParams.get("token");
+  } catch {
+    return null;
+  }
+}
+
+function buildDirectTerminalLinkUrl(
+  embeddedTerminalUrl: string,
+  auth: Extract<TerminalTokenResult, { interactive: true }>,
+  bridgeId?: string | null,
+): string {
+  if (bridgeId?.trim() || !auth.tunnelUrl) {
+    return embeddedTerminalUrl;
+  }
+
+  try {
+    const directUrl = new URL(auth.tunnelUrl);
+    const token = extractResolvedTerminalToken(embeddedTerminalUrl);
+    if (token) {
+      directUrl.searchParams.set("token", token);
+    }
+    return directUrl.toString();
+  } catch {
+    return embeddedTerminalUrl;
+  }
 }
 
 export async function resolveTerminalConnection(
@@ -246,9 +295,11 @@ export async function resolveTerminalConnection(
   const backendOrigin = resolveBackendOrigin();
   const dashboardOrigin = resolveDashboardOrigin();
   const auth = await fetchTerminalToken(sessionId, options);
-  if (!auth.interactive) {
+  if (auth.interactive === false) {
     return {
       terminalUrl: null,
+      terminalLinkUrl: null,
+      relayTtydWsUrl: null,
       interactive: false,
       reason: auth.reason,
       expiresInSeconds: null,
@@ -256,34 +307,9 @@ export async function resolveTerminalConnection(
     };
   }
 
-  // When a cloudflare tunnel URL is available, use it directly instead of the
-  // proxied path. Tunnel URLs bypass the Next.js proxy entirely and connect
-  // the browser straight to ttyd through the tunnel, eliminating proxy
-  // latency and resize coordination overhead.
-  if (auth.tunnelUrl) {
-    try {
-      const tunnelTerminalUrl = new URL(auth.tunnelUrl);
-      // Preserve any token parameter from the backend response.
-      const ttydUrl = new URL(auth.ttydHttpUrl ?? auth.ttydWsUrl ?? "", backendOrigin);
-      const token = ttydUrl.searchParams.get("token");
-      if (token) {
-        tunnelTerminalUrl.searchParams.set("token", token);
-      }
-      return {
-        terminalUrl: appendBridgeIdToTerminalUrl(tunnelTerminalUrl.toString(), options?.bridgeId),
-        interactive: true,
-        reason: null,
-        expiresInSeconds: auth.expiresInSeconds,
-        tunnelUrl: auth.tunnelUrl,
-      };
-    } catch {
-      // If tunnel URL is malformed, fall through to the proxy path.
-    }
-  }
-
-  // Keep dashboard proxy ttyd routes on the dashboard origin so hosted auth
-  // and bridge-aware Next.js proxying stay in the request path. Only direct
-  // backend ttyd URLs should resolve against the backend origin.
+  // Keep the embedded iframe on the shimmed proxy path so auth sync, resize
+  // coordination, touch, and lifecycle hardening always stay in play. Tunnel
+  // URLs are exposed only as direct-open links for non-bridge sessions.
   const resolvedTerminalUrl = resolveProvidedTtydHttpUrl(
     auth.ttydHttpUrl,
     auth.ttydWsUrl,
@@ -293,13 +319,20 @@ export async function resolveTerminalConnection(
   if (!resolvedTerminalUrl) {
     return {
       terminalUrl: null,
+      terminalLinkUrl: null,
+      relayTtydWsUrl: null,
       interactive: false,
       reason: "Failed to resolve the ttyd terminal URL.",
     };
   }
 
+  const embeddedTerminalUrl = appendBridgeIdToTerminalUrl(resolvedTerminalUrl, options?.bridgeId);
+  const terminalLinkUrl = buildDirectTerminalLinkUrl(embeddedTerminalUrl, auth, options?.bridgeId);
+
   return {
-    terminalUrl: appendBridgeIdToTerminalUrl(resolvedTerminalUrl, options?.bridgeId),
+    terminalUrl: embeddedTerminalUrl,
+    terminalLinkUrl,
+    relayTtydWsUrl: auth.relayTtydWsUrl,
     interactive: true,
     reason: null,
     expiresInSeconds: auth.expiresInSeconds,

--- a/packages/web/src/components/sessions/terminal/terminalApi.ts
+++ b/packages/web/src/components/sessions/terminal/terminalApi.ts
@@ -279,9 +279,10 @@ function buildDirectTerminalLinkUrl(
   try {
     const directUrl = new URL(auth.tunnelUrl);
     const token = extractResolvedTerminalToken(embeddedTerminalUrl);
-    if (token) {
-      directUrl.searchParams.set("token", token);
+    if (!token) {
+      return embeddedTerminalUrl;
     }
+    directUrl.searchParams.set("token", token);
     return directUrl.toString();
   } catch {
     return embeddedTerminalUrl;

--- a/packages/web/src/components/sessions/terminal/terminalTypes.ts
+++ b/packages/web/src/components/sessions/terminal/terminalTypes.ts
@@ -26,6 +26,8 @@ export interface SessionTerminalProps {
 
 export type TerminalConnectionInfo = {
   terminalUrl: string | null;
+  terminalLinkUrl?: string | null;
+  relayTtydWsUrl?: string | null;
   interactive: boolean;
   reason: string | null;
   expiresInSeconds?: number | null;

--- a/packages/web/src/lib/bridgeTtyd.test.ts
+++ b/packages/web/src/lib/bridgeTtyd.test.ts
@@ -60,6 +60,8 @@ test("injectBridgeTtydRelayShim rewrites ttyd websocket connects through relay",
   assert.match(injected, /READY_MESSAGE_TYPE = 'conductor-ttyd-ready'/);
   assert.match(injected, /RELAY_UPDATE_MESSAGE_TYPE = 'conductor-ttyd-relay-url'/);
   assert.match(injected, /window\.parent\.postMessage\(\{ type: READY_MESSAGE_TYPE \}, '\*'\)/);
+  assert.match(injected, /const trustedParentOrigin = window\.location\.origin/);
+  assert.match(injected, /event\.origin !== trustedParentOrigin/);
   assert.match(injected, /currentRelayTtydWsUrl = nextRelayUrl/);
   assert.ok(
     injected.indexOf("conductor-bridge-ttyd-relay-shim") < injected.indexOf("<script src=\"/refresh.js\">"),
@@ -97,6 +99,11 @@ test("buildPatchedTtydHtmlResponse drops stale body headers after html injection
   assert.equal(patched.headers.get("content-length"), null);
   assert.equal(patched.headers.get("content-encoding"), null);
   assert.equal(patched.headers.get("etag"), null);
-  assert.equal(patched.headers.get("cache-control"), "no-store");
+  assert.equal(
+    patched.headers.get("cache-control"),
+    "no-store, no-cache, must-revalidate, max-age=0",
+  );
+  assert.equal(patched.headers.get("pragma"), "no-cache");
+  assert.equal(patched.headers.get("expires"), "0");
   assert.equal(await patched.text(), "<html><body>new</body></html>");
 });

--- a/packages/web/src/lib/bridgeTtyd.test.ts
+++ b/packages/web/src/lib/bridgeTtyd.test.ts
@@ -4,6 +4,8 @@ import test from "node:test";
 import {
   BRIDGE_TTYD_RELAY_WS_QUERY_PARAM,
   buildBridgeTtydProxyUrl,
+  buildPatchedTtydHtmlResponse,
+  buildStableBridgeTtydProxyUrl,
   injectBridgeTtydRelayShim,
   injectTtydResizeShim,
 } from "./bridgeTtyd";
@@ -24,6 +26,18 @@ test("buildBridgeTtydProxyUrl preserves session scope and relay ttyd ws", () => 
   );
 });
 
+test("buildStableBridgeTtydProxyUrl keeps the iframe url stable across relay refreshes", () => {
+  const url = buildStableBridgeTtydProxyUrl(
+    "bridge:device-1:session-9",
+    "device-1",
+  );
+
+  const resolved = new URL(url, "https://app.conductross.com");
+  assert.equal(resolved.pathname, "/api/sessions/bridge%3Adevice-1%3Asession-9/terminal/ttyd");
+  assert.equal(resolved.searchParams.get("bridgeId"), "device-1");
+  assert.equal(resolved.searchParams.get(BRIDGE_TTYD_RELAY_WS_QUERY_PARAM), null);
+});
+
 test("injectBridgeTtydRelayShim rewrites ttyd websocket connects through relay", () => {
   const html = "<html><head><script src=\"/refresh.js\"></script></head><body><script>console.log('ttyd');</script></body></html>";
   const injected = injectBridgeTtydRelayShim(
@@ -32,17 +46,21 @@ test("injectBridgeTtydRelayShim rewrites ttyd websocket connects through relay",
   );
 
   assert.match(injected, /conductor-bridge-ttyd-relay-shim/);
-  assert.match(injected, /RELAY_TTYD_WS_URL/);
+  assert.match(injected, /currentRelayTtydWsUrl/);
   assert.match(injected, /REQUEST_MESSAGE_TYPE = 'conductor-ttyd-auth-token-request'/);
-  assert.match(injected, /TOKEN_REQUEST_THROTTLE_MS = 1500/);
+  assert.match(injected, /TOKEN_REQUEST_THROTTLE_MS/);
   assert.match(injected, /LOOPBACK_HOSTS/);
-  assert.match(injected, /candidate\.hostname/);
+
   assert.match(injected, /candidate\.pathname === '\/'/);
   assert.match(injected, /candidate\.pathname === '\/ws'/);
   assert.match(injected, /candidate\.pathname\.endsWith\('\/ws'\)/);
-  assert.match(injected, /normalizedUrl = RELAY_TTYD_WS_URL/);
+  assert.match(injected, /normalizedUrl = currentRelayTtydWsUrl/);
   assert.match(injected, /requestFreshRelay\('bridge-websocket-close'\)/);
   assert.match(injected, /requestFreshRelay\('bridge-websocket-error'\)/);
+  assert.match(injected, /READY_MESSAGE_TYPE = 'conductor-ttyd-ready'/);
+  assert.match(injected, /RELAY_UPDATE_MESSAGE_TYPE = 'conductor-ttyd-relay-url'/);
+  assert.match(injected, /window\.parent\.postMessage\(\{ type: READY_MESSAGE_TYPE \}, '\*'\)/);
+  assert.match(injected, /currentRelayTtydWsUrl = nextRelayUrl/);
   assert.ok(
     injected.indexOf("conductor-bridge-ttyd-relay-shim") < injected.indexOf("<script src=\"/refresh.js\">"),
     "relay shim should be injected before ttyd bootstrap scripts",
@@ -59,4 +77,26 @@ test("injectTtydResizeShim matches backend ttyd scroll-preservation resize behav
     /syncViewportSizeEmbedded\(\);\s*\/\/ Match TTYD_RESIZE_SHIM boot/,
     "initial sync should be followed by a resize burst like terminal.rs",
   );
+});
+
+test("buildPatchedTtydHtmlResponse drops stale body headers after html injection", async () => {
+  const proxied = new Response("<html><body>old</body></html>", {
+    status: 200,
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      "content-length": "123",
+      "content-encoding": "gzip",
+      etag: '"abc123"',
+      "cache-control": "no-store",
+    },
+  });
+
+  const patched = buildPatchedTtydHtmlResponse(proxied, "<html><body>new</body></html>");
+
+  assert.equal(patched.headers.get("content-type"), "text/html; charset=utf-8");
+  assert.equal(patched.headers.get("content-length"), null);
+  assert.equal(patched.headers.get("content-encoding"), null);
+  assert.equal(patched.headers.get("etag"), null);
+  assert.equal(patched.headers.get("cache-control"), "no-store");
+  assert.equal(await patched.text(), "<html><body>new</body></html>");
 });

--- a/packages/web/src/lib/bridgeTtyd.ts
+++ b/packages/web/src/lib/bridgeTtyd.ts
@@ -46,6 +46,39 @@ export function buildBridgeTtydProxyUrl(
   return `${url.pathname}${url.search}`;
 }
 
+export function buildStableBridgeTtydProxyUrl(
+  routeSessionId: string,
+  bridgeId: string,
+): string {
+  const url = new URL(`/api/sessions/${encodeURIComponent(routeSessionId)}/terminal/ttyd`, "http://dashboard.local");
+  url.searchParams.set("bridgeId", bridgeId);
+  return `${url.pathname}${url.search}`;
+}
+
+const PATCHED_TTYD_RESPONSE_HEADERS_TO_DROP = [
+  "content-length",
+  "content-encoding",
+  "etag",
+  "last-modified",
+  "transfer-encoding",
+] as const;
+
+export function buildPatchedTtydHtmlResponse(proxied: Response, html: string): Response {
+  const headers = new Headers(proxied.headers);
+  for (const headerName of PATCHED_TTYD_RESPONSE_HEADERS_TO_DROP) {
+    headers.delete(headerName);
+  }
+  if (!headers.has("content-type")) {
+    headers.set("content-type", "text/html; charset=utf-8");
+  }
+
+  return new Response(html, {
+    status: proxied.status,
+    statusText: proxied.statusText,
+    headers,
+  });
+}
+
 function injectBridgeTtydHtmlFragmentEarly(html: string, marker: string, fragment: string): string {
   if (html.includes(marker)) {
     return html;
@@ -421,17 +454,27 @@ export function injectBridgeTtydRelayShim(html: string, relayTtydWsUrl: string):
   if (window.__conductorBridgeTtydRelayPatched) return;
   window.__conductorBridgeTtydRelayPatched = true;
 
-  const RELAY_TTYD_WS_URL = ${relayWsLiteral};
-  if (!RELAY_TTYD_WS_URL) return;
-
   const REQUEST_MESSAGE_TYPE = 'conductor-ttyd-auth-token-request';
+  const READY_MESSAGE_TYPE = 'conductor-ttyd-ready';
+  const RELAY_UPDATE_MESSAGE_TYPE = 'conductor-ttyd-relay-url';
   const TOKEN_REQUEST_THROTTLE_MS = 1500;
   const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
   const previousWebSocket = window.WebSocket;
   if (typeof previousWebSocket !== 'function') return;
 
+  let currentRelayTtydWsUrl = ${relayWsLiteral};
+  if (!currentRelayTtydWsUrl) return;
+
   let lastTokenRequestAt = 0;
   let unloading = false;
+
+  function notifyReady() {
+    if (unloading || !window.parent || window.parent === window) return;
+    try {
+      window.parent.postMessage({ type: READY_MESSAGE_TYPE }, '*');
+    } catch {
+    }
+  }
 
   function requestFreshRelay(reason) {
     if (unloading || !window.parent || window.parent === window) return;
@@ -453,6 +496,9 @@ export function injectBridgeTtydRelayShim(html: string, relayTtydWsUrl: string):
     if (!socket || socket.__conductorTokenRefreshHookAttached) return socket;
 
     socket.__conductorTokenRefreshHookAttached = true;
+    socket.addEventListener('open', function() {
+      notifyReady();
+    });
     socket.addEventListener('close', function() {
       requestFreshRelay('bridge-websocket-close');
     });
@@ -462,7 +508,7 @@ export function injectBridgeTtydRelayShim(html: string, relayTtydWsUrl: string):
     return socket;
   }
 
-  const patchedWebSocket = function(url, protocols) {
+  function normalizedRelayUrl(url) {
     let normalizedUrl = String(url);
     try {
       const candidate = new URL(normalizedUrl, window.location.href);
@@ -472,11 +518,15 @@ export function injectBridgeTtydRelayShim(html: string, relayTtydWsUrl: string):
         candidate.pathname === '/ws' ||
         candidate.pathname.endsWith('/ws')
       ) {
-        normalizedUrl = RELAY_TTYD_WS_URL;
+        normalizedUrl = currentRelayTtydWsUrl;
       }
     } catch {
     }
+    return normalizedUrl;
+  }
 
+  const patchedWebSocket = function(url, protocols) {
+    const normalizedUrl = normalizedRelayUrl(url);
     if (arguments.length > 1) {
       return attachSocketListeners(new previousWebSocket(normalizedUrl, protocols));
     }
@@ -487,8 +537,25 @@ export function injectBridgeTtydRelayShim(html: string, relayTtydWsUrl: string):
   patchedWebSocket.prototype = previousWebSocket.prototype;
   window.WebSocket = patchedWebSocket;
 
+  function handleMessage(event) {
+    if (event.source !== window.parent) {
+      return;
+    }
+    const data = event.data;
+    if (!data || typeof data !== 'object' || data.type !== RELAY_UPDATE_MESSAGE_TYPE) {
+      return;
+    }
+    const nextRelayUrl = typeof data.relayTtydWsUrl === 'string' ? data.relayTtydWsUrl.trim() : '';
+    if (!nextRelayUrl) {
+      return;
+    }
+    currentRelayTtydWsUrl = nextRelayUrl;
+  }
+
+  window.addEventListener('message', handleMessage);
   window.addEventListener('beforeunload', function() {
     unloading = true;
+    window.removeEventListener('message', handleMessage);
   }, { once: true });
 })();
 </script>`;

--- a/packages/web/src/lib/bridgeTtyd.ts
+++ b/packages/web/src/lib/bridgeTtyd.ts
@@ -35,24 +35,32 @@ export function resolveBridgeSessionTarget(
   return { bridgeId, sessionId };
 }
 
+function buildBridgeTtydProxyPath(
+  routeSessionId: string,
+  bridgeId: string,
+  relayTtydWsUrl?: string,
+): string {
+  const url = new URL(`/api/sessions/${encodeURIComponent(routeSessionId)}/terminal/ttyd`, "http://dashboard.local");
+  url.searchParams.set("bridgeId", bridgeId);
+  if (relayTtydWsUrl) {
+    url.searchParams.set(BRIDGE_TTYD_RELAY_WS_QUERY_PARAM, relayTtydWsUrl);
+  }
+  return `${url.pathname}${url.search}`;
+}
+
 export function buildBridgeTtydProxyUrl(
   routeSessionId: string,
   bridgeId: string,
   relayTtydWsUrl: string,
 ): string {
-  const url = new URL(`/api/sessions/${encodeURIComponent(routeSessionId)}/terminal/ttyd`, "http://dashboard.local");
-  url.searchParams.set("bridgeId", bridgeId);
-  url.searchParams.set(BRIDGE_TTYD_RELAY_WS_QUERY_PARAM, relayTtydWsUrl);
-  return `${url.pathname}${url.search}`;
+  return buildBridgeTtydProxyPath(routeSessionId, bridgeId, relayTtydWsUrl);
 }
 
 export function buildStableBridgeTtydProxyUrl(
   routeSessionId: string,
   bridgeId: string,
 ): string {
-  const url = new URL(`/api/sessions/${encodeURIComponent(routeSessionId)}/terminal/ttyd`, "http://dashboard.local");
-  url.searchParams.set("bridgeId", bridgeId);
-  return `${url.pathname}${url.search}`;
+  return buildBridgeTtydProxyPath(routeSessionId, bridgeId);
 }
 
 const PATCHED_TTYD_RESPONSE_HEADERS_TO_DROP = [
@@ -71,6 +79,9 @@ export function buildPatchedTtydHtmlResponse(proxied: Response, html: string): R
   if (!headers.has("content-type")) {
     headers.set("content-type", "text/html; charset=utf-8");
   }
+  headers.set("cache-control", "no-store, no-cache, must-revalidate, max-age=0");
+  headers.set("pragma", "no-cache");
+  headers.set("expires", "0");
 
   const body = new TextEncoder().encode(html);
   return new Response(body, {
@@ -538,8 +549,10 @@ export function injectBridgeTtydRelayShim(html: string, relayTtydWsUrl: string):
   patchedWebSocket.prototype = previousWebSocket.prototype;
   window.WebSocket = patchedWebSocket;
 
+  const trustedParentOrigin = window.location.origin;
+
   function handleMessage(event) {
-    if (event.source !== window.parent) {
+    if (event.source !== window.parent || event.origin !== trustedParentOrigin) {
       return;
     }
     const data = event.data;

--- a/packages/web/src/lib/bridgeTtyd.ts
+++ b/packages/web/src/lib/bridgeTtyd.ts
@@ -72,7 +72,8 @@ export function buildPatchedTtydHtmlResponse(proxied: Response, html: string): R
     headers.set("content-type", "text/html; charset=utf-8");
   }
 
-  return new Response(html, {
+  const body = new TextEncoder().encode(html);
+  return new Response(body, {
     status: proxied.status,
     statusText: proxied.statusText,
     headers,


### PR DESCRIPTION
## Summary

Hardens the ttyd iframe lifecycle so the embedded terminal always stays on the shimmed proxy path, adds a real ready handshake between the iframe and parent session view, and stabilizes bridge relay refreshes so silent refreshes do not force a full iframe reload.

## User-Facing Release Notes

- The embedded session terminal now stays on the hardened iframe path instead of switching to a direct tunnel path, which keeps reconnects and resize behavior more stable.
- Bridge-backed terminals now refresh relay connection details in place instead of tearing down the iframe during silent refreshes.
- The terminal view now waits for the ttyd surface to report that it is actually ready before treating the iframe as loaded.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Testing

- `bun run --cwd packages/web test`
- `bun run --cwd packages/web typecheck`
- `cargo fmt`
- `cargo check -p conductor-server`
- `cargo clippy -p conductor-server -- -D warnings`
- `cargo test -p conductor-server routes::terminal::tests -- --nocapture`
- `cargo test -p conductor-server state::detached::ttyd_launcher::tests -- --nocapture`
- `cargo test -p conductor-server state::terminal_hosts::tests -- --nocapture`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal now notifies the parent UI when it's ready and supports dynamic relay URL updates for smoother embedded terminal access.
  * Added a direct "open terminal" link option and explicit terminal link metadata for improved access paths.

* **Bug Fixes**
  * Better handling and user-facing error emission when terminal sessions exceed max duration.
  * Improved iframe sync to avoid unnecessary reloads when tokens or relay URLs update.

* **Tests**
  * Expanded tests covering terminal connection resolution, shim messaging, and HTML response patching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->