### PR TITLE
fix: restore bundled ttyd iframe fallback

### DIFF
--- a/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
@@ -10,6 +10,10 @@ import {
   injectTtydResizeShim,
   resolveBridgeSessionTarget,
 } from "@/lib/bridgeTtyd";
+import {
+  buildBundledTtydHtmlResponse,
+  loadBundledTtydFrontendHtml,
+} from "@/lib/bundledTtydFrontend";
 import { readTtydHtmlResponse } from "@/lib/ttydHtmlResponse";
 
 export const dynamic = "force-dynamic";
@@ -43,7 +47,9 @@ export async function GET(
 
     const html = await readTtydHtmlResponse(proxied);
     if (html === null) {
-      return proxied;
+      return buildBundledTtydHtmlResponse(
+        injectTtydResizeShim(loadBundledTtydFrontendHtml()),
+      );
     }
 
     return buildPatchedTtydHtmlResponse(proxied, injectTtydResizeShim(html));
@@ -74,13 +80,15 @@ export async function GET(
   }
 
   const html = await readTtydHtmlResponse(proxied);
-  if (html === null) {
-    return proxied;
-  }
+  const ttydHtml = html ?? loadBundledTtydFrontendHtml();
 
   const patchedHtml = injectTtydResizeShim(
-    injectBridgeTtydRelayShim(html, relayTtydWsUrl),
+    injectBridgeTtydRelayShim(ttydHtml, relayTtydWsUrl),
   );
+
+  if (html === null) {
+    return buildBundledTtydHtmlResponse(patchedHtml);
+  }
 
   return buildPatchedTtydHtmlResponse(proxied, patchedHtml);
 }

--- a/packages/web/src/lib/bundledTtydFrontend.test.ts
+++ b/packages/web/src/lib/bundledTtydFrontend.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildBundledTtydHtmlResponse,
+  loadBundledTtydFrontendHtml,
+} from "./bundledTtydFrontend";
+
+test("loadBundledTtydFrontendHtml reads the vendored ttyd shell", () => {
+  const html = loadBundledTtydFrontendHtml();
+
+  assert.match(html, /<!DOCTYPE html>/);
+  assert.match(html, /ttyd - Terminal/);
+  assert.match(html, /\/token/);
+  assert.match(html, /\/ws/);
+});
+
+test("buildBundledTtydHtmlResponse serves html with no-store headers", async () => {
+  const response = buildBundledTtydHtmlResponse("<html><body>ok</body></html>");
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("content-type"), "text/html; charset=utf-8");
+  assert.equal(response.headers.get("cache-control"), "no-store, no-cache, must-revalidate, max-age=0");
+  assert.equal(await response.text(), "<html><body>ok</body></html>");
+});

--- a/packages/web/src/lib/bundledTtydFrontend.ts
+++ b/packages/web/src/lib/bundledTtydFrontend.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MODULE_DIRECTORY = dirname(fileURLToPath(import.meta.url));
+const BUNDLED_TTYD_FRONTEND_PATH = join(
+  MODULE_DIRECTORY,
+  "../../../../crates/conductor-server/src/routes/ttyd_frontend_v1.7.7.html",
+);
+
+const BUNDLED_TTYD_RESPONSE_HEADERS = {
+  "content-type": "text/html; charset=utf-8",
+  "cache-control": "no-store, no-cache, must-revalidate, max-age=0",
+  pragma: "no-cache",
+  expires: "0",
+} as const;
+
+let cachedBundledTtydFrontendHtml: string | null = null;
+
+export function loadBundledTtydFrontendHtml(): string {
+  if (cachedBundledTtydFrontendHtml !== null) {
+    return cachedBundledTtydFrontendHtml;
+  }
+
+  cachedBundledTtydFrontendHtml = readFileSync(BUNDLED_TTYD_FRONTEND_PATH, "utf8");
+  return cachedBundledTtydFrontendHtml;
+}
+
+export function buildBundledTtydHtmlResponse(html: string): Response {
+  return new Response(new TextEncoder().encode(html), {
+    status: 200,
+    headers: BUNDLED_TTYD_RESPONSE_HEADERS,
+  });
+}


### PR DESCRIPTION
## Summary
- restore the ttyd iframe frontend in the dashboard when the upstream ttyd route returns non-HTML
- reuse the bundled ttyd shell for both local and bridge terminal iframe routes
- add coverage for the bundled ttyd shell loader and response headers

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Internal maintenance

## User-Facing Release Notes
- The terminal iframe now falls back to the bundled ttyd frontend when an upstream session returns JSON or another non-HTML response, so the old embedded terminal loads again for both local and paired-device sessions.

## Validation
- bun run --cwd packages/web test bundledTtydFrontend.test.ts
- bun run --cwd packages/web typecheck
- bun run --cwd packages/web build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal sessions now include a bundled frontend as a fallback option for improved reliability.

* **Bug Fixes**
  * Improved terminal HTML rendering fallback handling for both bridge and non-bridge session types.

* **Tests**
  * Added tests validating bundled terminal frontend loading and response generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->