### PR TITLE
fix: restore legacy ttyd iframe framing

### DIFF
--- a/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
@@ -1,4 +1,3 @@
-import { NextResponse } from "next/server";
 import { guardApiAccess } from "@/lib/auth";
 import { buildForwardedAccessHeaders } from "@/lib/guardedRustProxy";
 import { proxyToBridgeDevice } from "@/lib/bridgeApiProxy";
@@ -11,6 +10,10 @@ import {
   injectTtydResizeShim,
   resolveBridgeSessionTarget,
 } from "@/lib/bridgeTtyd";
+import {
+  buildBundledTtydHtmlResponse,
+  loadBundledTtydFrontendHtml,
+} from "@/lib/bundledTtydFrontend";
 import { readTtydHtmlResponse } from "@/lib/ttydHtmlResponse";
 
 export const dynamic = "force-dynamic";
@@ -19,19 +22,6 @@ export const runtime = "nodejs";
 type RouteContext = {
   params: Promise<{ id: string }>;
 };
-
-
-function buildEmbeddedTerminalFallbackResponse(
-  request: Request,
-  sessionId: string,
-  bridgeId?: string,
-): Response {
-  const url = new URL(`/embed/terminal/${encodeURIComponent(sessionId)}`, request.url);
-  if (bridgeId) {
-    url.searchParams.set("bridgeId", bridgeId);
-  }
-  return NextResponse.redirect(url, { status: 307 });
-}
 
 export async function GET(
   request: Request,
@@ -54,13 +44,11 @@ export async function GET(
       },
     );
 
-    if (!proxied.ok) {
-      return buildEmbeddedTerminalFallbackResponse(request, id);
-    }
-
     const html = await readTtydHtmlResponse(proxied);
     if (html === null) {
-      return buildEmbeddedTerminalFallbackResponse(request, id);
+      return buildBundledTtydHtmlResponse(
+        injectTtydResizeShim(loadBundledTtydFrontendHtml()),
+      );
     }
 
     return buildPatchedTtydHtmlResponse(proxied, injectTtydResizeShim(html));
@@ -90,18 +78,16 @@ export async function GET(
     );
   }
 
-  if (!proxied.ok) {
-    return buildEmbeddedTerminalFallbackResponse(request, id, target.bridgeId);
-  }
-
   const html = await readTtydHtmlResponse(proxied);
-  if (html === null) {
-    return buildEmbeddedTerminalFallbackResponse(request, id, target.bridgeId);
-  }
+  const ttydHtml = html ?? loadBundledTtydFrontendHtml();
 
   const patchedHtml = injectTtydResizeShim(
-    injectBridgeTtydRelayShim(html, relayTtydWsUrl),
+    injectBridgeTtydRelayShim(ttydHtml, relayTtydWsUrl),
   );
+
+  if (html === null) {
+    return buildBundledTtydHtmlResponse(patchedHtml);
+  }
 
   return buildPatchedTtydHtmlResponse(proxied, patchedHtml);
 }

