### PR TITLE
fix: restore ttyd html size limit

### DIFF
--- a/packages/web/src/lib/ttydHtmlResponse.test.ts
+++ b/packages/web/src/lib/ttydHtmlResponse.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import test from "node:test";
 
 import { readTtydHtmlResponse } from "./ttydHtmlResponse";
@@ -25,11 +27,34 @@ test("readTtydHtmlResponse returns null when the proxied HTML stream errors", as
   assert.equal(html, null);
 });
 
+test("readTtydHtmlResponse accepts the vendored ttyd frontend size used by the iframe proxy", async () => {
+  const ttydFrontendPath = join(
+    process.cwd(),
+    "..",
+    "..",
+    "crates",
+    "conductor-server",
+    "src",
+    "routes",
+    "ttyd_frontend_v1.7.7.html",
+  );
+  const html = readFileSync(ttydFrontendPath, "utf8");
+  const proxied = new Response(html, {
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      "content-length": String(Buffer.byteLength(html)),
+    },
+  });
+
+  const resolved = await readTtydHtmlResponse(proxied);
+  assert.equal(resolved, html);
+});
+
 test("readTtydHtmlResponse still rejects oversized ttyd HTML responses", async () => {
   const proxied = new Response("<html><body>large</body></html>", {
     headers: {
       "content-type": "text/html; charset=utf-8",
-      "content-length": String(600 * 1024),
+      "content-length": String(9 * 1024 * 1024),
     },
   });
 

--- a/packages/web/src/lib/ttydHtmlResponse.ts
+++ b/packages/web/src/lib/ttydHtmlResponse.ts
@@ -1,4 +1,5 @@
-const MAX_TTYD_HTML_RESPONSE_BYTES = 512 * 1024;
+// Keep in sync with crates/conductor-server/src/routes/terminal.rs.
+const MAX_TTYD_HTML_RESPONSE_BYTES = 8 * 1024 * 1024;
 const TTYD_HTML_TOO_LARGE_ERROR = "ttyd frontend response is too large";
 
 export async function readTtydHtmlResponse(proxied: Response): Promise<string | null> {


### PR DESCRIPTION
## User-Facing Release Notes

- Fixed the session terminal iframe so ttyd-backed terminals no longer render a blank white screen when loading the proxied ttyd frontend.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore
