### PR TITLE
fix: stop ttyd iframe route from falling back to embed terminal

### DIFF
--- a/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
@@ -1,4 +1,3 @@
-import { NextResponse } from "next/server";
 import { guardApiAccess } from "@/lib/auth";
 import { buildForwardedAccessHeaders } from "@/lib/guardedRustProxy";
 import { proxyToBridgeDevice } from "@/lib/bridgeApiProxy";
@@ -21,18 +20,6 @@ type RouteContext = {
 };
 
 
-function buildEmbeddedTerminalFallbackResponse(
-  request: Request,
-  sessionId: string,
-  bridgeId?: string,
-): Response {
-  const url = new URL(`/embed/terminal/${encodeURIComponent(sessionId)}`, request.url);
-  if (bridgeId) {
-    url.searchParams.set("bridgeId", bridgeId);
-  }
-  return NextResponse.redirect(url, { status: 307 });
-}
-
 export async function GET(
   request: Request,
   context: RouteContext,
@@ -54,13 +41,9 @@ export async function GET(
       },
     );
 
-    if (!proxied.ok) {
-      return buildEmbeddedTerminalFallbackResponse(request, id);
-    }
-
     const html = await readTtydHtmlResponse(proxied);
     if (html === null) {
-      return buildEmbeddedTerminalFallbackResponse(request, id);
+      return proxied;
     }
 
     return buildPatchedTtydHtmlResponse(proxied, injectTtydResizeShim(html));
@@ -90,13 +73,9 @@ export async function GET(
     );
   }
 
-  if (!proxied.ok) {
-    return buildEmbeddedTerminalFallbackResponse(request, id, target.bridgeId);
-  }
-
   const html = await readTtydHtmlResponse(proxied);
   if (html === null) {
-    return buildEmbeddedTerminalFallbackResponse(request, id, target.bridgeId);
+    return proxied;
   }
 
   const patchedHtml = injectTtydResizeShim(


### PR DESCRIPTION
## User-Facing Release Notes

- Restored the real ttyd iframe path instead of silently dropping back to the stripped-down embedded terminal shell.
- Preserved the separate bridge attach fix from the prior production hotfix.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Summary

- removed the `/api/sessions/:id/terminal/ttyd` redirect fallback to `/embed/terminal/:id`
- when proxied ttyd HTML cannot be patched, the route now returns the proxied ttyd response instead of swapping in the basic embedded terminal UI
- keeps the earlier bridge token metadata fix intact, so production launches still attach correctly

## Testing

- `bun run --cwd packages/web typecheck`
- `bun test packages/web/src/components/sessions/terminal/terminalApi.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined terminal session error handling to directly process responses without fallback redirection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->