### PR TITLE
fix: harden bridge onboarding and bun dashboard startup

### DIFF
--- a/bridge-cmd/backend/backend.go
+++ b/bridge-cmd/backend/backend.go
@@ -571,9 +571,12 @@ func inferCliBinaryVersion(binaryPath string) string {
 
 func inferCliInstallMode(packageRoot string) string {
 	normalizedRoot := normalizeFsPath(packageRoot)
-	parentWorkspaceLockfile := filepath.Join(packageRoot, "..", "..", "pnpm-lock.yaml")
+	parentWorkspaceDir := filepath.Join(packageRoot, "..", "..")
 	if strings.HasSuffix(normalizedRoot, "/packages/cli") {
-		if _, err := os.Stat(parentWorkspaceLockfile); err == nil {
+		if _, err := os.Stat(filepath.Join(parentWorkspaceDir, "bun.lock")); err == nil {
+			return "source"
+		}
+		if _, err := os.Stat(filepath.Join(parentWorkspaceDir, "pnpm-lock.yaml")); err == nil {
 			return "source"
 		}
 	}

--- a/bridge-cmd/connect/connect.go
+++ b/bridge-cmd/connect/connect.go
@@ -27,6 +27,12 @@ const defaultDashboardURL = "https://conductross.com"
 
 var errInvalidSavedPairing = errors.New("saved device pairing is invalid")
 
+var restartBridgeService = install.RestartServiceIfInstalled
+var installBridgeService = func() error {
+	return install.Install("")
+}
+var runBridgeDaemon = daemon.Run
+
 type savedPairingSource string
 
 const (
@@ -169,17 +175,7 @@ func Run(ctx context.Context, opts Options) error {
 			announceSavedPairingReuse(stdout, candidate, dashboardURL, savedDashboardURL)
 			announceBrowser(openTarget, opts.OpenBrowser, stdout, stderr)
 			if opts.StartupDaemon {
-				if err := install.RestartServiceIfInstalled(); err == nil {
-					fmt.Fprintln(stdout, "Bridge background service restarted.")
-					return nil
-				} else {
-					fmt.Fprintf(stderr, "bridge service restart unavailable, continuing in the current terminal: %v\n", err)
-				}
-				return daemon.Run(ctx, daemon.Options{
-					RelayURL: opts.RelayURL,
-					Store:    store,
-					Stderr:   stderr,
-				})
+				return ensureStartupDaemon(ctx, opts.RelayURL, store, stdout, stderr)
 			}
 			return nil
 		case errors.Is(resolveErr, errInvalidSavedPairing):
@@ -226,20 +222,37 @@ func Run(ctx context.Context, opts Options) error {
 	fmt.Fprintf(stdout, "Active refresh token saved to %s\n", store.Path())
 
 	if opts.StartupDaemon {
-		if err := install.RestartServiceIfInstalled(); err == nil {
-			fmt.Fprintln(stdout, "Bridge background service restarted.")
-			return nil
-		} else {
-			fmt.Fprintf(stderr, "bridge service restart unavailable, continuing in the current terminal: %v\n", err)
-		}
-		return daemon.Run(ctx, daemon.Options{
-			RelayURL: opts.RelayURL,
-			Store:    store,
-			Stderr:   stderr,
-		})
+		return ensureStartupDaemon(ctx, opts.RelayURL, store, stdout, stderr)
 	}
 
 	return nil
+}
+
+func ensureStartupDaemon(ctx context.Context, relayURL string, store *token.Store, stdout io.Writer, stderr io.Writer) error {
+	if err := restartBridgeService(); err == nil {
+		fmt.Fprintln(stdout, "Bridge background service restarted.")
+		return nil
+	} else {
+		fmt.Fprintf(stderr, "bridge service restart unavailable, attempting automatic service install: %v\n", err)
+	}
+
+	if err := installBridgeService(); err == nil {
+		fmt.Fprintln(stdout, "Bridge background service installed.")
+		if err := restartBridgeService(); err == nil {
+			fmt.Fprintln(stdout, "Bridge background service restarted.")
+			return nil
+		}
+		fmt.Fprintln(stderr, "bridge service install completed, but automatic restart still failed. Continuing in the current terminal.")
+	} else {
+		fmt.Fprintf(stderr, "bridge service install failed, continuing in the current terminal: %v\n", err)
+	}
+
+	fmt.Fprintln(stderr, "Keep this terminal open until the dashboard shows the laptop online.")
+	return runBridgeDaemon(ctx, daemon.Options{
+		RelayURL: relayURL,
+		Store:    store,
+		Stderr:   stderr,
+	})
 }
 
 func loadSavedDashboardURL(store *dashboardurl.Store) (string, error) {

--- a/bridge-cmd/connect/connect_test.go
+++ b/bridge-cmd/connect/connect_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/charannyk06/conductor-oss/bridge/daemon"
 	"github.com/charannyk06/conductor-oss/bridge/dashboardurl"
 	"github.com/charannyk06/conductor-oss/bridge/token"
 )
@@ -247,6 +249,84 @@ func TestRunCreatesNewPairingWhenSavedPairingsAreInvalidAndWarnsAboutRotation(t 
 	assertStringContains(t, stdout.String(), `Device paired: "Preview Mac"`)
 	assertStringContains(t, stderr.String(), "Saved pairing cached for https://preview.conductross.com is invalid or expired.")
 	assertStringContains(t, stderr.String(), "The active pairing saved for https://conductross.com is invalid or expired.")
+}
+
+func TestRunInstallsAndRestartsBackgroundServiceWhenRestartIsUnavailable(t *testing.T) {
+	tokenStore, dashboardStore := newBridgeTestStores(t)
+
+	if err := tokenStore.Save("refresh-active"); err != nil {
+		t.Fatalf("Save returned error: %v", err)
+	}
+	if err := dashboardStore.Save("https://conductross.com"); err != nil {
+		t.Fatalf("dashboard Save returned error: %v", err)
+	}
+
+	withDefaultHTTPClient(t, func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/api/devices/auth" {
+			t.Fatalf("unexpected relay path %q", r.URL.Path)
+		}
+
+		return jsonHTTPResponse(http.StatusOK, map[string]string{
+			"device_id":   "device-123",
+			"device_name": "Preview Mac",
+		}), nil
+	})
+
+	originalRestart := restartBridgeService
+	originalInstall := installBridgeService
+	originalRunDaemon := runBridgeDaemon
+	t.Cleanup(func() {
+		restartBridgeService = originalRestart
+		installBridgeService = originalInstall
+		runBridgeDaemon = originalRunDaemon
+	})
+
+	restartCalls := 0
+	installCalls := 0
+	daemonCalls := 0
+	restartBridgeService = func() error {
+		restartCalls += 1
+		if restartCalls == 1 {
+			return errors.New("service missing")
+		}
+		return nil
+	}
+	installBridgeService = func() error {
+		installCalls += 1
+		return nil
+	}
+	runBridgeDaemon = func(ctx context.Context, opts daemon.Options) error {
+		daemonCalls += 1
+		return nil
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if err := Run(context.Background(), Options{
+		RelayURL:      "https://relay.example.com",
+		DashboardURL:  "https://preview.conductross.com",
+		Store:         tokenStore,
+		Stdout:        &stdout,
+		Stderr:        &stderr,
+		OpenBrowser:   false,
+		StartupDaemon: true,
+	}); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if restartCalls != 2 {
+		t.Fatalf("restartBridgeService called %d times, want 2", restartCalls)
+	}
+	if installCalls != 1 {
+		t.Fatalf("installBridgeService called %d times, want 1", installCalls)
+	}
+	if daemonCalls != 0 {
+		t.Fatalf("runBridgeDaemon called %d times, want 0", daemonCalls)
+	}
+
+	assertStringContains(t, stdout.String(), "Bridge background service installed.")
+	assertStringContains(t, stdout.String(), "Bridge background service restarted.")
+	assertStringContains(t, stderr.String(), "bridge service restart unavailable, attempting automatic service install: service missing")
 }
 
 func newBridgeTestStores(t *testing.T) (*token.Store, *dashboardurl.Store) {

--- a/conductor.example.yaml
+++ b/conductor.example.yaml
@@ -70,7 +70,7 @@ projects:
         permissions: default
     # Optional project dev server for preview/test loop
     # devServer:
-    #   command: pnpm dev          # optional; leave blank if you run the app yourself
+    #   command: bun dev           # optional; leave blank if you run the app yourself
     #   cwd: apps/web             # optional; relative to the project root
     #   port: 3000                # optional; used for auto-preview + PORT env injection
     #   host: 127.0.0.1           # optional; defaults to 127.0.0.1

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "pnpm install --frozen-lockfile && pnpm --filter @conductor-oss/core build && pnpm --filter @conductor-oss/web build"
+  command = "bun install --frozen-lockfile && bun run --cwd packages/core build && bun run --cwd packages/web build"
   publish = "packages/web/.next"
 
 [build.environment]

--- a/packages/cli/src/__tests__/start.test.ts
+++ b/packages/cli/src/__tests__/start.test.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 import {
   isLoopbackHost,
   quoteWindowsCliArg,
+  resolveDashboardPackageManager,
   resolveLocalDashboardAuthEnv,
   resolveRustBackendLaunch,
 } from "../commands/start.js";
@@ -66,4 +67,27 @@ test("quoteWindowsCliArg escapes quotes and trailing backslashes", () => {
   assert.equal(quoteWindowsCliArg("C:\\Program Files\\Conductor"), "\"C:\\Program Files\\Conductor\"");
   assert.equal(quoteWindowsCliArg("C:\\path with spaces\\"), "\"C:\\path with spaces\\\\\"");
   assert.equal(quoteWindowsCliArg("say \"hello\""), "\"say \\\"hello\\\"\"");
+});
+
+test("resolveDashboardPackageManager honors the workspace packageManager field", () => {
+  const root = mkdtempSync(join(tmpdir(), "conductor-dashboard-pm-"));
+
+  try {
+    mkdirSync(join(root, "packages", "web"), { recursive: true });
+    writeFileSync(
+      join(root, "package.json"),
+      JSON.stringify({ packageManager: "bun@1.2.0" }),
+    );
+
+    assert.equal(resolveDashboardPackageManager(join(root, "packages", "web")), "bun");
+
+    writeFileSync(
+      join(root, "package.json"),
+      JSON.stringify({ packageManager: "pnpm@9.0.0" }),
+    );
+
+    assert.equal(resolveDashboardPackageManager(join(root, "packages", "web")), "pnpm");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -42,6 +42,8 @@ type CliUpdateContext = {
   installMode: CliInstallMode;
 };
 
+type DashboardPackageManager = "bun" | "pnpm";
+
 export function quoteWindowsCliArg(value: string): string {
   let escaped = "";
   let backslashCount = 0;
@@ -115,6 +117,74 @@ function resolveBunGlobalNodeModulesDir(): string {
   return join(bunInstallRoot, "install", "global", "node_modules");
 }
 
+function hasWorkspaceLockfile(packageRoot: string): boolean {
+  const workspaceRoot = join(packageRoot, "..", "..");
+  return existsSync(join(workspaceRoot, "bun.lock"))
+    || existsSync(join(workspaceRoot, "pnpm-lock.yaml"));
+}
+
+export function resolveDashboardPackageManager(startDir: string): DashboardPackageManager {
+  const candidates = [
+    startDir,
+    join(startDir, ".."),
+    join(startDir, "..", ".."),
+  ];
+
+  for (const candidate of candidates) {
+    const packageJsonPath = join(candidate, "package.json");
+    if (!existsSync(packageJsonPath)) {
+      continue;
+    }
+
+    try {
+      const payload = JSON.parse(readFileSync(packageJsonPath, "utf8")) as { packageManager?: string };
+      const declaredPackageManager = payload.packageManager?.trim().toLowerCase() ?? "";
+      if (declaredPackageManager.startsWith("bun@")) {
+        return "bun";
+      }
+      if (declaredPackageManager.startsWith("pnpm@")) {
+        return "pnpm";
+      }
+    } catch {
+      // Ignore invalid package metadata and fall back to lockfile detection.
+    }
+
+    if (existsSync(join(candidate, "bun.lock"))) {
+      return "bun";
+    }
+    if (existsSync(join(candidate, "pnpm-lock.yaml"))) {
+      return "pnpm";
+    }
+  }
+
+  return "bun";
+}
+
+function buildDashboardPackageManagerCommand(
+  packageManager: DashboardPackageManager,
+  script: "dev" | "start",
+  bindHost: string,
+  dashboardPort: number,
+): { cmd: string; args: string[] } {
+  if (packageManager === "pnpm") {
+    return {
+      cmd: "pnpm",
+      args: ["run", script, "--hostname", bindHost, "--port", String(dashboardPort)],
+    };
+  }
+
+  return {
+    cmd: "bun",
+    args: ["run", script, "--", "--hostname", bindHost, "--port", String(dashboardPort)],
+  };
+}
+
+function dashboardBuildHint(packageManager: DashboardPackageManager): string {
+  return packageManager === "pnpm"
+    ? "pnpm --filter @conductor-oss/web build"
+    : "bun run --cwd packages/web build";
+}
+
 function resolveCliUpdateContext(): CliUpdateContext {
   const packageJsonUrl = new URL("../../package.json", import.meta.url);
   const packageRoot = dirname(fileURLToPath(packageJsonUrl));
@@ -137,8 +207,7 @@ function resolveCliUpdateContext(): CliUpdateContext {
   }
 
   const normalizedRoot = normalizeFsPath(packageRoot);
-  const parentWorkspaceLockfile = join(packageRoot, "..", "..", "pnpm-lock.yaml");
-  if (normalizedRoot.endsWith("/packages/cli") && existsSync(parentWorkspaceLockfile)) {
+  if (normalizedRoot.endsWith("/packages/cli") && hasWorkspaceLockfile(packageRoot)) {
     return { packageName, version, installMode: "source" };
   }
 
@@ -1025,8 +1094,11 @@ export function registerStart(program: Command): void {
               }
             }
 
+            const packageManager = resolveDashboardPackageManager(webDir ?? dirname(configPath));
+            const buildHint = dashboardBuildHint(packageManager);
+
             if (!webDir) {
-              dashSpinner.warn("Dashboard not found. Run: pnpm --filter @conductor-oss/web build");
+              dashSpinner.warn(`Dashboard not found. Run: ${buildHint}`);
               return;
             }
 
@@ -1068,11 +1140,9 @@ export function registerStart(program: Command): void {
             let dashboardCwd = webDir;
 
             if (preferDevServer) {
-              cmd = "pnpm";
-              args = ["run", "dev", "--hostname", bindHost, "--port", String(dashboardPort)];
+              ({ cmd, args } = buildDashboardPackageManagerCommand(packageManager, "dev", bindHost, dashboardPort));
             } else if (webMode === "production" && hasNextBuild) {
-              cmd = "pnpm";
-              args = ["run", "start", "--hostname", bindHost, "--port", String(dashboardPort)];
+              ({ cmd, args } = buildDashboardPackageManagerCommand(packageManager, "start", bindHost, dashboardPort));
             } else if (standaloneServer) {
               const standaloneAppDir = dirname(standaloneServer);
               const standaloneStaticDir = join(standaloneAppDir, ".next", "static");
@@ -1090,11 +1160,9 @@ export function registerStart(program: Command): void {
               args = [standaloneServer];
               dashboardCwd = standaloneDir;
             } else if (hasNextBuild) {
-              cmd = "pnpm";
-              args = ["run", "start", "--hostname", bindHost, "--port", String(dashboardPort)];
+              ({ cmd, args } = buildDashboardPackageManagerCommand(packageManager, "start", bindHost, dashboardPort));
             } else {
-              cmd = "pnpm";
-              args = ["run", "dev", "--hostname", bindHost, "--port", String(dashboardPort)];
+              ({ cmd, args } = buildDashboardPackageManagerCommand(packageManager, "dev", bindHost, dashboardPort));
             }
 
             dashboardProcess = spawn(cmd, args, {
@@ -1146,7 +1214,7 @@ export function registerStart(program: Command): void {
             });
 
             dashboardProcess.on("error", () => {
-              dashSpinner.warn("Dashboard failed to start. Try: cd packages/web && pnpm build");
+              dashSpinner.warn(`Dashboard failed to start. Try: ${buildHint}`);
             });
 
             const dashboardInternalUrl = `http://127.0.0.1:${dashboardPort}`;

--- a/packages/web/src/features/bridge/BridgeConnectClient.tsx
+++ b/packages/web/src/features/bridge/BridgeConnectClient.tsx
@@ -868,7 +868,7 @@ export default function BridgeConnectClient({
                       <div className="mt-1">
                         {claimedDeviceRecord?.connected
                           ? "This laptop is online and ready to use."
-                          : "The bridge service is restarting for this laptop now. This page will refresh until it reports online."}
+                          : "Conductor is still waiting for this laptop to come online. If you closed the setup terminal, rerun the hosted installer or `conductor-bridge connect` and keep that terminal open until the device reports online."}
                       </div>
                       {pairingAutoUpdate.message ? (
                         <div className={cn(


### PR DESCRIPTION
## Summary

Fixes the broken Bun migration in Conductor's dashboard startup flow and makes bridge pairing more resilient when the background service is missing.

## User-Facing Release Notes

- Fixed dashboard startup instructions and launcher commands so Bun-based installs no longer tell users to run missing `pnpm` commands.
- Improved paired-device onboarding so Conductor tries to install and restart the bridge background service before falling back to a foreground daemon.
- Clarified the paired-device UI when a laptop is still offline, including what to rerun if the setup terminal was closed.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Testing

- `bun run --cwd packages/cli test`
- `bun run --cwd packages/web test`
- `go test ./...` in `bridge-cmd`
