### PR TITLE
fix: extend paired relay terminal attach window

### DIFF
--- a/bridge-cmd/relay/client.go
+++ b/bridge-cmd/relay/client.go
@@ -28,7 +28,7 @@ const (
 	defaultScope              = "conductor-bridge-control"
 	defaultHeartbeatInterval  = 30 * time.Second
 	maxReconnectBackoff       = 30 * time.Second
-	terminalAttachMaxAttempts = 5
+	terminalAttachMaxAttempts = 12
 	ttydPortRangeStart        = 7681
 	ttydPortRangeEnd          = 8699
 	bridgeProxyMetaKey        = "$bridgeProxy"

--- a/crates/conductor-relay/src/relay.rs
+++ b/crates/conductor-relay/src/relay.rs
@@ -134,7 +134,7 @@ struct ProxiedPreviewResponse {
     body_base64: Option<String>,
 }
 
-const TERMINAL_SESSION_READY_TIMEOUT: Duration = Duration::from_secs(8);
+const TERMINAL_SESSION_READY_TIMEOUT: Duration = Duration::from_secs(20);
 /// Maximum number of output chunks buffered while the browser peer is paused.
 const TERMINAL_PAUSE_BUFFER_CAPACITY: usize = 256;
 /// ttyd protocol command bytes (first byte of binary WebSocket message).


### PR DESCRIPTION
## User-Facing Release Notes

- Paired-device terminals now wait longer for the laptop relay terminal to come online during fresh session startup, so the terminal is less likely to fail with a relay-ready timeout on slower devices.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal connection reliability by increasing retry attempts for backend terminal connections.
  * Extended timeout period for terminal session initialization to accommodate slower connection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->