### PR TITLE
fix: restore iframe terminal opening and chrome

### DIFF
--- a/packages/web/src/components/sessions/IframeTerminalPage.tsx
+++ b/packages/web/src/components/sessions/IframeTerminalPage.tsx
@@ -6,6 +6,7 @@ import { Terminal } from "xterm";
 import "xterm/css/xterm.css";
 import { withBridgeQuery } from "@/lib/bridgeQuery";
 import { attachMobileTouchScrollShim } from "@/components/sessions/terminal/mobileTouchScroll";
+import { resolveNativeTerminalWebSocketUrl } from "@/components/sessions/terminal/terminalClientUrls";
 
 type ConnectionInfo = {
   interactive?: boolean;
@@ -52,16 +53,6 @@ const TERMINAL_THEME = {
   brightCyan: "#9fe8e2",
   brightWhite: "#fff8f2",
 } as const;
-
-function resolveWebSocketUrl(pathOrUrl: string): string {
-  if (pathOrUrl.startsWith("ws://") || pathOrUrl.startsWith("wss://")) {
-    return pathOrUrl;
-  }
-  const origin = window.location.protocol === "https:"
-    ? `wss://${window.location.host}`
-    : `ws://${window.location.host}`;
-  return `${origin}${pathOrUrl.startsWith("/") ? pathOrUrl : `/${pathOrUrl}`}`;
-}
 
 export function IframeTerminalPage({
   sessionId,
@@ -164,7 +155,7 @@ export function IframeTerminalPage({
       return;
     }
 
-    const ws = new WebSocket(resolveWebSocketUrl(info.wsUrl));
+    const ws = new WebSocket(resolveNativeTerminalWebSocketUrl(info.wsUrl, window.location.origin));
     ws.binaryType = "arraybuffer";
     socketRef.current = ws;
 

--- a/packages/web/src/components/sessions/SessionTerminal.tsx
+++ b/packages/web/src/components/sessions/SessionTerminal.tsx
@@ -1,10 +1,34 @@
 "use client";
 
-import { memo, useEffect, useMemo, useRef, useState } from "react";
+import {
+  AlertCircle,
+  Clipboard,
+  ExternalLink,
+  FileUp,
+  Loader2,
+  RefreshCw,
+  Send,
+  SquareStop,
+  X,
+} from "lucide-react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+} from "react";
+import { Button } from "@/components/ui/Button";
+import { uploadProjectAttachments } from "@/components/sessions/attachmentUploads";
 import type { SessionTerminalProps } from "@/components/sessions/terminal/terminalTypes";
+import { LIVE_TERMINAL_STATUSES, RESUMABLE_STATUSES } from "@/components/sessions/terminal/terminalConstants";
 import { withBridgeQuery } from "@/lib/bridgeQuery";
+import { buildSessionHref } from "@/lib/dashboardHref";
 
 const TERMINAL_IFRAME_LOAD_TIMEOUT_MS = 15_000;
+const TERMINAL_CLOSED_STATUSES = new Set(["archived", "killed", "terminated", "restored"]);
 
 async function sendTerminalKeys(
   sessionId: string,
@@ -27,24 +51,73 @@ async function sendTerminalKeys(
   }
 }
 
+async function sendFollowUpMessage(
+  sessionId: string,
+  message: string,
+  bridgeId?: string | null,
+): Promise<void> {
+  const response = await fetch(
+    withBridgeQuery(`/api/sessions/${encodeURIComponent(sessionId)}/actions`, bridgeId),
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ action: "send", message }),
+    },
+  );
+  if (!response.ok) {
+    const data = (await response.json().catch(() => null)) as { error?: string } | null;
+    throw new Error(data?.error ?? `Failed to send message (${response.status})`);
+  }
+}
+
 function SessionTerminalView({
   sessionId,
+  projectId,
   bridgeId,
+  sessionState,
+  runtimeMode,
   pendingInsert,
+  immersiveMobileMode = false,
   panelVisible = true,
   onPendingInsertConsumed,
 }: SessionTerminalProps) {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const attachmentInputRef = useRef<HTMLInputElement | null>(null);
+  const promptInputRef = useRef<HTMLInputElement | null>(null);
   const loadTimerRef = useRef<number | null>(null);
   const lastAppliedInsertNonceRef = useRef(0);
+  const pendingInsertNonceRef = useRef<number | null>(null);
+
   const [frameLoaded, setFrameLoaded] = useState(false);
   const [connectionError, setConnectionError] = useState<string | null>(null);
   const [queuedInsertError, setQueuedInsertError] = useState<string | null>(null);
+  const [attachmentError, setAttachmentError] = useState<string | null>(null);
+  const [attachmentUploading, setAttachmentUploading] = useState(false);
+  const [promptMessage, setPromptMessage] = useState("");
+  const [promptSending, setPromptSending] = useState(false);
+  const [promptError, setPromptError] = useState<string | null>(null);
+  const [reloadNonce, setReloadNonce] = useState(0);
 
   const iframeSrc = useMemo(
     () => withBridgeQuery(`/embed/terminal/${encodeURIComponent(sessionId)}`, bridgeId),
     [bridgeId, sessionId],
   );
+
+  const normalizedSessionStatus = useMemo(
+    () => sessionState.trim().toLowerCase(),
+    [sessionState],
+  );
+  const normalizedRuntimeMode = runtimeMode?.trim().toLowerCase() ?? null;
+  const sessionClosed = TERMINAL_CLOSED_STATUSES.has(normalizedSessionStatus);
+  const liveRuntimeExpected = normalizedRuntimeMode === "direct"
+    ? !sessionClosed
+    : LIVE_TERMINAL_STATUSES.has(normalizedSessionStatus);
+  const showPromptBar = !liveRuntimeExpected
+    && !immersiveMobileMode
+    && RESUMABLE_STATUSES.has(normalizedSessionStatus);
+  const terminalSessionHref = buildSessionHref(sessionId, { bridgeId, tab: "terminal" });
 
   useEffect(() => {
     setFrameLoaded(false);
@@ -62,33 +135,46 @@ function SessionTerminalView({
         loadTimerRef.current = null;
       }
     };
-  }, [iframeSrc]);
+  }, [iframeSrc, reloadNonce]);
 
   useEffect(() => {
-    if (!pendingInsert || pendingInsert.nonce <= lastAppliedInsertNonceRef.current) {
+    if (!pendingInsert) {
+      return;
+    }
+    if (pendingInsert.nonce <= lastAppliedInsertNonceRef.current) {
+      return;
+    }
+    if (pendingInsertNonceRef.current === pendingInsert.nonce) {
       return;
     }
 
-    lastAppliedInsertNonceRef.current = pendingInsert.nonce;
     const inlineText = pendingInsert.inlineText.trim();
     if (inlineText.length === 0) {
+      lastAppliedInsertNonceRef.current = pendingInsert.nonce;
+      onPendingInsertConsumed?.();
       return;
     }
 
+    pendingInsertNonceRef.current = pendingInsert.nonce;
     let cancelled = false;
     void sendTerminalKeys(sessionId, `${inlineText} `, bridgeId)
       .then(() => {
-        if (!cancelled) {
-          setQueuedInsertError(null);
-          onPendingInsertConsumed?.();
+        if (cancelled) {
+          return;
         }
+        lastAppliedInsertNonceRef.current = pendingInsert.nonce;
+        pendingInsertNonceRef.current = null;
+        setQueuedInsertError(null);
+        onPendingInsertConsumed?.();
       })
       .catch((error) => {
-        if (!cancelled) {
-          setQueuedInsertError(
-            error instanceof Error ? error.message : "Failed to queue terminal input.",
-          );
+        if (cancelled) {
+          return;
         }
+        pendingInsertNonceRef.current = null;
+        setQueuedInsertError(
+          error instanceof Error ? error.message : "Failed to queue terminal input.",
+        );
       });
 
     return () => {
@@ -96,34 +182,319 @@ function SessionTerminalView({
     };
   }, [bridgeId, onPendingInsertConsumed, pendingInsert, sessionId]);
 
+  const handlePromptSend = useCallback(async () => {
+    const message = promptMessage.trim();
+    if (!message || promptSending) {
+      return;
+    }
+
+    setPromptSending(true);
+    setPromptError(null);
+    try {
+      await sendFollowUpMessage(sessionId, message, bridgeId);
+      setPromptMessage("");
+      promptInputRef.current?.focus();
+    } catch (error) {
+      setPromptError(error instanceof Error ? error.message : "Failed to send message.");
+    } finally {
+      setPromptSending(false);
+    }
+  }, [bridgeId, promptMessage, promptSending, sessionId]);
+
+  const handleRetry = useCallback(() => {
+    setConnectionError(null);
+    setFrameLoaded(false);
+    setReloadNonce((value) => value + 1);
+  }, []);
+
+  const handleAttachmentPick = useCallback(() => {
+    attachmentInputRef.current?.click();
+  }, []);
+
+  const handleAttachmentFiles = useCallback(async (event: ChangeEvent<HTMLInputElement>) => {
+    const { files } = event.target;
+    event.target.value = "";
+    if (!files || files.length === 0) {
+      return;
+    }
+
+    setAttachmentUploading(true);
+    setAttachmentError(null);
+    try {
+      const uploadedPaths = await uploadProjectAttachments({
+        files: Array.from(files),
+        projectId,
+        taskRef: sessionId,
+        bridgeId,
+      });
+      for (const path of uploadedPaths) {
+        await sendTerminalKeys(sessionId, `\r\n[attached file: ${path}]\r\n`, bridgeId);
+      }
+    } catch (error) {
+      setAttachmentError(
+        error instanceof Error ? error.message : "Failed to upload attachment.",
+      );
+    } finally {
+      setAttachmentUploading(false);
+    }
+  }, [bridgeId, projectId, sessionId]);
+
+  const handleMobilePaste = useCallback(async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      if (text) {
+        await sendTerminalKeys(sessionId, text, bridgeId);
+        setQueuedInsertError(null);
+      }
+    } catch {
+      setQueuedInsertError("Clipboard paste failed.");
+    }
+  }, [bridgeId, sessionId]);
+
+  const handleSoftStop = useCallback(async () => {
+    try {
+      await sendTerminalKeys(sessionId, "\x03", bridgeId);
+      setQueuedInsertError(null);
+    } catch (error) {
+      setQueuedInsertError(
+        error instanceof Error ? error.message : "Failed to send Ctrl+C.",
+      );
+    }
+  }, [bridgeId, sessionId]);
+
   return (
-    <div className="relative flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden rounded-none border-0 bg-[#060404] lg:rounded-[14px] lg:border lg:border-white/10 lg:shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
-      {connectionError ? (
-        <div className="absolute inset-x-0 top-3 z-10 mx-auto w-fit rounded-full border border-red-500/30 bg-red-500/10 px-3 py-1 text-[12px] text-red-200">
-          {connectionError}
+    <div
+      className={immersiveMobileMode
+        ? "group/terminal relative flex min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden bg-[#060404]"
+        : "group/terminal relative flex min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden rounded-none border-0 bg-[#060404] lg:rounded-[14px] lg:border lg:border-white/10 lg:shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]"}
+    >
+      <div className="absolute right-2 top-2 z-20 flex items-center gap-2 sm:right-3 sm:top-3">
+        <input
+          ref={attachmentInputRef}
+          type="file"
+          multiple
+          accept="*/*"
+          className="sr-only"
+          tabIndex={-1}
+          aria-hidden
+          onChange={(event) => void handleAttachmentFiles(event)}
+        />
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className="h-9 w-9 rounded-full border border-white/10 bg-[#141010]/92 text-[#c9c0b7] backdrop-blur-sm hover:bg-[#201818] disabled:opacity-40 sm:h-7 sm:w-7"
+          onClick={handleAttachmentPick}
+          aria-label="Attach files"
+          disabled={attachmentUploading}
+        >
+          {attachmentUploading ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <FileUp className="h-3.5 w-3.5" />
+          )}
+        </Button>
+        <Button
+          asChild
+          size="icon"
+          variant="ghost"
+          className="h-9 w-9 rounded-full border border-white/10 bg-[#141010]/92 text-[#c9c0b7] backdrop-blur-sm hover:bg-[#201818] sm:h-7 sm:w-7"
+        >
+          <a
+            href={terminalSessionHref}
+            target="_blank"
+            rel="noreferrer"
+            aria-label="Open terminal in new tab"
+          >
+            <ExternalLink className="h-3.5 w-3.5" />
+          </a>
+        </Button>
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className="h-9 w-9 rounded-full border border-white/10 bg-[#141010]/92 text-[#c9c0b7] backdrop-blur-sm hover:bg-[#201818] sm:h-7 sm:w-7"
+          onClick={() => void handleMobilePaste()}
+          aria-label="Paste from clipboard"
+        >
+          <Clipboard className="h-3.5 w-3.5" />
+        </Button>
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className="h-9 w-9 rounded-full border border-white/10 bg-[#141010]/92 text-[#c9c0b7] backdrop-blur-sm hover:bg-[#201818] sm:h-7 sm:w-7"
+          onClick={() => void handleSoftStop()}
+          aria-label="Soft stop terminal"
+        >
+          <SquareStop className="h-3.5 w-3.5" />
+        </Button>
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className="h-9 w-9 rounded-full border border-white/10 bg-[#141010]/92 text-[#c9c0b7] backdrop-blur-sm hover:bg-[#201818] sm:h-7 sm:w-7"
+          onClick={handleRetry}
+          aria-label="Reload terminal"
+        >
+          {!frameLoaded ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <RefreshCw className="h-3.5 w-3.5" />
+          )}
+        </Button>
+      </div>
+
+      <div
+        className={immersiveMobileMode
+          ? "min-h-0 min-w-0 h-0 flex-1 overflow-hidden px-0 pb-[env(safe-area-inset-bottom)] pt-0 w-full"
+          : "min-h-0 min-w-0 h-0 flex-1 overflow-hidden px-0.5 pb-0 pt-0.5 lg:px-1.5 lg:pb-1 lg:pt-3 w-full"}
+      >
+        <div className="relative flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden rounded-[10px] bg-[#060404] pb-[env(safe-area-inset-bottom)]">
+          {!frameLoaded ? (
+            <div className="absolute inset-0 z-10 flex items-center justify-center bg-[#060404]">
+              <div className="flex items-center gap-2 rounded-full border border-white/10 bg-[#141010]/92 px-3 py-2 text-[12px] text-[#c9c0b7] backdrop-blur-sm">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                <span>Loading terminal…</span>
+              </div>
+            </div>
+          ) : null}
+          {connectionError ? (
+            <div className="absolute inset-x-0 top-3 z-10 mx-auto w-fit rounded-full border border-red-500/30 bg-red-500/10 px-3 py-1 text-[12px] text-red-200">
+              {connectionError}
+            </div>
+          ) : null}
+          <iframe
+            key={`${sessionId}:${reloadNonce}`}
+            ref={iframeRef}
+            src={iframeSrc}
+            title={`Conductor terminal ${sessionId}`}
+            className="block h-full min-h-0 w-full flex-1 border-0 bg-[#060404]"
+            allow="clipboard-read; clipboard-write"
+            loading="eager"
+            onError={() => {
+              setConnectionError("Failed to load the terminal frame.");
+            }}
+            onLoad={() => {
+              setFrameLoaded(true);
+              setConnectionError(null);
+              if (loadTimerRef.current !== null) {
+                window.clearTimeout(loadTimerRef.current);
+                loadTimerRef.current = null;
+              }
+            }}
+          />
+          {!panelVisible && !frameLoaded ? (
+            <div className="pointer-events-none absolute inset-0 bg-[#060404]" />
+          ) : null}
+        </div>
+      </div>
+
+      {!showPromptBar && (queuedInsertError || attachmentError) ? (
+        <div className="absolute inset-x-0 bottom-0 z-10 border-t border-white/12 bg-[#161212] px-3 py-2 text-[11px] text-[#ffb39e] backdrop-blur-sm [padding-bottom:env(safe-area-inset-bottom)]">
+          {queuedInsertError ? (
+            <div className="flex items-center gap-1.5">
+              <AlertCircle className="h-3 w-3 shrink-0" />
+              <span className="truncate">{queuedInsertError}</span>
+              <button
+                type="button"
+                className="ml-auto shrink-0 text-[#8e847d] hover:text-[#c9c0b7]"
+                onClick={() => setQueuedInsertError(null)}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          ) : null}
+          {attachmentError ? (
+            <div className={`flex items-center gap-1.5 ${queuedInsertError ? "mt-2" : ""}`}>
+              <AlertCircle className="h-3 w-3 shrink-0" />
+              <span className="truncate">{attachmentError}</span>
+              <button
+                type="button"
+                className="ml-auto shrink-0 text-[#8e847d] hover:text-[#c9c0b7]"
+                onClick={() => setAttachmentError(null)}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          ) : null}
         </div>
       ) : null}
-      {queuedInsertError ? (
-        <div className="absolute inset-x-0 top-12 z-10 mx-auto w-fit rounded-full border border-amber-500/30 bg-amber-500/10 px-3 py-1 text-[12px] text-amber-100">
-          {queuedInsertError}
+
+      {showPromptBar ? (
+        <div className="absolute inset-x-0 bottom-0 z-10 border-t border-white/12 bg-[#161212] backdrop-blur-sm [padding-bottom:env(safe-area-inset-bottom)]">
+          {queuedInsertError ? (
+            <div className="flex items-center gap-1.5 px-3 pt-1.5 text-[11px] text-[#ffb39e]">
+              <AlertCircle className="h-3 w-3 shrink-0" />
+              <span className="truncate">{queuedInsertError}</span>
+              <button
+                type="button"
+                className="ml-auto shrink-0 text-[#8e847d] hover:text-[#c9c0b7]"
+                onClick={() => setQueuedInsertError(null)}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          ) : null}
+          {attachmentError ? (
+            <div className="flex items-center gap-1.5 px-3 pt-1.5 text-[11px] text-[#ffb39e]">
+              <AlertCircle className="h-3 w-3 shrink-0" />
+              <span className="truncate">{attachmentError}</span>
+              <button
+                type="button"
+                className="ml-auto shrink-0 text-[#8e847d] hover:text-[#c9c0b7]"
+                onClick={() => setAttachmentError(null)}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          ) : null}
+          {promptError ? (
+            <div className="flex items-center gap-1.5 px-3 pt-1.5 text-[11px] text-[#ff8f7a]">
+              <AlertCircle className="h-3 w-3 shrink-0" />
+              <span className="truncate">{promptError}</span>
+              <button
+                type="button"
+                className="ml-auto shrink-0 text-[#8e847d] hover:text-[#c9c0b7]"
+                onClick={() => setPromptError(null)}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          ) : null}
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              void handlePromptSend();
+            }}
+            className="flex items-center gap-2 px-2 py-2 lg:px-3"
+          >
+            <input
+              ref={promptInputRef}
+              type="text"
+              value={promptMessage}
+              onChange={(event) => setPromptMessage(event.target.value)}
+              placeholder="Send a follow-up message…"
+              enterKeyHint="done"
+              disabled={promptSending}
+              className="h-8 min-w-0 flex-1 rounded-md border border-white/10 bg-[#0c0808] px-2.5 text-[12px] text-[#efe8e1] outline-none placeholder:text-[#7d746e] focus:border-white/20 disabled:opacity-50"
+            />
+            <Button
+              type="submit"
+              size="icon"
+              variant="ghost"
+              disabled={promptSending || promptMessage.trim().length === 0}
+              className="h-8 w-8 shrink-0 rounded-md border border-white/10 bg-[#0c0808] text-[#c9c0b7] hover:bg-[#201818] disabled:opacity-30"
+              aria-label="Send message"
+            >
+              {promptSending ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Send className="h-3.5 w-3.5" />
+              )}
+            </Button>
+          </form>
         </div>
-      ) : null}
-      <iframe
-        ref={iframeRef}
-        src={iframeSrc}
-        title={`Conductor terminal ${sessionId}`}
-        className="h-full w-full border-0 bg-[#060404]"
-        onLoad={() => {
-          setFrameLoaded(true);
-          setConnectionError(null);
-          if (loadTimerRef.current !== null) {
-            window.clearTimeout(loadTimerRef.current);
-            loadTimerRef.current = null;
-          }
-        }}
-      />
-      {!panelVisible && !frameLoaded ? (
-        <div className="pointer-events-none absolute inset-0 bg-[#060404]" />
       ) : null}
     </div>
   );

--- a/packages/web/src/components/sessions/SessionTerminal.tsx
+++ b/packages/web/src/components/sessions/SessionTerminal.tsx
@@ -7,7 +7,6 @@ import {
   FileUp,
   Loader2,
   RefreshCw,
-  Send,
   SquareStop,
   X,
 } from "lucide-react";
@@ -23,7 +22,7 @@ import {
 import { Button } from "@/components/ui/Button";
 import { uploadProjectAttachments } from "@/components/sessions/attachmentUploads";
 import type { SessionTerminalProps } from "@/components/sessions/terminal/terminalTypes";
-import { LIVE_TERMINAL_STATUSES, RESUMABLE_STATUSES } from "@/components/sessions/terminal/terminalConstants";
+import { LIVE_TERMINAL_STATUSES } from "@/components/sessions/terminal/terminalConstants";
 import { withBridgeQuery } from "@/lib/bridgeQuery";
 import { buildSessionHref } from "@/lib/dashboardHref";
 
@@ -51,27 +50,6 @@ async function sendTerminalKeys(
   }
 }
 
-async function sendFollowUpMessage(
-  sessionId: string,
-  message: string,
-  bridgeId?: string | null,
-): Promise<void> {
-  const response = await fetch(
-    withBridgeQuery(`/api/sessions/${encodeURIComponent(sessionId)}/actions`, bridgeId),
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ action: "send", message }),
-    },
-  );
-  if (!response.ok) {
-    const data = (await response.json().catch(() => null)) as { error?: string } | null;
-    throw new Error(data?.error ?? `Failed to send message (${response.status})`);
-  }
-}
-
 function SessionTerminalView({
   sessionId,
   projectId,
@@ -85,7 +63,6 @@ function SessionTerminalView({
 }: SessionTerminalProps) {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const attachmentInputRef = useRef<HTMLInputElement | null>(null);
-  const promptInputRef = useRef<HTMLInputElement | null>(null);
   const loadTimerRef = useRef<number | null>(null);
   const lastAppliedInsertNonceRef = useRef(0);
   const pendingInsertNonceRef = useRef<number | null>(null);
@@ -95,9 +72,6 @@ function SessionTerminalView({
   const [queuedInsertError, setQueuedInsertError] = useState<string | null>(null);
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
   const [attachmentUploading, setAttachmentUploading] = useState(false);
-  const [promptMessage, setPromptMessage] = useState("");
-  const [promptSending, setPromptSending] = useState(false);
-  const [promptError, setPromptError] = useState<string | null>(null);
   const [reloadNonce, setReloadNonce] = useState(0);
 
   const iframeSrc = useMemo(
@@ -114,9 +88,6 @@ function SessionTerminalView({
   const liveRuntimeExpected = normalizedRuntimeMode === "direct"
     ? !sessionClosed
     : LIVE_TERMINAL_STATUSES.has(normalizedSessionStatus);
-  const showPromptBar = !liveRuntimeExpected
-    && !immersiveMobileMode
-    && RESUMABLE_STATUSES.has(normalizedSessionStatus);
   const terminalSessionHref = buildSessionHref(sessionId, { bridgeId, tab: "terminal" });
 
   useEffect(() => {
@@ -181,25 +152,6 @@ function SessionTerminalView({
       cancelled = true;
     };
   }, [bridgeId, onPendingInsertConsumed, pendingInsert, sessionId]);
-
-  const handlePromptSend = useCallback(async () => {
-    const message = promptMessage.trim();
-    if (!message || promptSending) {
-      return;
-    }
-
-    setPromptSending(true);
-    setPromptError(null);
-    try {
-      await sendFollowUpMessage(sessionId, message, bridgeId);
-      setPromptMessage("");
-      promptInputRef.current?.focus();
-    } catch (error) {
-      setPromptError(error instanceof Error ? error.message : "Failed to send message.");
-    } finally {
-      setPromptSending(false);
-    }
-  }, [bridgeId, promptMessage, promptSending, sessionId]);
 
   const handleRetry = useCallback(() => {
     setConnectionError(null);
@@ -390,7 +342,7 @@ function SessionTerminalView({
         </div>
       </div>
 
-      {!showPromptBar && (queuedInsertError || attachmentError) ? (
+      {queuedInsertError || attachmentError ? (
         <div className="absolute inset-x-0 bottom-0 z-10 border-t border-white/12 bg-[#161212] px-3 py-2 text-[11px] text-[#ffb39e] backdrop-blur-sm [padding-bottom:env(safe-area-inset-bottom)]">
           {queuedInsertError ? (
             <div className="flex items-center gap-1.5">
@@ -418,82 +370,6 @@ function SessionTerminalView({
               </button>
             </div>
           ) : null}
-        </div>
-      ) : null}
-
-      {showPromptBar ? (
-        <div className="absolute inset-x-0 bottom-0 z-10 border-t border-white/12 bg-[#161212] backdrop-blur-sm [padding-bottom:env(safe-area-inset-bottom)]">
-          {queuedInsertError ? (
-            <div className="flex items-center gap-1.5 px-3 pt-1.5 text-[11px] text-[#ffb39e]">
-              <AlertCircle className="h-3 w-3 shrink-0" />
-              <span className="truncate">{queuedInsertError}</span>
-              <button
-                type="button"
-                className="ml-auto shrink-0 text-[#8e847d] hover:text-[#c9c0b7]"
-                onClick={() => setQueuedInsertError(null)}
-              >
-                <X className="h-3 w-3" />
-              </button>
-            </div>
-          ) : null}
-          {attachmentError ? (
-            <div className="flex items-center gap-1.5 px-3 pt-1.5 text-[11px] text-[#ffb39e]">
-              <AlertCircle className="h-3 w-3 shrink-0" />
-              <span className="truncate">{attachmentError}</span>
-              <button
-                type="button"
-                className="ml-auto shrink-0 text-[#8e847d] hover:text-[#c9c0b7]"
-                onClick={() => setAttachmentError(null)}
-              >
-                <X className="h-3 w-3" />
-              </button>
-            </div>
-          ) : null}
-          {promptError ? (
-            <div className="flex items-center gap-1.5 px-3 pt-1.5 text-[11px] text-[#ff8f7a]">
-              <AlertCircle className="h-3 w-3 shrink-0" />
-              <span className="truncate">{promptError}</span>
-              <button
-                type="button"
-                className="ml-auto shrink-0 text-[#8e847d] hover:text-[#c9c0b7]"
-                onClick={() => setPromptError(null)}
-              >
-                <X className="h-3 w-3" />
-              </button>
-            </div>
-          ) : null}
-          <form
-            onSubmit={(event) => {
-              event.preventDefault();
-              void handlePromptSend();
-            }}
-            className="flex items-center gap-2 px-2 py-2 lg:px-3"
-          >
-            <input
-              ref={promptInputRef}
-              type="text"
-              value={promptMessage}
-              onChange={(event) => setPromptMessage(event.target.value)}
-              placeholder="Send a follow-up message…"
-              enterKeyHint="done"
-              disabled={promptSending}
-              className="h-8 min-w-0 flex-1 rounded-md border border-white/10 bg-[#0c0808] px-2.5 text-[12px] text-[#efe8e1] outline-none placeholder:text-[#7d746e] focus:border-white/20 disabled:opacity-50"
-            />
-            <Button
-              type="submit"
-              size="icon"
-              variant="ghost"
-              disabled={promptSending || promptMessage.trim().length === 0}
-              className="h-8 w-8 shrink-0 rounded-md border border-white/10 bg-[#0c0808] text-[#c9c0b7] hover:bg-[#201818] disabled:opacity-30"
-              aria-label="Send message"
-            >
-              {promptSending ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <Send className="h-3.5 w-3.5" />
-              )}
-            </Button>
-          </form>
         </div>
       ) : null}
     </div>

--- a/packages/web/src/components/sessions/terminal/terminalClientUrls.test.ts
+++ b/packages/web/src/components/sessions/terminal/terminalClientUrls.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  normalizeBrowserBackendOrigin,
+  resolveNativeTerminalWebSocketUrl,
+} from "./terminalClientUrls";
+
+const env = process.env as Record<string, string | undefined>;
+const previousPublicBackendUrl = env.NEXT_PUBLIC_CONDUCTOR_BACKEND_URL;
+const previousDocument = globalThis.document;
+
+test.afterEach(() => {
+  if (previousPublicBackendUrl === undefined) {
+    delete env.NEXT_PUBLIC_CONDUCTOR_BACKEND_URL;
+  } else {
+    env.NEXT_PUBLIC_CONDUCTOR_BACKEND_URL = previousPublicBackendUrl;
+  }
+  Object.defineProperty(globalThis, "document", {
+    value: previousDocument,
+    configurable: true,
+    writable: true,
+  });
+});
+
+test("normalizeBrowserBackendOrigin remaps loopback backend hints onto hosted origins", () => {
+  assert.equal(
+    normalizeBrowserBackendOrigin("http://127.0.0.1:4749", "https://app.conductross.com"),
+    "https://app.conductross.com:4749",
+  );
+});
+
+test("resolveNativeTerminalWebSocketUrl routes native terminal websocket paths to the backend origin", () => {
+  Object.defineProperty(globalThis, "document", {
+    value: {
+      querySelector: () => ({ content: "http://127.0.0.1:4749" }),
+    },
+    configurable: true,
+    writable: true,
+  });
+
+  assert.equal(
+    resolveNativeTerminalWebSocketUrl(
+      "/api/sessions/demo/terminal/ws?token=abc",
+      "https://app.conductross.com",
+    ),
+    "wss://app.conductross.com:4749/api/sessions/demo/terminal/ws?token=abc",
+  );
+});
+
+test("resolveNativeTerminalWebSocketUrl keeps non-terminal paths on the current origin", () => {
+  Object.defineProperty(globalThis, "document", {
+    value: { querySelector: () => null },
+    configurable: true,
+    writable: true,
+  });
+
+  assert.equal(
+    resolveNativeTerminalWebSocketUrl("/socket.io/live", "https://app.conductross.com"),
+    "wss://app.conductross.com/socket.io/live",
+  );
+});
+
+test("resolveNativeTerminalWebSocketUrl preserves explicit websocket URLs", () => {
+  assert.equal(
+    resolveNativeTerminalWebSocketUrl("wss://backend.example.com/terminal", "https://app.conductross.com"),
+    "wss://backend.example.com/terminal",
+  );
+});

--- a/packages/web/src/components/sessions/terminal/terminalClientUrls.ts
+++ b/packages/web/src/components/sessions/terminal/terminalClientUrls.ts
@@ -1,0 +1,67 @@
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "::1";
+}
+
+export function normalizeBrowserBackendOrigin(rawOrigin: string | null | undefined, currentOrigin: string): string | null {
+  const trimmed = rawOrigin?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const current = new URL(currentOrigin);
+    const resolved = new URL(trimmed, currentOrigin);
+    if (resolved.protocol !== "http:" && resolved.protocol !== "https:") {
+      return null;
+    }
+
+    if (isLoopbackHostname(resolved.hostname) && !isLoopbackHostname(current.hostname)) {
+      resolved.hostname = current.hostname;
+      if (current.protocol === "https:" && resolved.protocol === "http:") {
+        resolved.protocol = "https:";
+      }
+    }
+
+    return resolved.origin;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveTerminalBrowserBackendOrigin(currentOrigin: string): string {
+  const metaOrigin = typeof document === "undefined"
+    ? null
+    : document.querySelector<HTMLMetaElement>('meta[name="conductor-backend-url"]')?.content ?? null;
+
+  return normalizeBrowserBackendOrigin(
+    metaOrigin || process.env.NEXT_PUBLIC_CONDUCTOR_BACKEND_URL || null,
+    currentOrigin,
+  ) ?? currentOrigin;
+}
+
+function looksLikeNativeTerminalProxyPath(pathname: string): boolean {
+  return pathname.startsWith("/api/sessions/") && pathname.includes("/terminal/ws");
+}
+
+export function resolveNativeTerminalWebSocketUrl(pathOrUrl: string, currentOrigin: string): string {
+  if (pathOrUrl.startsWith("ws://") || pathOrUrl.startsWith("wss://")) {
+    return pathOrUrl;
+  }
+
+  const baseOrigin = (() => {
+    try {
+      const candidate = new URL(pathOrUrl, currentOrigin);
+      if (looksLikeNativeTerminalProxyPath(candidate.pathname)) {
+        return resolveTerminalBrowserBackendOrigin(currentOrigin);
+      }
+    } catch {
+      // Fall back to current origin below.
+    }
+    return currentOrigin;
+  })();
+
+  const origin = new URL(baseOrigin);
+  origin.protocol = origin.protocol === "https:" ? "wss:" : "ws:";
+  const normalizedPath = pathOrUrl.startsWith("/") ? pathOrUrl : `/${pathOrUrl}`;
+  return `${origin.origin}${normalizedPath}`;
+}


### PR DESCRIPTION
## User-Facing Release Notes

- Restores hosted iframe terminals so live sessions can open again.
- Restores the session terminal iframe chrome, including the action icons and follow-up input bar that were present before the native PTY cutover.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Summary

This PR fixes two regressions in the native PTY iframe terminal path:

1. The embedded terminal page was trying to connect through a Next.js fetch proxy that cannot forward WebSocket upgrades, so hosted terminals never opened.
2. The session terminal host lost the older iframe chrome and action controls during the cutover.

The fix routes iframe WebSocket connections directly to the backend origin and restores the terminal shell UI around the iframe.

## Testing

- `bun run --cwd packages/web typecheck`
- `bun run --cwd packages/web test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal toolbar, retry/reload control, and bottom status bar for improved connection and feedback
  * File attachment upload to terminals
  * Clipboard paste into terminal
  * Soft stop (Ctrl+C) control and option to open terminal in a new tab

* **Bug Fixes**
  * Improved pending input handling to prevent duplicate sends and clearer error reporting

* **Tests**
  * Added tests for terminal URL resolution logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->