### PR TITLE
fix: restore app surface scrolling

### DIFF
--- a/packages/web/src/components/sessions/SessionSkills.tsx
+++ b/packages/web/src/components/sessions/SessionSkills.tsx
@@ -39,7 +39,7 @@ import type {
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
 import { Card, CardContent, CardHeader } from "@/components/ui/Card";
-import { MOBILE_MOMENTUM_SCROLL_CLASS_NAME } from "./sessionMobileScroll";
+import { APP_SURFACE_SCROLL_CLASS_NAME } from "./sessionMobileScroll";
 
 type SessionSkillsProps = {
   session: DashboardSession;
@@ -355,7 +355,7 @@ export function SessionSkills({ session, sessionId, active }: SessionSkillsProps
 
   return (
     <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
-      <div className={`min-h-0 min-w-0 flex-1 overflow-y-auto pb-4 lg:overflow-hidden lg:pb-0 ${MOBILE_MOMENTUM_SCROLL_CLASS_NAME}`}>
+      <div className={`min-h-0 min-w-0 flex-1 pb-4 lg:pb-0 ${APP_SURFACE_SCROLL_CLASS_NAME}`}>
         <div className="flex min-h-full min-w-0 flex-col gap-3">
           <Card className="min-w-0">
             <CardHeader className="flex flex-col items-stretch gap-3">

--- a/packages/web/src/components/sessions/sessionMobileScroll.test.ts
+++ b/packages/web/src/components/sessions/sessionMobileScroll.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  APP_SURFACE_SCROLL_CLASS_NAME,
   MOBILE_MOMENTUM_SCROLL_CLASS_NAME,
   SESSION_PREVIEW_SCROLL_SHELL_CLASS_NAME,
   SESSION_SCROLL_AREA_VIEWPORT_CLASS_NAME,
@@ -26,6 +27,12 @@ test("mobile momentum scroll helper opts into touch-friendly vertical scrolling"
   assert.match(MOBILE_MOMENTUM_SCROLL_CLASS_NAME, /overscroll-contain/);
   assert.match(MOBILE_MOMENTUM_SCROLL_CLASS_NAME, /touch-pan-y/);
   assert.match(MOBILE_MOMENTUM_SCROLL_CLASS_NAME, /-webkit-overflow-scrolling:touch/);
+});
+
+test("app surface scroll helper keeps scrolling enabled across desktop and mobile", () => {
+  assert.match(APP_SURFACE_SCROLL_CLASS_NAME, /overflow-y-auto/);
+  assert.match(APP_SURFACE_SCROLL_CLASS_NAME, /overscroll-contain/);
+  assert.doesNotMatch(APP_SURFACE_SCROLL_CLASS_NAME, /lg:overflow-hidden/);
 });
 
 test("preview shell stays passive so the screenshot surface keeps mobile scroll ownership", () => {

--- a/packages/web/src/components/sessions/sessionMobileScroll.ts
+++ b/packages/web/src/components/sessions/sessionMobileScroll.ts
@@ -1,4 +1,5 @@
 export const MOBILE_MOMENTUM_SCROLL_CLASS_NAME = "overscroll-contain touch-pan-y [-webkit-overflow-scrolling:touch]";
+export const APP_SURFACE_SCROLL_CLASS_NAME = `overflow-y-auto ${MOBILE_MOMENTUM_SCROLL_CLASS_NAME}`;
 export const SESSION_PREVIEW_SCROLL_SHELL_CLASS_NAME = "min-h-0 flex-1 overflow-hidden bg-[#0f1012] p-3";
 export const SESSION_SCROLL_AREA_VIEWPORT_CLASS_NAME = MOBILE_MOMENTUM_SCROLL_CLASS_NAME;
 

--- a/packages/web/src/features/dashboard/components/WorkspaceOverview.tsx
+++ b/packages/web/src/features/dashboard/components/WorkspaceOverview.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from "@/components/ui/Button";
 import { Badge } from "@/components/ui/Badge";
 import { Card, CardContent, CardHeader } from "@/components/ui/Card";
+import { APP_SURFACE_SCROLL_CLASS_NAME } from "@/components/sessions/sessionMobileScroll";
 import { getAttentionLevel, type DashboardSession } from "@/lib/types";
 import type { ConfigProject } from "@/hooks/useConfig";
 import { SessionCard } from "@/components/SessionCard";
@@ -90,7 +91,7 @@ export function WorkspaceOverview({
 
   if (showWelcomeState) {
     return (
-      <div className="flex h-full min-h-0 w-full flex-col overflow-y-auto overscroll-contain bg-[linear-gradient(180deg,rgba(255,255,255,0.03),rgba(255,255,255,0))] lg:overflow-hidden">
+      <div className={`flex h-full min-h-0 w-full flex-col bg-[linear-gradient(180deg,rgba(255,255,255,0.03),rgba(255,255,255,0))] ${APP_SURFACE_SCROLL_CLASS_NAME}`}>
         <div className="mx-auto flex h-full min-h-0 w-full max-w-[1200px] flex-1 flex-col px-3 py-3 sm:px-4 sm:py-4">
           <div className="mb-4 flex justify-end">
             <Button variant="outline" size="md" onClick={onCreateWorkspace}>
@@ -132,7 +133,7 @@ export function WorkspaceOverview({
   }
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-col overflow-y-auto overscroll-contain bg-[linear-gradient(180deg,rgba(255,255,255,0.03),rgba(255,255,255,0))] lg:overflow-hidden">
+    <div className={`flex h-full min-h-0 w-full flex-col bg-[linear-gradient(180deg,rgba(255,255,255,0.03),rgba(255,255,255,0))] ${APP_SURFACE_SCROLL_CLASS_NAME}`}>
       <div className="flex h-full min-h-0 w-full flex-1 flex-col gap-4 px-3 py-3 sm:px-4">
         <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
           <div className="max-w-3xl">


### PR DESCRIPTION
## User-Facing Release Notes
- Dashboard and skills surfaces keep scrolling enabled on desktop and mobile instead of freezing behind hidden overflow shells.

## Type of Change
- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Summary
- add a shared app surface scroll helper that preserves overflow-y scrolling across breakpoints
- remove desktop-only overflow clipping from WorkspaceOverview and SessionSkills root scroll containers
- lock the new scroll contract with regression tests

## Testing
- bun test src/components/sessions/sessionMobileScroll.test.ts
- bun run typecheck
- bun test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated scroll styling implementation across application surfaces for improved code consistency and maintainability.

* **Tests**
  * Expanded test coverage for scroll behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->