### PR TITLE
fix: restore ttyd-era iframe sizing behavior

### DIFF
--- a/packages/web/src/components/sessions/IframeTerminalPage.tsx
+++ b/packages/web/src/components/sessions/IframeTerminalPage.tsx
@@ -43,6 +43,8 @@ const CMD_OUTPUT = "0".charCodeAt(0);
 const CMD_SET_WINDOW_TITLE = "1".charCodeAt(0);
 const CMD_SET_PREFERENCES = "2".charCodeAt(0);
 const CMD_RESIZE = "1".charCodeAt(0);
+const TERMINAL_RESIZE_MESSAGE_TYPE = "conductor-terminal-resize";
+const TTYD_READY_MESSAGE_TYPE = "conductor-ttyd-ready";
 
 const TERMINAL_THEME = {
   background: "#060404",
@@ -69,7 +71,7 @@ const TERMINAL_THEME = {
 } as const;
 
 const IFRAME_TERMINAL_PAGE_CLASSNAME =
-  "flex h-[100dvh] min-h-[100dvh] w-full min-w-0 flex-col overflow-hidden bg-[#060404] text-[#efe8e1]";
+  "flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden bg-[#060404] text-[#efe8e1]";
 const IFRAME_TERMINAL_HOST_CLASSNAME =
   "h-full w-full overflow-hidden overscroll-contain px-2 py-2 text-left touch-pan-y pb-[env(safe-area-inset-bottom)] [&_.xterm]:h-full [&_.xterm]:w-full [&_.xterm]:px-1 [&_.xterm-screen]:h-full [&_.xterm-screen]:w-full [&_.xterm-viewport]:overflow-y-auto [&_.xterm-viewport]:overscroll-contain [&_.xterm-viewport]:[-webkit-overflow-scrolling:touch] [&_.xterm-scrollable-element]:overscroll-contain [&_.xterm-scrollable-element]:[-webkit-overflow-scrolling:touch]";
 
@@ -182,6 +184,17 @@ export function IframeTerminalPage({
     fitAddon.fit();
     return { cols: terminal.cols, rows: terminal.rows };
   }, [applyKeyboardAwareTerminalHeight, applyTerminalViewport]);
+
+  const postParentReady = useCallback(() => {
+    if (typeof window === "undefined" || window.parent === window) {
+      return;
+    }
+    try {
+      window.parent.postMessage({ type: TTYD_READY_MESSAGE_TYPE }, window.location.origin);
+    } catch {
+      // Ignore parent message failures.
+    }
+  }, []);
 
   const loadStoredOutput = useCallback(async (outputUrl?: string | null): Promise<boolean> => {
     if (!outputUrl) {
@@ -522,14 +535,27 @@ export function IframeTerminalPage({
         applyGeometry();
       }
     };
+    const handleParentMessage = (event: MessageEvent) => {
+      if (event.source !== window.parent || event.origin !== window.location.origin) {
+        return;
+      }
+      if ((event.data as { type?: string } | null)?.type !== TERMINAL_RESIZE_MESSAGE_TYPE) {
+        return;
+      }
+      window.requestAnimationFrame(() => {
+        applyGeometry();
+      });
+    };
 
     window.addEventListener("resize", applyGeometry);
     visualViewport?.addEventListener("resize", applyGeometry);
     visualViewport?.addEventListener("scroll", applyGeometry);
     document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("message", handleParentMessage);
 
     window.requestAnimationFrame(() => {
       applyGeometry();
+      postParentReady();
       connectInvokerRef.current?.();
     });
 
@@ -541,6 +567,7 @@ export function IframeTerminalPage({
       visualViewport?.removeEventListener("resize", applyGeometry);
       visualViewport?.removeEventListener("scroll", applyGeometry);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("message", handleParentMessage);
       cleanupTouchRef.current?.();
       cleanupTouchRef.current = null;
       clearReconnectTimer();
@@ -555,6 +582,7 @@ export function IframeTerminalPage({
     closeSocket,
     connect,
     encodeInputFrame,
+    postParentReady,
     usesRelayTerminal,
   ]);
 

--- a/packages/web/src/components/sessions/SessionTerminal.tsx
+++ b/packages/web/src/components/sessions/SessionTerminal.tsx
@@ -20,8 +20,16 @@ import {
 } from "react";
 import { Button } from "@/components/ui/Button";
 import { uploadProjectAttachments } from "@/components/sessions/attachmentUploads";
+import {
+  calculateMobileTerminalViewportMetrics,
+} from "@/components/sessions/sessionTerminalUtils";
 import type { SessionTerminalProps } from "@/components/sessions/terminal/terminalTypes";
 import { withBridgeQuery } from "@/lib/bridgeQuery";
+
+const TTYD_READY_MESSAGE_TYPE = "conductor-ttyd-ready";
+const TERMINAL_RESIZE_MESSAGE_TYPE = "conductor-terminal-resize";
+const TERMINAL_RESIZE_DEBOUNCE_MS = 150;
+const TERMINAL_RESIZE_BURST_DELAYS_MS = [0, 50, 150, 400] as const;
 
 async function sendTerminalKeys(
   sessionId: string,
@@ -54,11 +62,16 @@ function SessionTerminalView({
   onPendingInsertConsumed,
 }: SessionTerminalProps) {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const terminalHostRef = useRef<HTMLDivElement | null>(null);
   const attachmentInputRef = useRef<HTMLInputElement | null>(null);
   const lastAppliedInsertNonceRef = useRef(0);
   const pendingInsertNonceRef = useRef<number | null>(null);
+  const burstResizeTimersRef = useRef<number[]>([]);
+  const resizeSuppressUntilRef = useRef(0);
+  const lastPostedTerminalHostSizeRef = useRef<{ w: number; h: number } | null>(null);
 
   const [frameLoaded, setFrameLoaded] = useState(false);
+  const [, setKeyboardVisible] = useState(false);
   const [queuedInsertError, setQueuedInsertError] = useState<string | null>(null);
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
   const [attachmentUploading, setAttachmentUploading] = useState(false);
@@ -69,8 +82,87 @@ function SessionTerminalView({
     [bridgeId, sessionId],
   );
 
+  const clearBurstResizeTimers = useCallback(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    for (const timerId of burstResizeTimersRef.current) {
+      window.clearTimeout(timerId);
+    }
+    burstResizeTimersRef.current = [];
+  }, []);
+
+  const postTerminalResizeMessage = useCallback(() => {
+    const iframe = iframeRef.current;
+    const host = terminalHostRef.current;
+    if (!iframe?.contentWindow || !host) {
+      return;
+    }
+    const rect = host.getBoundingClientRect();
+    const width = Math.round(rect.width);
+    const height = Math.round(rect.height);
+    if (width < 10 || height < 10) {
+      return;
+    }
+    const previous = lastPostedTerminalHostSizeRef.current;
+    if (previous && previous.w === width && previous.h === height) {
+      return;
+    }
+    lastPostedTerminalHostSizeRef.current = { w: width, h: height };
+    try {
+      iframe.contentWindow.postMessage({ type: TERMINAL_RESIZE_MESSAGE_TYPE }, window.location.origin);
+    } catch {
+      // Ignore navigation races while the iframe reloads.
+    }
+  }, []);
+
+  const scheduleTerminalResizeBurst = useCallback(() => {
+    if (typeof window === "undefined" || !iframeRef.current?.contentWindow) {
+      return;
+    }
+    clearBurstResizeTimers();
+    for (const delay of TERMINAL_RESIZE_BURST_DELAYS_MS) {
+      burstResizeTimersRef.current.push(
+        window.setTimeout(() => {
+          postTerminalResizeMessage();
+        }, delay),
+      );
+    }
+  }, [clearBurstResizeTimers, postTerminalResizeMessage]);
+
+  const applyKeyboardAwareTerminalHeight = useCallback(() => {
+    const host = terminalHostRef.current;
+    if (typeof window === "undefined" || !host) {
+      return;
+    }
+
+    const visualViewport = window.visualViewport;
+    if (!visualViewport) {
+      host.style.height = "100%";
+      setKeyboardVisible(false);
+      return;
+    }
+
+    const { usableHeight, keyboardVisible: nextKeyboardVisible } = calculateMobileTerminalViewportMetrics(
+      window.innerHeight,
+      visualViewport.height,
+      visualViewport.offsetTop,
+      host.getBoundingClientRect().top,
+    );
+
+    if (!nextKeyboardVisible || usableHeight <= 0) {
+      host.style.height = "100%";
+      setKeyboardVisible(false);
+      return;
+    }
+
+    host.style.height = `${Math.max(0, Math.round(usableHeight))}px`;
+    setKeyboardVisible(true);
+  }, []);
+
   useEffect(() => {
     setFrameLoaded(false);
+    lastPostedTerminalHostSizeRef.current = null;
   }, [iframeSrc, reloadNonce]);
 
   useEffect(() => {
@@ -178,6 +270,145 @@ function SessionTerminalView({
     }
   }, [bridgeId, sessionId]);
 
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleMessage = (event: MessageEvent) => {
+      if (event.source !== iframeRef.current?.contentWindow || event.origin !== window.location.origin) {
+        return;
+      }
+      if ((event.data as { type?: string } | null)?.type !== TTYD_READY_MESSAGE_TYPE) {
+        return;
+      }
+      setFrameLoaded(true);
+      lastPostedTerminalHostSizeRef.current = null;
+      scheduleTerminalResizeBurst();
+      postTerminalResizeMessage();
+    };
+
+    window.addEventListener("message", handleMessage);
+    return () => {
+      window.removeEventListener("message", handleMessage);
+    };
+  }, [postTerminalResizeMessage, scheduleTerminalResizeBurst]);
+
+  useEffect(() => {
+    const host = terminalHostRef.current;
+    if (!host || typeof window === "undefined") {
+      return;
+    }
+
+    let debounceTimer: number | null = null;
+    const applyGeometry = () => {
+      if (!panelVisible) {
+        return;
+      }
+      if (window.Date.now() < resizeSuppressUntilRef.current) {
+        return;
+      }
+      const rect = host.getBoundingClientRect();
+      if (rect.width < 10 || rect.height < 10) {
+        return;
+      }
+      if (debounceTimer !== null) {
+        window.clearTimeout(debounceTimer);
+      }
+      debounceTimer = window.setTimeout(() => {
+        debounceTimer = null;
+        if (window.Date.now() < resizeSuppressUntilRef.current) {
+          return;
+        }
+        const currentRect = host.getBoundingClientRect();
+        if (currentRect.width < 10 || currentRect.height < 10) {
+          return;
+        }
+        applyKeyboardAwareTerminalHeight();
+        postTerminalResizeMessage();
+      }, TERMINAL_RESIZE_DEBOUNCE_MS);
+    };
+
+    applyGeometry();
+
+    const resizeObserver = typeof ResizeObserver === "undefined"
+      ? null
+      : new ResizeObserver(() => {
+        applyGeometry();
+      });
+    const visualViewport = window.visualViewport;
+
+    resizeObserver?.observe(host);
+    window.addEventListener("resize", applyGeometry);
+    visualViewport?.addEventListener("resize", applyGeometry);
+    visualViewport?.addEventListener("scroll", applyGeometry);
+
+    return () => {
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", applyGeometry);
+      visualViewport?.removeEventListener("resize", applyGeometry);
+      visualViewport?.removeEventListener("scroll", applyGeometry);
+      if (debounceTimer !== null) {
+        window.clearTimeout(debounceTimer);
+      }
+      host.style.removeProperty("height");
+    };
+  }, [applyKeyboardAwareTerminalHeight, panelVisible, postTerminalResizeMessage]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        resizeSuppressUntilRef.current = window.Date.now() + 250;
+        return;
+      }
+      resizeSuppressUntilRef.current = window.Date.now() + 100;
+      lastPostedTerminalHostSizeRef.current = null;
+      applyKeyboardAwareTerminalHeight();
+      scheduleTerminalResizeBurst();
+    };
+
+    const handleFocus = () => {
+      resizeSuppressUntilRef.current = window.Date.now() + 120;
+      lastPostedTerminalHostSizeRef.current = null;
+      applyKeyboardAwareTerminalHeight();
+      scheduleTerminalResizeBurst();
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("focus", handleFocus);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("focus", handleFocus);
+    };
+  }, [applyKeyboardAwareTerminalHeight, scheduleTerminalResizeBurst]);
+
+  useEffect(() => {
+    if (!panelVisible) {
+      return;
+    }
+    let outerRaf = 0;
+    let innerRaf = 0;
+    outerRaf = window.requestAnimationFrame(() => {
+      innerRaf = window.requestAnimationFrame(() => {
+        lastPostedTerminalHostSizeRef.current = null;
+        applyKeyboardAwareTerminalHeight();
+        scheduleTerminalResizeBurst();
+      });
+    });
+    return () => {
+      window.cancelAnimationFrame(outerRaf);
+      window.cancelAnimationFrame(innerRaf);
+    };
+  }, [applyKeyboardAwareTerminalHeight, panelVisible, reloadNonce, scheduleTerminalResizeBurst]);
+
+  useEffect(() => () => {
+    clearBurstResizeTimers();
+  }, [clearBurstResizeTimers]);
+
   return (
     <div
       className={immersiveMobileMode
@@ -251,7 +482,18 @@ function SessionTerminalView({
           ? "min-h-0 min-w-0 h-0 flex-1 overflow-hidden px-0 pb-[env(safe-area-inset-bottom)] pt-0 w-full"
           : "min-h-0 min-w-0 h-0 flex-1 overflow-hidden px-0.5 pb-0 pt-0.5 lg:px-1.5 lg:pb-1 lg:pt-3 w-full"}
       >
-        <div className="relative flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden rounded-[10px] bg-[#060404] pb-[env(safe-area-inset-bottom)]">
+        <div
+          ref={terminalHostRef}
+          className="relative flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden rounded-[10px] bg-[#060404] pb-[env(safe-area-inset-bottom)]"
+        >
+          {!frameLoaded ? (
+            <div className="absolute inset-0 z-10 flex items-center justify-center bg-[#060404]">
+              <div className="flex items-center gap-2 rounded-full border border-white/10 bg-[#141010]/92 px-3 py-2 text-[12px] text-[#c9c0b7] backdrop-blur-sm">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                <span>Loading terminal…</span>
+              </div>
+            </div>
+          ) : null}
           <iframe
             key={`${sessionId}:${reloadNonce}`}
             ref={iframeRef}
@@ -264,7 +506,10 @@ function SessionTerminalView({
               setFrameLoaded(false);
             }}
             onLoad={() => {
-              setFrameLoaded(true);
+              setFrameLoaded(false);
+              lastPostedTerminalHostSizeRef.current = null;
+              applyKeyboardAwareTerminalHeight();
+              scheduleTerminalResizeBurst();
             }}
           />
           {!panelVisible && !frameLoaded ? (

--- a/packages/web/src/components/sessions/SessionTerminal.tsx
+++ b/packages/web/src/components/sessions/SessionTerminal.tsx
@@ -3,7 +3,7 @@
 import {
   AlertCircle,
   Clipboard,
-  FileUp,
+  ExternalLink,
   Loader2,
   RefreshCw,
   SquareStop,
@@ -25,6 +25,7 @@ import {
 } from "@/components/sessions/sessionTerminalUtils";
 import type { SessionTerminalProps } from "@/components/sessions/terminal/terminalTypes";
 import { withBridgeQuery } from "@/lib/bridgeQuery";
+import { buildSessionHref } from "@/lib/dashboardHref";
 
 const TTYD_READY_MESSAGE_TYPE = "conductor-ttyd-ready";
 const TERMINAL_RESIZE_MESSAGE_TYPE = "conductor-terminal-resize";
@@ -79,6 +80,10 @@ function SessionTerminalView({
 
   const iframeSrc = useMemo(
     () => withBridgeQuery(`/embed/terminal/${encodeURIComponent(sessionId)}`, bridgeId),
+    [bridgeId, sessionId],
+  );
+  const terminalSessionHref = useMemo(
+    () => buildSessionHref(sessionId, { bridgeId, tab: "terminal" }),
     [bridgeId, sessionId],
   );
 
@@ -213,10 +218,6 @@ function SessionTerminalView({
   const handleRetry = useCallback(() => {
     setFrameLoaded(false);
     setReloadNonce((value) => value + 1);
-  }, []);
-
-  const handleAttachmentPick = useCallback(() => {
-    attachmentInputRef.current?.click();
   }, []);
 
   const handleAttachmentFiles = useCallback(async (event: ChangeEvent<HTMLInputElement>) => {
@@ -430,16 +431,13 @@ function SessionTerminalView({
           type="button"
           size="icon"
           variant="ghost"
-          className="h-9 w-9 rounded-full border border-white/10 bg-[#141010]/92 text-[#c9c0b7] backdrop-blur-sm hover:bg-[#201818] disabled:opacity-40 sm:h-7 sm:w-7"
-          onClick={handleAttachmentPick}
-          aria-label="Attach files"
-          disabled={attachmentUploading}
+          className="h-9 w-9 rounded-full border border-white/10 bg-[#141010]/92 text-[#c9c0b7] backdrop-blur-sm hover:bg-[#201818] sm:h-7 sm:w-7"
+          onClick={() => {
+            window.open(terminalSessionHref, "_blank", "noopener,noreferrer");
+          }}
+          aria-label="Open terminal in new tab"
         >
-          {attachmentUploading ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
-          ) : (
-            <FileUp className="h-3.5 w-3.5" />
-          )}
+          <ExternalLink className="h-3.5 w-3.5" />
         </Button>
         <Button
           type="button"


### PR DESCRIPTION
## Summary

Reworks the embedded terminal shell to match the old ttyd-era iframe behavior more closely, restoring parent-driven sizing, ready handshakes, and resize coordination between the dashboard shell and the embedded terminal page.

## User-Facing Release Notes

- Restored the old ttyd-style iframe sizing behavior so the embedded terminal is no longer squeezed.
- Improved terminal layout stability on desktop and mobile by coordinating iframe readiness and resize events again.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Plugin Addition / Modification
- [ ] Documentation Update
- [ ] Refactor / Chore

## Testing

- bun run --cwd packages/web typecheck
- bun run --cwd packages/web test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Open in new tab" control for the terminal.
  * Shows a loading overlay while the terminal initializes.

* **Improvements**
  * Better terminal responsiveness: coordinated resizing between parent and embedded terminal for smoother layout updates.
  * Improved mobile keyboard handling with dynamic viewport sizing and reduced resize flicker.
  * More reliable resize scheduling and suppression to prevent unnecessary layout updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->