--- a/packages/web/src/components/sessions/SessionTerminal.tsx
+++ b/packages/web/src/components/sessions/SessionTerminal.tsx
@@ -8,7 +8,7 @@
 import {
   AlertCircle,
   Clipboard,
-  ExternalLink,
+  FileUp,
   Loader2,
   RefreshCw,
   Send,
@@ -1079,17 +1079,35 @@ function SessionTerminalView(props: SessionTerminalProps) {
         : "group/terminal relative flex min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden rounded-none border-0 bg-[#060404] lg:rounded-[14px] lg:border lg:border-white/10 lg:shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]"}
     >
       <div className="absolute right-2 top-2 z-20 flex items-center gap-2 sm:right-3 sm:top-3">
-        {terminalDirectHref ? (
-          <a
-            href={terminalDirectHref}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/10 bg-[#141010]/92 text-[#c9c0b7] backdrop-blur-sm transition hover:bg-[#201818] sm:h-7 sm:w-7"
-            aria-label="Open ttyd terminal in a new tab"
-          >
-            <ExternalLink className="h-3.5 w-3.5" />
-          </a>
-        ) : null}
+        <input
+          ref={attachmentInputRef}
+          type="file"
+          multiple
+          accept="*/*"
+          className="sr-only"
+          tabIndex={-1}
+          aria-hidden
+          onChange={(event) => void handleAttachmentFiles(event)}
+        />
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          disabled={
+            !expectsLiveTerminal
+            || !terminalUrl
+            || attachmentUploading
+          }
+          className="h-9 w-9 rounded-full border border-white/10 bg-[#141010]/92 text-[#c9c0b7] backdrop-blur-sm hover:bg-[#201818] disabled:opacity-40 sm:h-7 sm:w-7"
+          onClick={handleAttachmentPick}
+          aria-label="Attach photos or files"
+        >
+          {attachmentUploading ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <FileUp className="h-3.5 w-3.5" />
+          )}
+        </Button>
         {typeof window !== "undefined" && window.matchMedia?.("(pointer: coarse)").matches ? (
           <Button
             type="button"

--- a/packages/web/src/components/sessions/terminal/terminalApi.test.ts
+++ b/packages/web/src/components/sessions/terminal/terminalApi.test.ts
@@ -157,7 +157,7 @@ test("resolveTerminalConnection resolves proxy ttyd paths against the current da
   );
 });
 
-test("resolveTerminalConnection falls back to the embedded iframe page when only the native terminal websocket exists", async () => {
+test("resolveTerminalConnection fronts legacy native terminal metadata through the ttyd iframe route", async () => {
   setWindowLocation("https://dashboard.example.com/sessions/session-3");
   setFetchResponse({
     required: true,
@@ -171,11 +171,11 @@ test("resolveTerminalConnection falls back to the embedded iframe page when only
   assert.equal(connection.reason, null);
   assert.equal(
     connection.terminalUrl,
-    "https://dashboard.example.com/embed/terminal/session-3",
+    "https://dashboard.example.com/api/sessions/session-3/terminal/ttyd?token=native-token",
   );
   assert.equal(
     connection.terminalLinkUrl,
-    "https://dashboard.example.com/embed/terminal/session-3",
+    "https://dashboard.example.com/api/sessions/session-3/terminal/ttyd?token=native-token",
   );
 });
 

--- a/packages/web/src/components/sessions/terminal/terminalApi.ts
+++ b/packages/web/src/components/sessions/terminal/terminalApi.ts
@@ -165,16 +165,28 @@ function appendBridgeIdToTerminalUrl(
   }
 }
 
-function buildEmbeddedTerminalUrl(
+function buildLegacyProxyTtydUrl(
   sessionId: string,
   dashboardOrigin: string,
+  legacyWsUrl: string,
   bridgeId?: string | null,
 ): string {
-  const url = new URL(`/embed/terminal/${encodeURIComponent(sessionId)}`, dashboardOrigin);
+  const url = new URL(`/api/sessions/${encodeURIComponent(sessionId)}/terminal/ttyd`, dashboardOrigin);
   const normalizedBridgeId = bridgeId?.trim();
   if (normalizedBridgeId) {
     url.searchParams.set("bridgeId", normalizedBridgeId);
   }
+
+  try {
+    const token = new URL(legacyWsUrl, dashboardOrigin).searchParams.get("token")?.trim();
+    if (token) {
+      url.searchParams.set("token", token);
+    }
+  } catch {
+    // Ignore malformed legacy websocket URLs. The terminal auth cookie still covers
+    // the common same-origin case.
+  }
+
   return url.toString();
 }
 
@@ -331,18 +343,19 @@ export async function resolveTerminalConnection(
     dashboardOrigin,
   );
 
-  // Frontend-only iframe path: when the backend exposes only the native terminal
-  // websocket contract, render the existing iframe page instead of trying to open a
-  // ttyd HTML route that does not exist on the current backend.
+  // Legacy backend fallback: still front the terminal through the ttyd iframe
+  // route so the dashboard keeps the old iframe UX even when the backend only
+  // advertises the native websocket contract.
   if (!auth.ttydHttpUrl && auth.ttydWsUrl) {
-    const embeddedTerminalUrl = buildEmbeddedTerminalUrl(
+    const legacyProxyTtydUrl = buildLegacyProxyTtydUrl(
       sessionId,
       dashboardOrigin,
+      auth.ttydWsUrl,
       options?.bridgeId,
     );
     return {
-      terminalUrl: embeddedTerminalUrl,
-      terminalLinkUrl: embeddedTerminalUrl,
+      terminalUrl: legacyProxyTtydUrl,
+      terminalLinkUrl: legacyProxyTtydUrl,
       relayTtydWsUrl: auth.relayTtydWsUrl,
       interactive: true,
       reason: null,


### PR DESCRIPTION
## User-Facing Release Notes

- Restored the earlier ttyd iframe framing so legacy websocket-backed sessions render through the real ttyd iframe route again, while keeping the attachment, clipboard, stop, and reload controls.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore
