### PR TITLE
fix: stop bridge ttyd route from blank-500ing on read failures

### DIFF
--- a/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
@@ -10,6 +10,7 @@ import {
   injectTtydResizeShim,
   resolveBridgeSessionTarget,
 } from "@/lib/bridgeTtyd";
+import { readTtydHtmlResponse } from "@/lib/ttydHtmlResponse";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -18,43 +19,6 @@ type RouteContext = {
   params: Promise<{ id: string }>;
 };
 
-const MAX_TTYD_HTML_RESPONSE_BYTES = 512 * 1024;
-
-async function readTtydHtmlResponse(proxied: Response): Promise<string | null> {
-  const contentType = proxied.headers.get("content-type")?.toLowerCase() ?? "";
-  if (!contentType.startsWith("text/html")) {
-    return null;
-  }
-
-  const contentLength = Number.parseInt(proxied.headers.get("content-length") ?? "", 10);
-  if (Number.isFinite(contentLength) && contentLength > MAX_TTYD_HTML_RESPONSE_BYTES) {
-    throw new Error("ttyd frontend response is too large");
-  }
-
-  const reader = proxied.body?.getReader();
-  if (!reader) {
-    return null;
-  }
-
-  const decoder = new TextDecoder();
-  let totalBytes = 0;
-  let html = "";
-
-  for (;;) {
-    const { done, value } = await reader.read();
-    if (done) {
-      break;
-    }
-    totalBytes += value.byteLength;
-    if (totalBytes > MAX_TTYD_HTML_RESPONSE_BYTES) {
-      throw new Error("ttyd frontend response is too large");
-    }
-    html += decoder.decode(value, { stream: true });
-  }
-
-  html += decoder.decode();
-  return html;
-}
 
 /**
  * Inject the resize coordination shim into a proxied HTML response.

--- a/packages/web/src/components/sessions/SessionPreview.tsx
+++ b/packages/web/src/components/sessions/SessionPreview.tsx
@@ -33,7 +33,11 @@ import { ScrollArea } from "@/components/ui/ScrollArea";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/Tabs";
 import { cn } from "@/lib/cn";
 import { selectPreviewAutoConnectCandidate } from "@/lib/previewAutoConnect";
-import { MOBILE_MOMENTUM_SCROLL_CLASS_NAME } from "./sessionMobileScroll";
+import {
+  MOBILE_MOMENTUM_SCROLL_CLASS_NAME,
+  SESSION_PREVIEW_SCROLL_SHELL_CLASS_NAME,
+  SESSION_SCROLL_AREA_VIEWPORT_CLASS_NAME,
+} from "./sessionMobileScroll";
 import type {
   PreviewCommandRequest,
   PreviewDomNode,
@@ -1291,7 +1295,7 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
               ) : null}
             </div>
 
-            <ScrollArea className="min-h-0 flex-1">
+            <ScrollArea className="min-h-0 flex-1" viewportClassName={SESSION_SCROLL_AREA_VIEWPORT_CLASS_NAME}>
               <div className="space-y-1 p-3">
                 {domLoading ? (
                   <div className="flex items-center gap-2 rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-3 py-3 text-[12px] text-[var(--vk-text-muted)]">
@@ -1377,7 +1381,7 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
                 Queue for terminal
               </Button>
             </div>
-            <ScrollArea className="min-h-0 flex-1">
+            <ScrollArea className="min-h-0 flex-1" viewportClassName={SESSION_SCROLL_AREA_VIEWPORT_CLASS_NAME}>
               <div className="space-y-1 p-3">
                 {status?.consoleLogs.length ? status.consoleLogs.map((entry) => (
                   <div
@@ -1418,7 +1422,7 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
                 Queue for terminal
               </Button>
             </div>
-            <ScrollArea className="min-h-0 flex-1">
+            <ScrollArea className="min-h-0 flex-1" viewportClassName={SESSION_SCROLL_AREA_VIEWPORT_CLASS_NAME}>
               <div className="space-y-1 p-3">
                 {status?.networkLogs.length ? status.networkLogs.map((entry) => (
                   <div
@@ -1461,7 +1465,7 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
                 Copy URL
               </Button>
             </div>
-            <ScrollArea className="min-h-0 flex-1">
+            <ScrollArea className="min-h-0 flex-1" viewportClassName={SESSION_SCROLL_AREA_VIEWPORT_CLASS_NAME}>
               <div className="space-y-3 p-3 text-[12px] text-[var(--vk-text-normal)]">
                 <div className="grid gap-2 sm:grid-cols-2">
                   <PreviewStatCard
@@ -1515,7 +1519,7 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
                 Copy route
               </Button>
             </div>
-            <ScrollArea className="min-h-0 flex-1">
+            <ScrollArea className="min-h-0 flex-1" viewportClassName={SESSION_SCROLL_AREA_VIEWPORT_CLASS_NAME}>
               <div className="space-y-3 p-3 text-[12px] text-[var(--vk-text-normal)]">
                 <div className="grid gap-2 sm:grid-cols-2">
                   <PreviewStatCard
@@ -1846,7 +1850,7 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
             ) : null}
           </div>
 
-          <div className={`min-h-0 flex-1 overflow-auto bg-[#0f1012] p-3 ${MOBILE_MOMENTUM_SCROLL_CLASS_NAME}`}>
+          <div className={SESSION_PREVIEW_SCROLL_SHELL_CLASS_NAME}>
             <div className="flex h-full min-h-[min(200px,45vh)] w-full items-center justify-center lg:min-h-[260px]">
               {loading ? (
                 <div className="flex items-center gap-2 text-[13px] text-[var(--vk-text-muted)]">

--- a/packages/web/src/components/sessions/sessionMobileScroll.test.ts
+++ b/packages/web/src/components/sessions/sessionMobileScroll.test.ts
@@ -3,6 +3,8 @@ import test from "node:test";
 
 import {
   MOBILE_MOMENTUM_SCROLL_CLASS_NAME,
+  SESSION_PREVIEW_SCROLL_SHELL_CLASS_NAME,
+  SESSION_SCROLL_AREA_VIEWPORT_CLASS_NAME,
   getSessionDetailRootClassName,
 } from "./sessionMobileScroll";
 
@@ -24,4 +26,13 @@ test("mobile momentum scroll helper opts into touch-friendly vertical scrolling"
   assert.match(MOBILE_MOMENTUM_SCROLL_CLASS_NAME, /overscroll-contain/);
   assert.match(MOBILE_MOMENTUM_SCROLL_CLASS_NAME, /touch-pan-y/);
   assert.match(MOBILE_MOMENTUM_SCROLL_CLASS_NAME, /-webkit-overflow-scrolling:touch/);
+});
+
+test("preview shell stays passive so the screenshot surface keeps mobile scroll ownership", () => {
+  assert.match(SESSION_PREVIEW_SCROLL_SHELL_CLASS_NAME, /overflow-hidden/);
+  assert.doesNotMatch(SESSION_PREVIEW_SCROLL_SHELL_CLASS_NAME, /overflow-auto/);
+});
+
+test("preview inspector scroll areas reuse the mobile momentum viewport helper", () => {
+  assert.equal(SESSION_SCROLL_AREA_VIEWPORT_CLASS_NAME, MOBILE_MOMENTUM_SCROLL_CLASS_NAME);
 });

--- a/packages/web/src/components/sessions/sessionMobileScroll.ts
+++ b/packages/web/src/components/sessions/sessionMobileScroll.ts
@@ -1,4 +1,6 @@
 export const MOBILE_MOMENTUM_SCROLL_CLASS_NAME = "overscroll-contain touch-pan-y [-webkit-overflow-scrolling:touch]";
+export const SESSION_PREVIEW_SCROLL_SHELL_CLASS_NAME = "min-h-0 flex-1 overflow-hidden bg-[#0f1012] p-3";
+export const SESSION_SCROLL_AREA_VIEWPORT_CLASS_NAME = MOBILE_MOMENTUM_SCROLL_CLASS_NAME;
 
 export function getSessionDetailRootClassName(immersiveTerminalActive: boolean): string {
   return [

--- a/packages/web/src/components/ui/ScrollArea.tsx
+++ b/packages/web/src/components/ui/ScrollArea.tsx
@@ -6,14 +6,16 @@ import { cn } from "@/lib/cn";
 
 export const ScrollArea = forwardRef<
   HTMLDivElement,
-  ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
->(({ className, children, ...props }, ref) => (
+  ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> & {
+    viewportClassName?: string;
+  }
+>(({ className, children, viewportClassName, ...props }, ref) => (
   <ScrollAreaPrimitive.Root
     ref={ref}
     className={cn("relative overflow-hidden", className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+    <ScrollAreaPrimitive.Viewport className={cn("h-full w-full rounded-[inherit]", viewportClassName)}>
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />

--- a/packages/web/src/lib/bridgeTtyd.test.ts
+++ b/packages/web/src/lib/bridgeTtyd.test.ts
@@ -107,3 +107,19 @@ test("buildPatchedTtydHtmlResponse drops stale body headers after html injection
   assert.equal(patched.headers.get("expires"), "0");
   assert.equal(await patched.text(), "<html><body>new</body></html>");
 });
+
+test("buildPatchedTtydHtmlResponse forces html rendering headers for patched ttyd pages", async () => {
+  const proxied = new Response("<html><body>old</body></html>", {
+    status: 200,
+    headers: {
+      "content-type": "application/octet-stream",
+      "content-disposition": 'attachment; filename="ttyd"',
+    },
+  });
+
+  const patched = buildPatchedTtydHtmlResponse(proxied, "<html><body>new</body></html>");
+
+  assert.equal(patched.headers.get("content-type"), "text/html; charset=utf-8");
+  assert.equal(patched.headers.get("content-disposition"), null);
+  assert.equal(await patched.text(), "<html><body>new</body></html>");
+});

--- a/packages/web/src/lib/bridgeTtyd.ts
+++ b/packages/web/src/lib/bridgeTtyd.ts
@@ -66,6 +66,7 @@ export function buildStableBridgeTtydProxyUrl(
 const PATCHED_TTYD_RESPONSE_HEADERS_TO_DROP = [
   "content-length",
   "content-encoding",
+  "content-disposition",
   "etag",
   "last-modified",
   "transfer-encoding",
@@ -76,9 +77,7 @@ export function buildPatchedTtydHtmlResponse(proxied: Response, html: string): R
   for (const headerName of PATCHED_TTYD_RESPONSE_HEADERS_TO_DROP) {
     headers.delete(headerName);
   }
-  if (!headers.has("content-type")) {
-    headers.set("content-type", "text/html; charset=utf-8");
-  }
+  headers.set("content-type", "text/html; charset=utf-8");
   headers.set("cache-control", "no-store, no-cache, must-revalidate, max-age=0");
   headers.set("pragma", "no-cache");
   headers.set("expires", "0");

--- a/packages/web/src/lib/ttydHtmlResponse.test.ts
+++ b/packages/web/src/lib/ttydHtmlResponse.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { readTtydHtmlResponse } from "./ttydHtmlResponse";
+
+test("readTtydHtmlResponse returns null when the proxied HTML stream errors", async () => {
+  const proxied = new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(new Error("bridge stream failed"));
+      },
+    }),
+    {
+      headers: {
+        "content-type": "text/html; charset=utf-8",
+      },
+    },
+  );
+
+  const html = await readTtydHtmlResponse(proxied);
+  assert.equal(html, null);
+});
+
+test("readTtydHtmlResponse still rejects oversized ttyd HTML responses", async () => {
+  const proxied = new Response("<html><body>large</body></html>", {
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      "content-length": String(600 * 1024),
+    },
+  });
+
+  await assert.rejects(
+    () => readTtydHtmlResponse(proxied),
+    /ttyd frontend response is too large/,
+  );
+});

--- a/packages/web/src/lib/ttydHtmlResponse.test.ts
+++ b/packages/web/src/lib/ttydHtmlResponse.test.ts
@@ -4,10 +4,11 @@ import test from "node:test";
 import { readTtydHtmlResponse } from "./ttydHtmlResponse";
 
 test("readTtydHtmlResponse returns null when the proxied HTML stream errors", async () => {
+  let failRead: (error: Error) => void = () => {};
   const proxied = new Response(
     new ReadableStream<Uint8Array>({
       start(controller) {
-        controller.error(new Error("bridge stream failed"));
+        failRead = (error) => controller.error(error);
       },
     }),
     {
@@ -17,7 +18,10 @@ test("readTtydHtmlResponse returns null when the proxied HTML stream errors", as
     },
   );
 
-  const html = await readTtydHtmlResponse(proxied);
+  const readPromise = readTtydHtmlResponse(proxied);
+  failRead(new Error("bridge stream failed"));
+
+  const html = await readPromise;
   assert.equal(html, null);
 });
 

--- a/packages/web/src/lib/ttydHtmlResponse.ts
+++ b/packages/web/src/lib/ttydHtmlResponse.ts
@@ -2,18 +2,19 @@ const MAX_TTYD_HTML_RESPONSE_BYTES = 512 * 1024;
 const TTYD_HTML_TOO_LARGE_ERROR = "ttyd frontend response is too large";
 
 export async function readTtydHtmlResponse(proxied: Response): Promise<string | null> {
-  const contentType = proxied.headers.get("content-type")?.toLowerCase() ?? "";
+  const candidate = proxied.clone();
+  const contentType = candidate.headers.get("content-type")?.toLowerCase() ?? "";
   if (!contentType.startsWith("text/html")) {
     return null;
   }
 
-  const contentLength = Number.parseInt(proxied.headers.get("content-length") ?? "", 10);
+  const contentLength = Number.parseInt(candidate.headers.get("content-length") ?? "", 10);
   if (Number.isFinite(contentLength) && contentLength > MAX_TTYD_HTML_RESPONSE_BYTES) {
     throw new Error(TTYD_HTML_TOO_LARGE_ERROR);
   }
 
   try {
-    const reader = proxied.body?.getReader();
+    const reader = candidate.body?.getReader();
     if (!reader) {
       return null;
     }

--- a/packages/web/src/lib/ttydHtmlResponse.ts
+++ b/packages/web/src/lib/ttydHtmlResponse.ts
@@ -1,0 +1,45 @@
+const MAX_TTYD_HTML_RESPONSE_BYTES = 512 * 1024;
+const TTYD_HTML_TOO_LARGE_ERROR = "ttyd frontend response is too large";
+
+export async function readTtydHtmlResponse(proxied: Response): Promise<string | null> {
+  const contentType = proxied.headers.get("content-type")?.toLowerCase() ?? "";
+  if (!contentType.startsWith("text/html")) {
+    return null;
+  }
+
+  const contentLength = Number.parseInt(proxied.headers.get("content-length") ?? "", 10);
+  if (Number.isFinite(contentLength) && contentLength > MAX_TTYD_HTML_RESPONSE_BYTES) {
+    throw new Error(TTYD_HTML_TOO_LARGE_ERROR);
+  }
+
+  try {
+    const reader = proxied.body?.getReader();
+    if (!reader) {
+      return null;
+    }
+
+    const decoder = new TextDecoder();
+    let totalBytes = 0;
+    let html = "";
+
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_TTYD_HTML_RESPONSE_BYTES) {
+        throw new Error(TTYD_HTML_TOO_LARGE_ERROR);
+      }
+      html += decoder.decode(value, { stream: true });
+    }
+
+    html += decoder.decode();
+    return html;
+  } catch (error) {
+    if (error instanceof Error && error.message === TTYD_HTML_TOO_LARGE_ERROR) {
+      throw error;
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## User-Facing Release Notes
- Fixed mobile and bridge-backed ttyd terminals getting stuck behind a blank load state when the proxied HTML stream could not be read safely.
- Prevented Safari from surfacing the broken ttyd iframe load as a download prompt for `ttyd`.

## Type of Change
- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Summary
- move ttyd HTML reading into a shared helper
- fall back to the original proxied response when the bridge ttyd HTML stream fails to read
- keep oversize ttyd HTML as a hard failure and add regression coverage

## Verification
- bun run test
- bun run typecheck
- bun run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TTYD response header handling to properly enforce `text/html` content-type and remove conflicting headers.

* **Improvements**
  * Enhanced scroll area viewport styling flexibility for improved UI consistency across session preview tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->