### PR TITLE
fix: restore original ttyd iframe display and prod attach path

### DIFF
--- a/crates/conductor-server/src/routes/terminal.rs
+++ b/crates/conductor-server/src/routes/terminal.rs
@@ -1635,17 +1635,7 @@ async fn build_terminal_token_response(
     };
     let ws_url = interactive.then(|| ttyd_frontend_proxy_ws_path(&id, url_token));
     let ttyd_ws_url = ws_url.clone();
-    let ttyd_http_url = if interactive {
-        match shared_ttyd_frontend_base_url().await {
-            Ok(_) => Some(ttyd_frontend_proxy_path(&id, url_token)),
-            Err(err) => {
-                tracing::debug!(session_id = %id, error = %err, "ttyd frontend unavailable, falling back to embedded terminal page");
-                None
-            }
-        }
-    } else {
-        None
-    };
+    let ttyd_http_url = interactive.then(|| ttyd_frontend_proxy_path(&id, url_token));
     let payload = json!({
         "token": token,
         "required": token_required,

--- a/packages/web/src/app/api/sessions/[id]/terminal/token/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/terminal/token/route.ts
@@ -35,18 +35,16 @@ export async function GET(
   const tunnelUrl = typeof ensured.upstreamPayload?.tunnelUrl === "string"
     ? ensured.upstreamPayload.tunnelUrl
     : null;
-  const hasFrontendHtml = typeof ensured.upstreamPayload?.ttydHttpUrl === "string"
-    && ensured.upstreamPayload.ttydHttpUrl.trim().length > 0;
 
   return NextResponse.json({
     required: false,
     expiresInSeconds: null,
-    ttydHttpUrl: hasFrontendHtml
-      ? buildStableBridgeTtydProxyUrl(
-        ensured.routeSessionId,
-        ensured.bridgeId,
-      )
-      : null,
+    wsUrl: ensured.relayTtydWsUrl,
+    wsProtocol: "tty",
+    ttydHttpUrl: buildStableBridgeTtydProxyUrl(
+      ensured.routeSessionId,
+      ensured.bridgeId,
+    ),
     ttydWsUrl: ensured.relayTtydWsUrl,
     relayTtydWsUrl: ensured.relayTtydWsUrl,
     tunnelUrl,

--- a/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
@@ -1,3 +1,4 @@
+import { NextResponse } from "next/server";
 import { guardApiAccess } from "@/lib/auth";
 import { buildForwardedAccessHeaders } from "@/lib/guardedRustProxy";
 import { proxyToBridgeDevice } from "@/lib/bridgeApiProxy";
@@ -20,17 +21,16 @@ type RouteContext = {
 };
 
 
-/**
- * Inject the resize coordination shim into a proxied HTML response.
- * Falls back to the original response if the content is not HTML.
- */
-async function injectResizeShimIntoResponse(proxied: Response): Promise<Response> {
-  const html = await readTtydHtmlResponse(proxied);
-  if (html === null) {
-    return proxied;
+function buildEmbeddedTerminalFallbackResponse(
+  request: Request,
+  sessionId: string,
+  bridgeId?: string,
+): Response {
+  const url = new URL(`/embed/terminal/${encodeURIComponent(sessionId)}`, request.url);
+  if (bridgeId) {
+    url.searchParams.set("bridgeId", bridgeId);
   }
-
-  return buildPatchedTtydHtmlResponse(proxied, injectTtydResizeShim(html));
+  return NextResponse.redirect(url, { status: 307 });
 }
 
 export async function GET(
@@ -54,7 +54,16 @@ export async function GET(
       },
     );
 
-    return injectResizeShimIntoResponse(proxied);
+    if (!proxied.ok) {
+      return buildEmbeddedTerminalFallbackResponse(request, id);
+    }
+
+    const html = await readTtydHtmlResponse(proxied);
+    if (html === null) {
+      return buildEmbeddedTerminalFallbackResponse(request, id);
+    }
+
+    return buildPatchedTtydHtmlResponse(proxied, injectTtydResizeShim(html));
   }
 
   // Bridge session: proxy to bridge device, inject relay shim + resize shim.
@@ -81,9 +90,13 @@ export async function GET(
     );
   }
 
+  if (!proxied.ok) {
+    return buildEmbeddedTerminalFallbackResponse(request, id, target.bridgeId);
+  }
+
   const html = await readTtydHtmlResponse(proxied);
   if (html === null) {
-    return proxied;
+    return buildEmbeddedTerminalFallbackResponse(request, id, target.bridgeId);
   }
 
   const patchedHtml = injectTtydResizeShim(

--- a/packages/web/src/components/sessions/IframeTerminalPage.tsx
+++ b/packages/web/src/components/sessions/IframeTerminalPage.tsx
@@ -18,6 +18,7 @@ type ConnectionInfo = {
   reason?: string | null;
   wsUrl?: string | null;
   wsProtocol?: string | null;
+  ttydWsUrl?: string | null;
   outputUrl?: string | null;
 };
 
@@ -292,7 +293,8 @@ export function IframeTerminalPage({
       throw new Error((info as { error?: string } | null)?.error ?? `Failed to resolve terminal (${response.status})`);
     }
 
-    if (!info?.wsUrl) {
+    const tokenWsUrl = info?.wsUrl ?? info?.ttydWsUrl ?? null;
+    if (!tokenWsUrl) {
       const hasOutput = await loadStoredOutput(info?.outputUrl);
       if (hasOutput) {
         waitingForTerminalRef.current = false;
@@ -306,14 +308,15 @@ export function IframeTerminalPage({
       return;
     }
 
+    const resolvedInfo = info as ConnectionInfo;
     const relayConnection = usesRelayTerminal ? await fetchRelayTerminalUrl() : null;
-    const directWsProtocol = typeof info.wsProtocol === "string" && info.wsProtocol.trim().length > 0
-      ? info.wsProtocol.trim()
-      : null;
+    const directWsProtocol = typeof resolvedInfo.wsProtocol === "string" && resolvedInfo.wsProtocol.trim().length > 0
+      ? resolvedInfo.wsProtocol.trim()
+      : (typeof resolvedInfo.ttydWsUrl === "string" && resolvedInfo.ttydWsUrl.trim().length > 0 ? "tty" : null);
     const useTtydProtocol = Boolean(
       relayConnection || directWsProtocol?.toLowerCase() === "tty",
     );
-    const resolvedDirectWsUrl = resolveNativeTerminalWebSocketUrl(info.wsUrl, window.location.origin);
+    const resolvedDirectWsUrl = resolveNativeTerminalWebSocketUrl(tokenWsUrl, window.location.origin);
     const ws = relayConnection
       ? new WebSocket(relayConnection.wsUrl, relayConnection.wsProtocol)
       : directWsProtocol


### PR DESCRIPTION
## User-Facing Release Notes

- Restored the original ttyd iframe terminal display instead of the stripped-down basic fallback terminal.
- Fixed production bridge sessions that could sit on "Waiting for the live terminal to attach" even while the session was already working.
- Kept the session scrolling fixes that shipped with the earlier terminal work.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Summary

- reverted the narrowing commit that swapped the real ttyd-backed iframe stack for the simplified native-host display
- restored the full ttyd terminal backend/frontend path and token route that produced the earlier iframe UI
- kept the production bridge attach fix by returning bridge websocket metadata needed for iframe attachment
- kept the iframe terminal page able to consume `ttydWsUrl` when `wsUrl` is absent

## Testing

- `cargo fmt --all`
- `bun run --cwd packages/web typecheck`
- `bun test packages/web/src/components/sessions/terminal/terminalApi.test.ts`
- `cargo test -p conductor-server routes::terminal::tests -- --nocapture`
