### PR TITLE
fix: clean up iframe terminal chrome for production

### DIFF
--- a/packages/web/src/components/sessions/IframeTerminalPage.tsx
+++ b/packages/web/src/components/sessions/IframeTerminalPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { FitAddon } from "@xterm/addon-fit";
 import { Terminal } from "xterm";
 import "xterm/css/xterm.css";
@@ -83,9 +83,6 @@ export function IframeTerminalPage({
   const bridgeScopedSession = useMemo(() => decodeBridgeSessionId(sessionId), [sessionId]);
   const usesRelayTerminal = Boolean(bridgeId?.trim() || bridgeScopedSession);
 
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
   const tokenUrl = useMemo(
     () => withBridgeQuery(`/api/sessions/${encodeURIComponent(sessionId)}/terminal/token`, bridgeId),
     [bridgeId, sessionId],
@@ -122,8 +119,15 @@ export function IframeTerminalPage({
     return { cols: terminal.cols, rows: terminal.rows };
   }, []);
 
+  const writeTerminalNotice = useCallback((message: string) => {
+    const trimmed = message.trim();
+    if (!trimmed) {
+      return;
+    }
+    terminalRef.current?.writeln(`\r\n[Conductor] ${trimmed}`);
+  }, []);
+
   const loadStoredOutput = useCallback(async (outputUrl?: string | null, reason?: string | null) => {
-    setLoading(false);
     if (!outputUrl) {
       if (reason) {
         terminalRef.current?.writeln(`\r\n[Conductor] ${reason}`);
@@ -142,10 +146,9 @@ export function IframeTerminalPage({
       }
     } catch (nextError) {
       const message = nextError instanceof Error ? nextError.message : "Failed to load stored output.";
-      setError(message);
-      terminalRef.current?.writeln(`\r\n[Conductor] ${message}`);
+      writeTerminalNotice(message);
     }
-  }, []);
+  }, [writeTerminalNotice]);
 
   const fetchRelayTerminalUrl = useCallback(async (): Promise<RelayConnectionInfo> => {
     const response = await fetch(
@@ -184,8 +187,6 @@ export function IframeTerminalPage({
     if (!allowReconnectRef.current) {
       return;
     }
-    setLoading(true);
-    setError(null);
 
     const response = await fetch(tokenUrl, { cache: "no-store" });
     if (!allowReconnectRef.current) {
@@ -264,18 +265,14 @@ export function IframeTerminalPage({
         const payload = JSON.parse(text) as ControlMessage;
         switch (payload.type) {
           case "ready":
-            setLoading(false);
             return;
           case "cwd":
             return;
           case "exit":
-            setLoading(false);
-            terminalRef.current?.writeln(`\r\n[Conductor] Terminal exited (${payload.exitCode ?? 0}).`);
+            writeTerminalNotice(`Terminal exited (${payload.exitCode ?? 0}).`);
             return;
           case "error":
-            setLoading(false);
-            setError(payload.message ?? "Terminal connection failed.");
-            terminalRef.current?.writeln(`\r\n[Conductor] ${payload.message ?? "Terminal connection failed."}`);
+            writeTerminalNotice(payload.message ?? "Terminal connection failed.");
             return;
           case "pong":
             return;
@@ -286,7 +283,9 @@ export function IframeTerminalPage({
     };
 
     ws.onerror = () => {
-      setError(relayConnection ? "Relay terminal connection failed." : "Terminal websocket failed.");
+      writeTerminalNotice(
+        relayConnection ? "Relay terminal connection failed." : "Terminal websocket failed.",
+      );
     };
 
     ws.onclose = async () => {
@@ -297,8 +296,7 @@ export function IframeTerminalPage({
         return;
       }
       if (retryAttemptRef.current >= MAX_RECONNECT_ATTEMPTS) {
-        setLoading(false);
-        terminalRef.current?.writeln("\r\n[Conductor] Terminal disconnected.");
+        writeTerminalNotice("Terminal disconnected.");
         return;
       }
       retryAttemptRef.current += 1;
@@ -306,12 +304,22 @@ export function IframeTerminalPage({
       clearReconnectTimer();
       reconnectTimerRef.current = window.setTimeout(() => {
         void connect().catch((nextError) => {
-          setLoading(false);
-          setError(nextError instanceof Error ? nextError.message : "Failed to reconnect terminal.");
+          writeTerminalNotice(
+            nextError instanceof Error ? nextError.message : "Failed to reconnect terminal.",
+          );
         });
       }, delay);
     };
-  }, [clearReconnectTimer, fitTerminal, loadStoredOutput, tokenUrl, usesRelayTerminal, fetchRelayTerminalUrl, encodeResizeFrame]);
+  }, [
+    clearReconnectTimer,
+    fitTerminal,
+    loadStoredOutput,
+    tokenUrl,
+    usesRelayTerminal,
+    fetchRelayTerminalUrl,
+    encodeResizeFrame,
+    writeTerminalNotice,
+  ]);
 
   useEffect(() => {
     const terminal = new Terminal({
@@ -319,7 +327,7 @@ export function IframeTerminalPage({
       fontFamily: "var(--font-ibm-plex-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
       fontSize: 13,
       lineHeight: 1.2,
-      convertEol: false,
+      convertEol: true,
       scrollback: 5000,
       allowTransparency: false,
       theme: TERMINAL_THEME,
@@ -372,8 +380,7 @@ export function IframeTerminalPage({
     resizeObserver.observe(host);
 
     void connect().catch((nextError) => {
-      setLoading(false);
-      setError(nextError instanceof Error ? nextError.message : "Failed to connect terminal.");
+      writeTerminalNotice(nextError instanceof Error ? nextError.message : "Failed to connect terminal.");
     });
 
     return () => {
@@ -387,21 +394,20 @@ export function IframeTerminalPage({
       terminalRef.current = null;
       fitAddonRef.current = null;
     };
-  }, [clearReconnectTimer, closeSocket, connect, encodeInputFrame, encodeResizeFrame, fitTerminal, usesRelayTerminal]);
+  }, [
+    clearReconnectTimer,
+    closeSocket,
+    connect,
+    encodeInputFrame,
+    encodeResizeFrame,
+    fitTerminal,
+    usesRelayTerminal,
+    writeTerminalNotice,
+  ]);
 
   return (
     <div className="flex h-screen min-h-0 w-full min-w-0 flex-col bg-[#060404] text-[#efe8e1]">
       <div className="relative min-h-0 flex-1">
-        {loading ? (
-          <div className="absolute inset-x-0 top-3 z-10 mx-auto w-fit rounded-full border border-white/10 bg-[#141010]/92 px-3 py-1 text-[12px] text-[#c9c0b7]">
-            Connecting…
-          </div>
-        ) : null}
-        {error ? (
-          <div className="absolute inset-x-0 top-3 z-10 mx-auto w-fit rounded-full border border-red-500/30 bg-red-500/10 px-3 py-1 text-[12px] text-red-200">
-            {error}
-          </div>
-        ) : null}
         <div ref={hostRef} className="h-full w-full overflow-hidden" />
       </div>
     </div>

--- a/packages/web/src/components/sessions/IframeTerminalPage.tsx
+++ b/packages/web/src/components/sessions/IframeTerminalPage.tsx
@@ -7,6 +7,7 @@ import "xterm/css/xterm.css";
 import { withBridgeQuery } from "@/lib/bridgeQuery";
 import { attachMobileTouchScrollShim } from "@/components/sessions/terminal/mobileTouchScroll";
 import { resolveNativeTerminalWebSocketUrl } from "@/components/sessions/terminal/terminalClientUrls";
+import { decodeBridgeSessionId } from "@/lib/bridgeSessionIds";
 
 type ConnectionInfo = {
   interactive?: boolean;
@@ -20,6 +21,11 @@ type OutputPayload = {
   error?: string;
 };
 
+type RelayConnectionInfo = {
+  wsUrl: string;
+  wsProtocol: string;
+};
+
 type ControlMessage =
   | { type: "ready"; sequence?: number; cwd?: string | null }
   | { type: "cwd"; cwd?: string | null }
@@ -29,6 +35,10 @@ type ControlMessage =
 
 const RECONNECT_MAX_DELAY_MS = 4_000;
 const MAX_RECONNECT_ATTEMPTS = 20;
+const CMD_OUTPUT = "0".charCodeAt(0);
+const CMD_SET_WINDOW_TITLE = "1".charCodeAt(0);
+const CMD_SET_PREFERENCES = "2".charCodeAt(0);
+const CMD_RESIZE = "1".charCodeAt(0);
 
 const TERMINAL_THEME = {
   background: "#060404",
@@ -69,9 +79,11 @@ export function IframeTerminalPage({
   const reconnectTimerRef = useRef<number | null>(null);
   const cleanupTouchRef = useRef<(() => void) | null>(null);
   const retryAttemptRef = useRef(0);
+  const decoderRef = useRef(new TextDecoder());
+  const bridgeScopedSession = useMemo(() => decodeBridgeSessionId(sessionId), [sessionId]);
+  const usesRelayTerminal = Boolean(bridgeId?.trim() || bridgeScopedSession);
 
   const [loading, setLoading] = useState(true);
-  const [status, setStatus] = useState<string | null>("Connecting terminal…");
   const [error, setError] = useState<string | null>(null);
 
   const tokenUrl = useMemo(
@@ -112,8 +124,10 @@ export function IframeTerminalPage({
 
   const loadStoredOutput = useCallback(async (outputUrl?: string | null, reason?: string | null) => {
     setLoading(false);
-    setStatus(reason ?? "Showing stored terminal output.");
     if (!outputUrl) {
+      if (reason) {
+        terminalRef.current?.writeln(`\r\n[Conductor] ${reason}`);
+      }
       return;
     }
     try {
@@ -133,13 +147,45 @@ export function IframeTerminalPage({
     }
   }, []);
 
+  const fetchRelayTerminalUrl = useCallback(async (): Promise<RelayConnectionInfo> => {
+    const response = await fetch(
+      withBridgeQuery(`/api/sessions/${encodeURIComponent(sessionId)}/terminal/relay`, bridgeId),
+      {
+        method: "POST",
+        cache: "no-store",
+      },
+    );
+    const payload = (await response.json().catch(() => null)) as
+      | { wsUrl?: string; wsProtocol?: string; error?: string }
+      | null;
+    if (!response.ok || !payload?.wsUrl || !payload.wsProtocol) {
+      throw new Error(payload?.error ?? `Failed to attach relay terminal (${response.status})`);
+    }
+    return { wsUrl: payload.wsUrl, wsProtocol: payload.wsProtocol };
+  }, [bridgeId, sessionId]);
+
+  const encodeResizeFrame = useCallback((cols: number, rows: number): Uint8Array => {
+    const payload = new TextEncoder().encode(JSON.stringify({ columns: cols, rows }));
+    const frame = new Uint8Array(payload.length + 1);
+    frame[0] = CMD_RESIZE;
+    frame.set(payload, 1);
+    return frame;
+  }, []);
+
+  const encodeInputFrame = useCallback((data: string): Uint8Array => {
+    const payload = new TextEncoder().encode(data);
+    const frame = new Uint8Array(payload.length + 1);
+    frame[0] = CMD_OUTPUT;
+    frame.set(payload, 1);
+    return frame;
+  }, []);
+
   const connect = useCallback(async () => {
     if (!allowReconnectRef.current) {
       return;
     }
     setLoading(true);
     setError(null);
-    setStatus(retryAttemptRef.current > 0 ? "Reconnecting terminal…" : "Connecting terminal…");
 
     const response = await fetch(tokenUrl, { cache: "no-store" });
     if (!allowReconnectRef.current) {
@@ -155,23 +201,61 @@ export function IframeTerminalPage({
       return;
     }
 
-    const ws = new WebSocket(resolveNativeTerminalWebSocketUrl(info.wsUrl, window.location.origin));
+    const relayConnection = usesRelayTerminal ? await fetchRelayTerminalUrl() : null;
+    const ws = relayConnection
+      ? new WebSocket(relayConnection.wsUrl, relayConnection.wsProtocol)
+      : new WebSocket(resolveNativeTerminalWebSocketUrl(info.wsUrl, window.location.origin));
     ws.binaryType = "arraybuffer";
     socketRef.current = ws;
 
     ws.onopen = () => {
       retryAttemptRef.current = 0;
+      decoderRef.current = new TextDecoder();
       const geometry = fitTerminal();
-      ws.send(JSON.stringify({
-        type: "hello",
-        cols: geometry?.cols ?? 120,
-        rows: geometry?.rows ?? 32,
-      }));
+      if (relayConnection) {
+        ws.send(encodeResizeFrame(geometry?.cols ?? 120, geometry?.rows ?? 32));
+      } else {
+        ws.send(JSON.stringify({
+          type: "hello",
+          cols: geometry?.cols ?? 120,
+          rows: geometry?.rows ?? 32,
+        }));
+      }
     };
 
     ws.onmessage = (event) => {
       if (event.data instanceof ArrayBuffer) {
-        terminalRef.current?.write(new Uint8Array(event.data));
+        const frame = new Uint8Array(event.data);
+        if (relayConnection) {
+          if (frame.length === 0) {
+            return;
+          }
+          switch (frame[0]) {
+            case CMD_OUTPUT: {
+              const text = decoderRef.current.decode(frame.slice(1), { stream: true });
+              if (text.length > 0) {
+                terminalRef.current?.write(text);
+              }
+              return;
+            }
+            case CMD_SET_WINDOW_TITLE: {
+              try {
+                const title = new TextDecoder().decode(frame.slice(1)).trim();
+                if (title) {
+                  document.title = title;
+                }
+              } catch {
+                // Ignore malformed title payloads.
+              }
+              return;
+            }
+            case CMD_SET_PREFERENCES:
+              return;
+            default:
+              return;
+          }
+        }
+        terminalRef.current?.write(frame);
         return;
       }
 
@@ -181,14 +265,12 @@ export function IframeTerminalPage({
         switch (payload.type) {
           case "ready":
             setLoading(false);
-            setStatus(payload.cwd ? `Live terminal, ${payload.cwd}` : "Live terminal connected.");
             return;
           case "cwd":
-            setStatus(payload.cwd ? `Live terminal, ${payload.cwd}` : "Live terminal connected.");
             return;
           case "exit":
             setLoading(false);
-            setStatus(`Terminal exited (${payload.exitCode ?? 0}).`);
+            terminalRef.current?.writeln(`\r\n[Conductor] Terminal exited (${payload.exitCode ?? 0}).`);
             return;
           case "error":
             setLoading(false);
@@ -204,7 +286,7 @@ export function IframeTerminalPage({
     };
 
     ws.onerror = () => {
-      setError("Terminal websocket failed.");
+      setError(relayConnection ? "Relay terminal connection failed." : "Terminal websocket failed.");
     };
 
     ws.onclose = async () => {
@@ -216,7 +298,7 @@ export function IframeTerminalPage({
       }
       if (retryAttemptRef.current >= MAX_RECONNECT_ATTEMPTS) {
         setLoading(false);
-        setStatus("Terminal disconnected.");
+        terminalRef.current?.writeln("\r\n[Conductor] Terminal disconnected.");
         return;
       }
       retryAttemptRef.current += 1;
@@ -229,7 +311,7 @@ export function IframeTerminalPage({
         });
       }, delay);
     };
-  }, [clearReconnectTimer, fitTerminal, loadStoredOutput, tokenUrl]);
+  }, [clearReconnectTimer, fitTerminal, loadStoredOutput, tokenUrl, usesRelayTerminal, fetchRelayTerminalUrl, encodeResizeFrame]);
 
   useEffect(() => {
     const terminal = new Terminal({
@@ -264,7 +346,11 @@ export function IframeTerminalPage({
       if (!socket || socket.readyState !== WebSocket.OPEN) {
         return;
       }
-      socket.send(JSON.stringify({ type: "input", data }));
+      if (usesRelayTerminal) {
+        socket.send(encodeInputFrame(data));
+      } else {
+        socket.send(JSON.stringify({ type: "input", data }));
+      }
     });
 
     const resizeObserver = new ResizeObserver(() => {
@@ -273,11 +359,15 @@ export function IframeTerminalPage({
       if (!geometry || !socket || socket.readyState !== WebSocket.OPEN) {
         return;
       }
-      socket.send(JSON.stringify({
-        type: "resize",
-        cols: geometry.cols,
-        rows: geometry.rows,
-      }));
+      if (usesRelayTerminal) {
+        socket.send(encodeResizeFrame(geometry.cols, geometry.rows));
+      } else {
+        socket.send(JSON.stringify({
+          type: "resize",
+          cols: geometry.cols,
+          rows: geometry.rows,
+        }));
+      }
     });
     resizeObserver.observe(host);
 
@@ -297,14 +387,10 @@ export function IframeTerminalPage({
       terminalRef.current = null;
       fitAddonRef.current = null;
     };
-  }, [clearReconnectTimer, closeSocket, connect, fitTerminal]);
+  }, [clearReconnectTimer, closeSocket, connect, encodeInputFrame, encodeResizeFrame, fitTerminal, usesRelayTerminal]);
 
   return (
     <div className="flex h-screen min-h-0 w-full min-w-0 flex-col bg-[#060404] text-[#efe8e1]">
-      <div className="flex items-center justify-between border-b border-white/10 px-3 py-2 text-[11px] uppercase tracking-[0.24em] text-[#c9c0b7]">
-        <span>Conductor terminal</span>
-        <span>{status ?? ""}</span>
-      </div>
       <div className="relative min-h-0 flex-1">
         {loading ? (
           <div className="absolute inset-x-0 top-3 z-10 mx-auto w-fit rounded-full border border-white/10 bg-[#141010]/92 px-3 py-1 text-[12px] text-[#c9c0b7]">
@@ -316,7 +402,7 @@ export function IframeTerminalPage({
             {error}
           </div>
         ) : null}
-        <div ref={hostRef} className="h-full w-full overflow-hidden px-2 py-1" />
+        <div ref={hostRef} className="h-full w-full overflow-hidden" />
       </div>
     </div>
   );

--- a/packages/web/src/components/sessions/SessionTerminal.tsx
+++ b/packages/web/src/components/sessions/SessionTerminal.tsx
@@ -3,7 +3,6 @@
 import {
   AlertCircle,
   Clipboard,
-  ExternalLink,
   FileUp,
   Loader2,
   RefreshCw,
@@ -22,12 +21,7 @@ import {
 import { Button } from "@/components/ui/Button";
 import { uploadProjectAttachments } from "@/components/sessions/attachmentUploads";
 import type { SessionTerminalProps } from "@/components/sessions/terminal/terminalTypes";
-import { LIVE_TERMINAL_STATUSES } from "@/components/sessions/terminal/terminalConstants";
 import { withBridgeQuery } from "@/lib/bridgeQuery";
-import { buildSessionHref } from "@/lib/dashboardHref";
-
-const TERMINAL_IFRAME_LOAD_TIMEOUT_MS = 15_000;
-const TERMINAL_CLOSED_STATUSES = new Set(["archived", "killed", "terminated", "restored"]);
 
 async function sendTerminalKeys(
   sessionId: string,
@@ -54,8 +48,6 @@ function SessionTerminalView({
   sessionId,
   projectId,
   bridgeId,
-  sessionState,
-  runtimeMode,
   pendingInsert,
   immersiveMobileMode = false,
   panelVisible = true,
@@ -63,12 +55,10 @@ function SessionTerminalView({
 }: SessionTerminalProps) {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const attachmentInputRef = useRef<HTMLInputElement | null>(null);
-  const loadTimerRef = useRef<number | null>(null);
   const lastAppliedInsertNonceRef = useRef(0);
   const pendingInsertNonceRef = useRef<number | null>(null);
 
   const [frameLoaded, setFrameLoaded] = useState(false);
-  const [connectionError, setConnectionError] = useState<string | null>(null);
   const [queuedInsertError, setQueuedInsertError] = useState<string | null>(null);
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
   const [attachmentUploading, setAttachmentUploading] = useState(false);
@@ -79,33 +69,8 @@ function SessionTerminalView({
     [bridgeId, sessionId],
   );
 
-  const normalizedSessionStatus = useMemo(
-    () => sessionState.trim().toLowerCase(),
-    [sessionState],
-  );
-  const normalizedRuntimeMode = runtimeMode?.trim().toLowerCase() ?? null;
-  const sessionClosed = TERMINAL_CLOSED_STATUSES.has(normalizedSessionStatus);
-  const liveRuntimeExpected = normalizedRuntimeMode === "direct"
-    ? !sessionClosed
-    : LIVE_TERMINAL_STATUSES.has(normalizedSessionStatus);
-  const terminalSessionHref = buildSessionHref(sessionId, { bridgeId, tab: "terminal" });
-
   useEffect(() => {
     setFrameLoaded(false);
-    setConnectionError(null);
-    if (loadTimerRef.current !== null) {
-      window.clearTimeout(loadTimerRef.current);
-    }
-    loadTimerRef.current = window.setTimeout(() => {
-      setConnectionError("The embedded terminal did not finish loading in time.");
-    }, TERMINAL_IFRAME_LOAD_TIMEOUT_MS);
-
-    return () => {
-      if (loadTimerRef.current !== null) {
-        window.clearTimeout(loadTimerRef.current);
-        loadTimerRef.current = null;
-      }
-    };
   }, [iframeSrc, reloadNonce]);
 
   useEffect(() => {
@@ -154,7 +119,6 @@ function SessionTerminalView({
   }, [bridgeId, onPendingInsertConsumed, pendingInsert, sessionId]);
 
   const handleRetry = useCallback(() => {
-    setConnectionError(null);
     setFrameLoaded(false);
     setReloadNonce((value) => value + 1);
   }, []);
@@ -228,7 +192,7 @@ function SessionTerminalView({
           accept="*/*"
           className="sr-only"
           tabIndex={-1}
-          aria-hidden
+          aria-hidden="true"
           onChange={(event) => void handleAttachmentFiles(event)}
         />
         <Button
@@ -245,21 +209,6 @@ function SessionTerminalView({
           ) : (
             <FileUp className="h-3.5 w-3.5" />
           )}
-        </Button>
-        <Button
-          asChild
-          size="icon"
-          variant="ghost"
-          className="h-9 w-9 rounded-full border border-white/10 bg-[#141010]/92 text-[#c9c0b7] backdrop-blur-sm hover:bg-[#201818] sm:h-7 sm:w-7"
-        >
-          <a
-            href={terminalSessionHref}
-            target="_blank"
-            rel="noreferrer"
-            aria-label="Open terminal in new tab"
-          >
-            <ExternalLink className="h-3.5 w-3.5" />
-          </a>
         </Button>
         <Button
           type="button"
@@ -303,19 +252,6 @@ function SessionTerminalView({
           : "min-h-0 min-w-0 h-0 flex-1 overflow-hidden px-0.5 pb-0 pt-0.5 lg:px-1.5 lg:pb-1 lg:pt-3 w-full"}
       >
         <div className="relative flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden rounded-[10px] bg-[#060404] pb-[env(safe-area-inset-bottom)]">
-          {!frameLoaded ? (
-            <div className="absolute inset-0 z-10 flex items-center justify-center bg-[#060404]">
-              <div className="flex items-center gap-2 rounded-full border border-white/10 bg-[#141010]/92 px-3 py-2 text-[12px] text-[#c9c0b7] backdrop-blur-sm">
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                <span>Loading terminal…</span>
-              </div>
-            </div>
-          ) : null}
-          {connectionError ? (
-            <div className="absolute inset-x-0 top-3 z-10 mx-auto w-fit rounded-full border border-red-500/30 bg-red-500/10 px-3 py-1 text-[12px] text-red-200">
-              {connectionError}
-            </div>
-          ) : null}
           <iframe
             key={`${sessionId}:${reloadNonce}`}
             ref={iframeRef}
@@ -325,15 +261,10 @@ function SessionTerminalView({
             allow="clipboard-read; clipboard-write"
             loading="eager"
             onError={() => {
-              setConnectionError("Failed to load the terminal frame.");
+              setFrameLoaded(false);
             }}
             onLoad={() => {
               setFrameLoaded(true);
-              setConnectionError(null);
-              if (loadTimerRef.current !== null) {
-                window.clearTimeout(loadTimerRef.current);
-                loadTimerRef.current = null;
-              }
             }}
           />
           {!panelVisible && !frameLoaded ? (
@@ -352,6 +283,7 @@ function SessionTerminalView({
                 type="button"
                 className="ml-auto shrink-0 text-[#8e847d] hover:text-[#c9c0b7]"
                 onClick={() => setQueuedInsertError(null)}
+                aria-label="Dismiss queued insert error"
               >
                 <X className="h-3 w-3" />
               </button>
@@ -365,6 +297,7 @@ function SessionTerminalView({
                 type="button"
                 className="ml-auto shrink-0 text-[#8e847d] hover:text-[#c9c0b7]"
                 onClick={() => setAttachmentError(null)}
+                aria-label="Dismiss attachment error"
               >
                 <X className="h-3 w-3" />
               </button>


### PR DESCRIPTION
## User-Facing Release Notes

- The session terminal now keeps only the iframe surface and the terminal action icons. The extra top banners and external-link button are gone.
- Terminal connection and disconnect notices now stay inside the terminal surface instead of covering it with floating status pills.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Removed terminal loading and connection error overlays for a cleaner interface.
  * Removed "open terminal in new tab" button.
  * Enhanced accessibility with improved labels on terminal controls.
  * Terminal notifications now displayed directly within the terminal.
  * Added relay terminal support for improved connectivity options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->