### PR TITLE
fix: restore known-good iframe terminal flow

### DIFF
--- a/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
@@ -1,3 +1,4 @@
+import { NextResponse } from "next/server";
 import { guardApiAccess } from "@/lib/auth";
 import { buildForwardedAccessHeaders } from "@/lib/guardedRustProxy";
 import { proxyToBridgeDevice } from "@/lib/bridgeApiProxy";
@@ -10,10 +11,6 @@ import {
   injectTtydResizeShim,
   resolveBridgeSessionTarget,
 } from "@/lib/bridgeTtyd";
-import {
-  buildBundledTtydHtmlResponse,
-  loadBundledTtydFrontendHtml,
-} from "@/lib/bundledTtydFrontend";
 import { readTtydHtmlResponse } from "@/lib/ttydHtmlResponse";
 
 export const dynamic = "force-dynamic";
@@ -23,6 +20,18 @@ type RouteContext = {
   params: Promise<{ id: string }>;
 };
 
+
+function buildEmbeddedTerminalFallbackResponse(
+  request: Request,
+  sessionId: string,
+  bridgeId?: string,
+): Response {
+  const url = new URL(`/embed/terminal/${encodeURIComponent(sessionId)}`, request.url);
+  if (bridgeId) {
+    url.searchParams.set("bridgeId", bridgeId);
+  }
+  return NextResponse.redirect(url, { status: 307 });
+}
 
 export async function GET(
   request: Request,
@@ -45,11 +54,13 @@ export async function GET(
       },
     );
 
+    if (!proxied.ok) {
+      return buildEmbeddedTerminalFallbackResponse(request, id);
+    }
+
     const html = await readTtydHtmlResponse(proxied);
     if (html === null) {
-      return buildBundledTtydHtmlResponse(
-        injectTtydResizeShim(loadBundledTtydFrontendHtml()),
-      );
+      return buildEmbeddedTerminalFallbackResponse(request, id);
     }
 
     return buildPatchedTtydHtmlResponse(proxied, injectTtydResizeShim(html));
@@ -79,16 +90,18 @@ export async function GET(
     );
   }
 
+  if (!proxied.ok) {
+    return buildEmbeddedTerminalFallbackResponse(request, id, target.bridgeId);
+  }
+
   const html = await readTtydHtmlResponse(proxied);
-  const ttydHtml = html ?? loadBundledTtydFrontendHtml();
+  if (html === null) {
+    return buildEmbeddedTerminalFallbackResponse(request, id, target.bridgeId);
+  }
 
   const patchedHtml = injectTtydResizeShim(
-    injectBridgeTtydRelayShim(ttydHtml, relayTtydWsUrl),
+    injectBridgeTtydRelayShim(html, relayTtydWsUrl),
   );
-
-  if (html === null) {
-    return buildBundledTtydHtmlResponse(patchedHtml);
-  }
 
   return buildPatchedTtydHtmlResponse(proxied, patchedHtml);
 }

--- a/packages/web/src/app/api/sessions/[id]/terminal/ttyd/token/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/terminal/ttyd/token/route.ts
@@ -1,0 +1,9 @@
+import { guardedSessionProxyParamRoute } from "@/lib/proxyRoutes";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export const GET = guardedSessionProxyParamRoute(
+  ({ id }) => `/api/sessions/${encodeURIComponent(id ?? "")}/terminal/ttyd/token`,
+  { role: "operator" },
+);


### PR DESCRIPTION
## Summary

Restore the known-good iframe terminal flow from the earlier working implementation. Legacy websocket-only terminal metadata no longer gets forced through a fake ttyd HTML path, and the ttyd route now falls back to the proper embedded iframe page when real ttyd HTML is unavailable.

## User-Facing Release Notes

- Restored the earlier working iframe terminal behavior for sessions that do not actually expose real ttyd HTML.
- Fixed the broken terminal flow that could send the browser into the wrong ttyd path instead of the proper embedded iframe terminal.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Testing

- `bun test packages/web/src/components/sessions/terminal/terminalApi.test.ts`
- `bun run --cwd packages/web typecheck`
