### PR TITLE
fix: allow embedded terminal iframes

### DIFF
--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -80,6 +80,10 @@ const nextConfig: NextConfig = {
         ],
       },
       {
+        source: "/embed/terminal/:path*",
+        headers: embeddedTerminalHeaders,
+      },
+      {
         source: "/api/sessions/:path*/terminal/ttyd",
         headers: embeddedTerminalHeaders,
       },


### PR DESCRIPTION
## User-Facing Release Notes

- Fixed the embedded terminal iframe so the fallback `/embed/terminal/*` page can render inside the dashboard again instead of being blocked and showing a blank white panel.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore
