### PR TITLE
fix: harden paired iframe terminal reconnects

### DIFF
--- a/bridge-cmd/relay/client.go
+++ b/bridge-cmd/relay/client.go
@@ -91,6 +91,31 @@ type terminalAttachError struct {
 	err    error
 }
 
+type backendTerminalProtocol string
+
+const (
+	backendTerminalProtocolNative backendTerminalProtocol = "native"
+	backendTerminalProtocolTTYD   backendTerminalProtocol = "ttyd"
+)
+
+type terminalTokenPayload struct {
+	WSURL     string `json:"wsUrl"`
+	TtydWSURL string `json:"ttydWsUrl"`
+	Error     string `json:"error"`
+}
+
+type nativeTerminalClientMessage struct {
+	Type string `json:"type"`
+	Cols int    `json:"cols,omitempty"`
+	Rows int    `json:"rows,omitempty"`
+	Data string `json:"data,omitempty"`
+}
+
+type relayResizePayload struct {
+	Columns int `json:"columns"`
+	Rows    int `json:"rows"`
+}
+
 func (e *terminalAttachError) Error() string {
 	if e == nil {
 		return "terminal attach failed"
@@ -564,54 +589,37 @@ func terminalBridgeEndpoint(relayURL, terminalID, refreshToken string) (string, 
 	return base.String(), nil
 }
 
-func fetchSessionTerminalWSURL(sessionID string) (string, error) {
-	if strings.TrimSpace(sessionID) == "" {
-		return "", fmt.Errorf("session id is required")
-	}
-
-	endpoint := fmt.Sprintf(
-		"http://127.0.0.1:4749/api/sessions/%s/terminal/token",
-		url.PathEscape(strings.TrimSpace(sessionID)),
-	)
-	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
-	if err != nil {
-		return "", fmt.Errorf("build terminal token request: %w", err)
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", &terminalAttachError{err: fmt.Errorf("request terminal token: %w", err)}
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", &terminalAttachError{err: fmt.Errorf("read terminal token response: %w", err)}
-	}
-
-	var payload struct {
-		TtydWSURL string `json:"ttydWsUrl"`
-		Error     string `json:"error"`
-	}
+func resolveTerminalTokenPayload(body []byte, statusCode int) (string, backendTerminalProtocol, error) {
+	var payload terminalTokenPayload
 	if err := json.Unmarshal(body, &payload); err != nil {
-		return "", &terminalAttachError{err: fmt.Errorf("decode terminal token response: %w", err)}
+		return "", "", &terminalAttachError{err: fmt.Errorf("decode terminal token response: %w", err)}
 	}
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+	if statusCode < 200 || statusCode >= 300 {
 		message := strings.TrimSpace(payload.Error)
 		if message == "" {
-			message = fmt.Sprintf("terminal token request failed with status %d", resp.StatusCode)
+			message = fmt.Sprintf("terminal token request failed with status %d", statusCode)
 		}
-		return "", &terminalAttachError{
-			status: resp.StatusCode,
+		return "", "", &terminalAttachError{
+			status: statusCode,
 			err:    errors.New(message),
 		}
 	}
 
+	rawURL := strings.TrimSpace(payload.WSURL)
+	protocol := backendTerminalProtocolNative
+	if rawURL == "" {
+		rawURL = strings.TrimSpace(payload.TtydWSURL)
+		protocol = backendTerminalProtocolTTYD
+	}
+	if rawURL == "" {
+		return "", "", &terminalAttachError{err: errors.New("terminal token response missing websocket url")}
+	}
+
 	base, _ := url.Parse("http://127.0.0.1:4749")
-	resolved, err := base.Parse(strings.TrimSpace(payload.TtydWSURL))
+	resolved, err := base.Parse(rawURL)
 	if err != nil {
-		return "", &terminalAttachError{err: fmt.Errorf("parse ttyd websocket url: %w", err)}
+		return "", "", &terminalAttachError{err: fmt.Errorf("parse terminal websocket url: %w", err)}
 	}
 
 	switch resolved.Scheme {
@@ -621,10 +629,38 @@ func fetchSessionTerminalWSURL(sessionID string) (string, error) {
 		resolved.Scheme = "wss"
 	case "ws", "wss":
 	default:
-		return "", &terminalAttachError{err: fmt.Errorf("unsupported ttyd websocket scheme %q", resolved.Scheme)}
+		return "", "", &terminalAttachError{err: fmt.Errorf("unsupported terminal websocket scheme %q", resolved.Scheme)}
 	}
 
-	return resolved.String(), nil
+	return resolved.String(), protocol, nil
+}
+
+func fetchSessionTerminalWSURL(sessionID string) (string, backendTerminalProtocol, error) {
+	if strings.TrimSpace(sessionID) == "" {
+		return "", "", fmt.Errorf("session id is required")
+	}
+
+	endpoint := fmt.Sprintf(
+		"http://127.0.0.1:4749/api/sessions/%s/terminal/token",
+		url.PathEscape(strings.TrimSpace(sessionID)),
+	)
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", "", fmt.Errorf("build terminal token request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", "", &terminalAttachError{err: fmt.Errorf("request terminal token: %w", err)}
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", &terminalAttachError{err: fmt.Errorf("read terminal token response: %w", err)}
+	}
+
+	return resolveTerminalTokenPayload(body, resp.StatusCode)
 }
 
 func shouldRetryTerminalAttach(err error) bool {
@@ -651,20 +687,20 @@ func shouldRetryTerminalAttach(err error) bool {
 	return false
 }
 
-func connectBackendTerminal(ctx context.Context, sessionID string) (*websocket.Conn, error) {
+func connectBackendTerminal(ctx context.Context, sessionID string) (*websocket.Conn, backendTerminalProtocol, error) {
 	var lastErr error
 	backoff := 250 * time.Millisecond
 
 	for attempt := 0; attempt < terminalAttachMaxAttempts; attempt++ {
 		if ctx.Err() != nil {
-			return nil, ctx.Err()
+			return nil, "", ctx.Err()
 		}
 
-		backendEndpoint, err := fetchSessionTerminalWSURL(sessionID)
+		backendEndpoint, protocol, err := fetchSessionTerminalWSURL(sessionID)
 		if err == nil {
 			conn, _, dialErr := websocket.DefaultDialer.DialContext(ctx, backendEndpoint, nil)
 			if dialErr == nil {
-				return conn, nil
+				return conn, protocol, nil
 			}
 			err = &terminalAttachError{err: fmt.Errorf("connect backend terminal socket: %w", dialErr)}
 		}
@@ -683,7 +719,7 @@ func connectBackendTerminal(ctx context.Context, sessionID string) (*websocket.C
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			return nil, ctx.Err()
+			return nil, "", ctx.Err()
 		case <-timer.C:
 		}
 		if backoff < 2*time.Second {
@@ -694,33 +730,32 @@ func connectBackendTerminal(ctx context.Context, sessionID string) (*websocket.C
 	if lastErr == nil {
 		lastErr = errors.New("backend terminal connection failed")
 	}
-	return nil, lastErr
+	return nil, "", lastErr
 }
 
-func proxyTerminalSession(
-	ctx context.Context,
-	relayURL string,
-	refreshToken string,
-	terminalID string,
-	sessionID string,
-) error {
-	backendConn, err := connectBackendTerminal(ctx, sessionID)
+func writeNativeTerminalMessage(conn *websocket.Conn, payload nativeTerminalClientMessage) error {
+	encoded, err := json.Marshal(payload)
 	if err != nil {
-		return err
+		return fmt.Errorf("encode native terminal message: %w", err)
 	}
-	defer backendConn.Close()
-
-	relayEndpoint, err := terminalBridgeEndpoint(relayURL, terminalID, refreshToken)
-	if err != nil {
-		return err
+	if err := conn.WriteMessage(websocket.TextMessage, encoded); err != nil {
+		return fmt.Errorf("write native terminal message: %w", err)
 	}
+	return nil
+}
 
-	relayConn, _, err := websocket.DefaultDialer.DialContext(ctx, relayEndpoint, nil)
-	if err != nil {
-		return fmt.Errorf("connect relay terminal socket: %w", err)
+func parseRelayResizeMessage(payload []byte) (int, int, error) {
+	var resize relayResizePayload
+	if err := json.Unmarshal(payload, &resize); err != nil {
+		return 0, 0, fmt.Errorf("decode relay resize message: %w", err)
 	}
-	defer relayConn.Close()
+	if resize.Columns <= 0 || resize.Rows <= 0 {
+		return 0, 0, fmt.Errorf("relay resize message missing terminal dimensions")
+	}
+	return resize.Columns, resize.Rows, nil
+}
 
+func proxyTTYDTerminalSession(ctx context.Context, backendConn *websocket.Conn, relayConn *websocket.Conn) error {
 	errCh := make(chan error, 2)
 
 	forward := func(srcName string, src *websocket.Conn, dstName string, dst *websocket.Conn) {
@@ -758,6 +793,172 @@ func proxyTerminalSession(
 		}
 		return err
 	}
+}
+
+func proxyNativeTerminalSession(ctx context.Context, backendConn *websocket.Conn, relayConn *websocket.Conn) error {
+	errCh := make(chan error, 2)
+
+	go func() {
+		helloSent := false
+		cols := 120
+		rows := 32
+		for {
+			msgType, data, err := relayConn.ReadMessage()
+			if err != nil {
+				errCh <- fmt.Errorf("relay terminal read: %w", err)
+				return
+			}
+			switch msgType {
+			case websocket.BinaryMessage:
+				if len(data) == 0 {
+					continue
+				}
+				command := data[0]
+				payload := data[1:]
+				switch command {
+				case '1':
+					nextCols, nextRows, err := parseRelayResizeMessage(payload)
+					if err != nil {
+						continue
+					}
+					cols = nextCols
+					rows = nextRows
+					messageType := "resize"
+					if !helloSent {
+						messageType = "hello"
+						helloSent = true
+					}
+					if err := writeNativeTerminalMessage(backendConn, nativeTerminalClientMessage{
+						Type: messageType,
+						Cols: cols,
+						Rows: rows,
+					}); err != nil {
+						errCh <- fmt.Errorf("backend terminal write: %w", err)
+						return
+					}
+				case '0':
+					if !helloSent {
+						if err := writeNativeTerminalMessage(backendConn, nativeTerminalClientMessage{
+							Type: "hello",
+							Cols: cols,
+							Rows: rows,
+						}); err != nil {
+							errCh <- fmt.Errorf("backend terminal write: %w", err)
+							return
+						}
+						helloSent = true
+					}
+					if len(payload) == 0 {
+						continue
+					}
+					if err := writeNativeTerminalMessage(backendConn, nativeTerminalClientMessage{
+						Type: "input",
+						Data: string(payload),
+					}); err != nil {
+						errCh <- fmt.Errorf("backend terminal write: %w", err)
+						return
+					}
+				case '2', '3':
+					continue
+				default:
+					continue
+				}
+			case websocket.TextMessage:
+				nextCols, nextRows, err := parseRelayResizeMessage(data)
+				if err != nil {
+					continue
+				}
+				cols = nextCols
+				rows = nextRows
+				messageType := "resize"
+				if !helloSent {
+					messageType = "hello"
+					helloSent = true
+				}
+				if err := writeNativeTerminalMessage(backendConn, nativeTerminalClientMessage{
+					Type: messageType,
+					Cols: cols,
+					Rows: rows,
+				}); err != nil {
+					errCh <- fmt.Errorf("backend terminal write: %w", err)
+					return
+				}
+			case websocket.CloseMessage:
+				_ = backendConn.WriteMessage(websocket.CloseMessage, data)
+				errCh <- io.EOF
+				return
+			}
+		}
+	}()
+
+	go func() {
+		for {
+			msgType, data, err := backendConn.ReadMessage()
+			if err != nil {
+				errCh <- fmt.Errorf("backend terminal read: %w", err)
+				return
+			}
+			switch msgType {
+			case websocket.TextMessage:
+				if err := relayConn.WriteMessage(websocket.TextMessage, data); err != nil {
+					errCh <- fmt.Errorf("relay terminal write: %w", err)
+					return
+				}
+			case websocket.BinaryMessage:
+				frame := make([]byte, 1+len(data))
+				frame[0] = '0'
+				copy(frame[1:], data)
+				if err := relayConn.WriteMessage(websocket.BinaryMessage, frame); err != nil {
+					errCh <- fmt.Errorf("relay terminal write: %w", err)
+					return
+				}
+			case websocket.CloseMessage:
+				_ = relayConn.WriteMessage(websocket.CloseMessage, data)
+				errCh <- io.EOF
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil
+	case err := <-errCh:
+		if err == io.EOF {
+			return nil
+		}
+		return err
+	}
+}
+
+func proxyTerminalSession(
+	ctx context.Context,
+	relayURL string,
+	refreshToken string,
+	terminalID string,
+	sessionID string,
+) error {
+	backendConn, protocol, err := connectBackendTerminal(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	defer backendConn.Close()
+
+	relayEndpoint, err := terminalBridgeEndpoint(relayURL, terminalID, refreshToken)
+	if err != nil {
+		return err
+	}
+
+	relayConn, _, err := websocket.DefaultDialer.DialContext(ctx, relayEndpoint, nil)
+	if err != nil {
+		return fmt.Errorf("connect relay terminal socket: %w", err)
+	}
+	defer relayConn.Close()
+
+	if protocol == backendTerminalProtocolTTYD {
+		return proxyTTYDTerminalSession(ctx, backendConn, relayConn)
+	}
+	return proxyNativeTerminalSession(ctx, backendConn, relayConn)
 }
 
 type apiResponse struct {

--- a/bridge-cmd/relay/client_test.go
+++ b/bridge-cmd/relay/client_test.go
@@ -46,3 +46,36 @@ func TestShouldRetryTerminalAttach(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveTerminalTokenPayloadPrefersNativeWSURL(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`{"wsUrl":"/api/sessions/session-123/terminal/ws?token=abc"}`)
+	wsURL, protocol, err := resolveTerminalTokenPayload(payload, http.StatusOK)
+	if err != nil {
+		t.Fatalf("resolveTerminalTokenPayload returned error: %v", err)
+	}
+	if protocol != backendTerminalProtocolNative {
+		t.Fatalf("protocol = %q, want %q", protocol, backendTerminalProtocolNative)
+	}
+	want := "ws://127.0.0.1:4749/api/sessions/session-123/terminal/ws?token=abc"
+	if wsURL != want {
+		t.Fatalf("wsURL = %q, want %q", wsURL, want)
+	}
+}
+
+func TestResolveTerminalTokenPayloadAcceptsLegacyTTYDURL(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`{"ttydWsUrl":"ws://127.0.0.1:7681/ws"}`)
+	wsURL, protocol, err := resolveTerminalTokenPayload(payload, http.StatusOK)
+	if err != nil {
+		t.Fatalf("resolveTerminalTokenPayload returned error: %v", err)
+	}
+	if protocol != backendTerminalProtocolTTYD {
+		t.Fatalf("protocol = %q, want %q", protocol, backendTerminalProtocolTTYD)
+	}
+	if wsURL != "ws://127.0.0.1:7681/ws" {
+		t.Fatalf("wsURL = %q, want %q", wsURL, "ws://127.0.0.1:7681/ws")
+	}
+}

--- a/crates/conductor-relay/src/relay.rs
+++ b/crates/conductor-relay/src/relay.rs
@@ -141,7 +141,7 @@ const TTYD_CMD_RESIZE: u8 = b'1';
 const TTYD_CMD_PAUSE: u8 = b'2';
 const TTYD_CMD_RESUME: u8 = b'3';
 #[cfg(not(test))]
-const TERMINAL_BROWSER_REATTACH_GRACE: Duration = Duration::from_secs(15);
+const TERMINAL_BROWSER_REATTACH_GRACE: Duration = Duration::from_secs(60);
 #[cfg(test)]
 const TERMINAL_BROWSER_REATTACH_GRACE: Duration = Duration::from_millis(25);
 
@@ -1306,8 +1306,9 @@ impl RelayState {
             match peer_kind {
                 TerminalPeerKind::Browser => {
                     session.browser = None;
-                    if session.bridge.is_some() {
-                        let disconnected_at = Instant::now();
+                    if session.bridge.is_some() || session.browser_disconnected_at.is_some() {
+                        let disconnected_at =
+                            session.browser_disconnected_at.unwrap_or_else(Instant::now);
                         session.browser_disconnected_at = Some(disconnected_at);
                         bridge_cleanup = Some(disconnected_at);
                         None
@@ -1317,11 +1318,16 @@ impl RelayState {
                     }
                 }
                 TerminalPeerKind::Bridge => {
-                    let session = inner
-                        .terminal_sessions
-                        .remove(terminal_id)
-                        .expect("session exists");
-                    session.browser.map(|record| record.tx)
+                    session.bridge = None;
+                    if session.browser.is_some() {
+                        let disconnected_at = Instant::now();
+                        session.browser_disconnected_at = Some(disconnected_at);
+                        bridge_cleanup = Some(disconnected_at);
+                        session.browser.as_ref().map(|record| record.tx.clone())
+                    } else {
+                        inner.terminal_sessions.remove(terminal_id);
+                        None
+                    }
                 }
             }
         };
@@ -3243,6 +3249,99 @@ mod tests {
             control_bridge_rx.try_recv().is_err(),
             "reuse should not start a new bridge proxy session"
         );
+    }
+
+    #[tokio::test]
+    async fn bridge_disconnect_keeps_terminal_restartable_during_browser_reconnect() {
+        let state = RelayState::default();
+        let (control_bridge_tx, mut control_bridge_rx) = mpsc::unbounded_channel::<Message>();
+        let (browser_tx, mut browser_rx) = mpsc::unbounded_channel::<Message>();
+        let (terminal_bridge_tx, _terminal_bridge_rx) = mpsc::unbounded_channel::<Message>();
+
+        {
+            let mut inner = state.inner.lock().await;
+            inner.devices.insert(
+                "device-123".to_string(),
+                DeviceRecord {
+                    device_id: "device-123".to_string(),
+                    owner_user_id: "user@example.com".to_string(),
+                    name: "Mac".to_string(),
+                    hostname: "macbook-pro".to_string(),
+                    os: "darwin".to_string(),
+                    arch: "arm64".to_string(),
+                    refresh_token: "refresh-token".to_string(),
+                },
+            );
+            inner.channels.insert(
+                "device-123".to_string(),
+                BridgeChannel {
+                    bridge: Some(ConnectionRecord {
+                        id: 1,
+                        user_id: "user@example.com".to_string(),
+                        tx: control_bridge_tx,
+                    }),
+                    browsers: HashMap::new(),
+                    last_status: None,
+                },
+            );
+            inner.terminal_sessions.insert(
+                "terminal-1".to_string(),
+                TerminalSessionRecord {
+                    terminal_id: "terminal-1".to_string(),
+                    session_id: "session-abc".to_string(),
+                    device_id: "device-123".to_string(),
+                    owner_user_id: "user@example.com".to_string(),
+                    browser: Some(TerminalConnectionRecord { tx: browser_tx }),
+                    bridge: Some(TerminalConnectionRecord {
+                        tx: terminal_bridge_tx,
+                    }),
+                    bridge_ready_waiters: vec![],
+                    browser_disconnected_at: None,
+                    browser_paused: false,
+                    pause_buffer: Vec::new(),
+                },
+            );
+        }
+
+        state
+            .unregister_terminal_connection("terminal-1", TerminalPeerKind::Bridge)
+            .await;
+
+        let close_message = browser_rx
+            .recv()
+            .await
+            .expect("browser should be told to reconnect");
+        assert!(matches!(close_message, Message::Close(_)));
+
+        state
+            .unregister_terminal_connection("terminal-1", TerminalPeerKind::Browser)
+            .await;
+
+        let terminal_id = state
+            .create_terminal_session("user@example.com", "device-123", "session-abc")
+            .await
+            .expect("terminal should be reusable after the bridge drops");
+        assert_eq!(terminal_id, "terminal-1");
+
+        let start_message = control_bridge_rx
+            .recv()
+            .await
+            .expect("bridge restart message");
+        let Message::Text(payload) = start_message else {
+            panic!("expected text restart payload");
+        };
+        let envelope: BrowserToBridgeMessage =
+            serde_json::from_str(payload.as_str()).expect("decode restart payload");
+        match envelope {
+            BrowserToBridgeMessage::TerminalProxyStart {
+                terminal_id,
+                session_id,
+            } => {
+                assert_eq!(terminal_id, "terminal-1");
+                assert_eq!(session_id, "session-abc");
+            }
+            other => panic!("unexpected bridge message: {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/packages/web/src/components/sessions/IframeTerminalPage.tsx
+++ b/packages/web/src/components/sessions/IframeTerminalPage.tsx
@@ -87,6 +87,7 @@ export function IframeTerminalPage({
   const connectInvokerRef = useRef<(() => void) | null>(null);
   const waitingForTerminalRef = useRef(false);
   const loadedOutputRef = useRef<string | null>(null);
+  const hasConnectedOnceRef = useRef(false);
   const bridgeScopedSession = useMemo(() => decodeBridgeSessionId(sessionId), [sessionId]);
   const usesRelayTerminal = Boolean(bridgeId?.trim() || bridgeScopedSession);
 
@@ -296,6 +297,11 @@ export function IframeTerminalPage({
       waitingForTerminalRef.current = false;
       loadedOutputRef.current = null;
       decoderRef.current = new TextDecoder();
+      if (hasConnectedOnceRef.current) {
+        terminalRef.current?.reset();
+      } else {
+        hasConnectedOnceRef.current = true;
+      }
       const geometry = fitTerminal();
       if (relayConnection) {
         ws.send(encodeResizeFrame(geometry?.cols ?? 120, geometry?.rows ?? 32));


### PR DESCRIPTION
## User-Facing Release Notes
- Paired-device iframe terminals now reconnect more reliably when the bridge drops and comes back.
- Mobile reconnects keep the embedded terminal stable instead of duplicating old output after reattach.

## Type of Change
- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Summary
- translate relay ttyd-style frames into the native PTY websocket protocol inside bridge-cmd
- accept both wsUrl and legacy ttydWsUrl terminal token payloads for backward compatibility
- keep relay terminal sessions restartable for 60 seconds when the paired bridge drops so browser reconnect can reuse the same terminal id
- reset the iframe xterm instance on reconnect so backend snapshot replay restores state without duplicate output

## Testing
- go test ./...
- cargo test -p conductor-relay -- --nocapture
- bun run --cwd packages/web typecheck
- bun run --cwd packages/web test
