### PR TITLE
fix: restore true ttyd iframe web terminal

### DIFF
--- a/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
@@ -1,4 +1,3 @@
-import { NextResponse } from "next/server";
 import { guardApiAccess } from "@/lib/auth";
 import { buildForwardedAccessHeaders } from "@/lib/guardedRustProxy";
 import { proxyToBridgeDevice } from "@/lib/bridgeApiProxy";
@@ -11,6 +10,10 @@ import {
   injectTtydResizeShim,
   resolveBridgeSessionTarget,
 } from "@/lib/bridgeTtyd";
+import {
+  buildBundledTtydHtmlResponse,
+  loadBundledTtydFrontendHtml,
+} from "@/lib/bundledTtydFrontend";
 import { readTtydHtmlResponse } from "@/lib/ttydHtmlResponse";
 
 export const dynamic = "force-dynamic";
@@ -20,18 +23,6 @@ type RouteContext = {
   params: Promise<{ id: string }>;
 };
 
-
-function buildEmbeddedTerminalFallbackResponse(
-  request: Request,
-  sessionId: string,
-  bridgeId?: string,
-): Response {
-  const url = new URL(`/embed/terminal/${encodeURIComponent(sessionId)}`, request.url);
-  if (bridgeId) {
-    url.searchParams.set("bridgeId", bridgeId);
-  }
-  return NextResponse.redirect(url, { status: 307 });
-}
 
 export async function GET(
   request: Request,
@@ -54,13 +45,11 @@ export async function GET(
       },
     );
 
-    if (!proxied.ok) {
-      return buildEmbeddedTerminalFallbackResponse(request, id);
-    }
-
     const html = await readTtydHtmlResponse(proxied);
     if (html === null) {
-      return buildEmbeddedTerminalFallbackResponse(request, id);
+      return buildBundledTtydHtmlResponse(
+        injectTtydResizeShim(loadBundledTtydFrontendHtml()),
+      );
     }
 
     return buildPatchedTtydHtmlResponse(proxied, injectTtydResizeShim(html));
@@ -90,18 +79,16 @@ export async function GET(
     );
   }
 
-  if (!proxied.ok) {
-    return buildEmbeddedTerminalFallbackResponse(request, id, target.bridgeId);
-  }
-
   const html = await readTtydHtmlResponse(proxied);
-  if (html === null) {
-    return buildEmbeddedTerminalFallbackResponse(request, id, target.bridgeId);
-  }
+  const ttydHtml = html ?? loadBundledTtydFrontendHtml();
 
   const patchedHtml = injectTtydResizeShim(
-    injectBridgeTtydRelayShim(html, relayTtydWsUrl),
+    injectBridgeTtydRelayShim(ttydHtml, relayTtydWsUrl),
   );
+
+  if (html === null) {
+    return buildBundledTtydHtmlResponse(patchedHtml);
+  }
 
   return buildPatchedTtydHtmlResponse(proxied, patchedHtml);
 }


### PR DESCRIPTION
## Summary

Restore the ttyd iframe web frontend on the terminal route. When the backend does not return ttyd HTML, the dashboard now serves the bundled ttyd shell again instead of redirecting away from the ttyd iframe path.

## User-Facing Release Notes

- Restored the proper ttyd iframe terminal frontend for web sessions.
- Fixed the regression where the terminal route could fall away from the ttyd iframe experience instead of serving the web terminal shell.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Testing

- `bun test packages/web/src/components/sessions/terminal/terminalApi.test.ts`
- `bun test packages/web/src/lib/bundledTtydFrontend.test.ts packages/web/src/lib/bridgeTtyd.test.ts`
- `bun run --cwd packages/web typecheck`
