### PR TITLE
fix: keep device claims resumable for browser pairing

### DIFF
--- a/crates/conductor-relay/src/relay.rs
+++ b/crates/conductor-relay/src/relay.rs
@@ -2156,7 +2156,9 @@ impl RelayState {
         };
 
         if let Some(response) = claim.paired_response.clone() {
-            inner.device_claims.remove(&claim_key);
+            if let Some(stored_claim) = inner.device_claims.get_mut(&claim_key) {
+                stored_claim.poll_token.clear();
+            }
             return Ok(DeviceClaimPollResponse {
                 status: "paired".to_string(),
                 expires_in: response.expires_in,
@@ -2862,6 +2864,18 @@ mod tests {
         assert_eq!(paired.device_id.as_deref(), Some("device-123"));
         assert_eq!(paired.device_name.as_deref(), Some("My Laptop"));
         assert!(paired.refresh_token.is_some());
+
+        let already_paired = state
+            .complete_device_claim(
+                "user@example.com",
+                DeviceClaimCompleteRequest {
+                    claim_token: created.claim_token.clone(),
+                },
+            )
+            .await
+            .expect("claim should stay resumable for the browser after polling");
+        assert!(already_paired.already_paired);
+        assert_eq!(already_paired.device_id, "device-123");
 
         let missing = state.poll_device_claim(&created.poll_token).await;
         assert!(matches!(missing, Err((StatusCode::NOT_FOUND, _))));


### PR DESCRIPTION
## User-Facing Release Notes
- Device-first laptop pairing no longer shows a fake "Claim token is invalid or expired" error after the machine has already paired.
- The browser can reopen the pairing page and still finish cleanly while the local command completes its handshake.

## Type of Change
- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Summary
- keep completed device claims available for browser resume instead of deleting them on the first successful poll
- invalidate the poll token after the local command consumes credentials so repeated poll requests still fail safely
- add a regression check proving the browser can still resolve the same claim token after polling succeeds

## Testing
- cargo fmt -p conductor-relay
- cargo test -p conductor-relay -- --nocapture


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device claim handling to allow claims to remain usable for completion operations after polling, enhancing reliability of the device pairing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->