### PR TITLE
fix: restore legacy embedded terminal fallback

### DIFF
--- a/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
@@ -1,3 +1,4 @@
+import { NextResponse } from "next/server";
 import { guardApiAccess } from "@/lib/auth";
 import { buildForwardedAccessHeaders } from "@/lib/guardedRustProxy";
 import { proxyToBridgeDevice } from "@/lib/bridgeApiProxy";
@@ -10,10 +11,6 @@ import {
   injectTtydResizeShim,
   resolveBridgeSessionTarget,
 } from "@/lib/bridgeTtyd";
-import {
-  buildBundledTtydHtmlResponse,
-  loadBundledTtydFrontendHtml,
-} from "@/lib/bundledTtydFrontend";
 import { readTtydHtmlResponse } from "@/lib/ttydHtmlResponse";
 
 export const dynamic = "force-dynamic";
@@ -22,6 +19,18 @@ export const runtime = "nodejs";
 type RouteContext = {
   params: Promise<{ id: string }>;
 };
+
+function buildEmbeddedTerminalFallbackResponse(
+  request: Request,
+  sessionId: string,
+  bridgeId?: string,
+): Response {
+  const url = new URL(`/embed/terminal/${encodeURIComponent(sessionId)}`, request.url);
+  if (bridgeId) {
+    url.searchParams.set("bridgeId", bridgeId);
+  }
+  return NextResponse.redirect(url, { status: 307 });
+}
 
 export async function GET(
   request: Request,
@@ -44,11 +53,13 @@ export async function GET(
       },
     );
 
+    if (!proxied.ok) {
+      return buildEmbeddedTerminalFallbackResponse(request, id);
+    }
+
     const html = await readTtydHtmlResponse(proxied);
     if (html === null) {
-      return buildBundledTtydHtmlResponse(
-        injectTtydResizeShim(loadBundledTtydFrontendHtml()),
-      );
+      return buildEmbeddedTerminalFallbackResponse(request, id);
     }
 
     return buildPatchedTtydHtmlResponse(proxied, injectTtydResizeShim(html));
@@ -78,16 +89,18 @@ export async function GET(
     );
   }
 
+  if (!proxied.ok) {
+    return buildEmbeddedTerminalFallbackResponse(request, id, target.bridgeId);
+  }
+
   const html = await readTtydHtmlResponse(proxied);
-  const ttydHtml = html ?? loadBundledTtydFrontendHtml();
+  if (html === null) {
+    return buildEmbeddedTerminalFallbackResponse(request, id, target.bridgeId);
+  }
 
   const patchedHtml = injectTtydResizeShim(
-    injectBridgeTtydRelayShim(ttydHtml, relayTtydWsUrl),
+    injectBridgeTtydRelayShim(html, relayTtydWsUrl),
   );
-
-  if (html === null) {
-    return buildBundledTtydHtmlResponse(patchedHtml);
-  }
 
   return buildPatchedTtydHtmlResponse(proxied, patchedHtml);
 }

--- a/packages/web/src/components/sessions/terminal/terminalApi.test.ts
+++ b/packages/web/src/components/sessions/terminal/terminalApi.test.ts
@@ -157,7 +157,7 @@ test("resolveTerminalConnection resolves proxy ttyd paths against the current da
   );
 });
 
-test("resolveTerminalConnection fronts legacy native terminal metadata through the ttyd iframe route", async () => {
+test("resolveTerminalConnection falls back to the embedded iframe page when only the native terminal websocket exists", async () => {
   setWindowLocation("https://dashboard.example.com/sessions/session-3");
   setFetchResponse({
     required: true,
@@ -171,11 +171,11 @@ test("resolveTerminalConnection fronts legacy native terminal metadata through t
   assert.equal(connection.reason, null);
   assert.equal(
     connection.terminalUrl,
-    "https://dashboard.example.com/api/sessions/session-3/terminal/ttyd?token=native-token",
+    "https://dashboard.example.com/embed/terminal/session-3",
   );
   assert.equal(
     connection.terminalLinkUrl,
-    "https://dashboard.example.com/api/sessions/session-3/terminal/ttyd?token=native-token",
+    "https://dashboard.example.com/embed/terminal/session-3",
   );
 });
 

--- a/packages/web/src/components/sessions/terminal/terminalApi.ts
+++ b/packages/web/src/components/sessions/terminal/terminalApi.ts
@@ -165,28 +165,16 @@ function appendBridgeIdToTerminalUrl(
   }
 }
 
-function buildLegacyProxyTtydUrl(
+function buildEmbeddedTerminalUrl(
   sessionId: string,
   dashboardOrigin: string,
-  legacyWsUrl: string,
   bridgeId?: string | null,
 ): string {
-  const url = new URL(`/api/sessions/${encodeURIComponent(sessionId)}/terminal/ttyd`, dashboardOrigin);
+  const url = new URL(`/embed/terminal/${encodeURIComponent(sessionId)}`, dashboardOrigin);
   const normalizedBridgeId = bridgeId?.trim();
   if (normalizedBridgeId) {
     url.searchParams.set("bridgeId", normalizedBridgeId);
   }
-
-  try {
-    const token = new URL(legacyWsUrl, dashboardOrigin).searchParams.get("token")?.trim();
-    if (token) {
-      url.searchParams.set("token", token);
-    }
-  } catch {
-    // Ignore malformed legacy websocket URLs. The terminal auth cookie still covers
-    // the common same-origin case.
-  }
-
   return url.toString();
 }
 
@@ -343,19 +331,18 @@ export async function resolveTerminalConnection(
     dashboardOrigin,
   );
 
-  // Legacy backend fallback: still front the terminal through the ttyd iframe
-  // route so the dashboard keeps the old iframe UX even when the backend only
-  // advertises the native websocket contract.
+  // Frontend-only iframe path: when the backend exposes only the native terminal
+  // websocket contract, render the existing iframe page instead of trying to open a
+  // ttyd HTML route that does not exist on the current backend.
   if (!auth.ttydHttpUrl && auth.ttydWsUrl) {
-    const legacyProxyTtydUrl = buildLegacyProxyTtydUrl(
+    const embeddedTerminalUrl = buildEmbeddedTerminalUrl(
       sessionId,
       dashboardOrigin,
-      auth.ttydWsUrl,
       options?.bridgeId,
     );
     return {
-      terminalUrl: legacyProxyTtydUrl,
-      terminalLinkUrl: legacyProxyTtydUrl,
+      terminalUrl: embeddedTerminalUrl,
+      terminalLinkUrl: embeddedTerminalUrl,
       relayTtydWsUrl: auth.relayTtydWsUrl,
       interactive: true,
       reason: null,


### PR DESCRIPTION
## Summary

Restores the older terminal routing split that Conductor used before the recent ttyd iframe regression. Legacy ws-only sessions now load through the embedded terminal page again, while the ttyd route only stays on the real ttyd HTML path.

## User-Facing Release Notes

- Fixed terminal sessions that were failing to load and incorrectly prompting users to download ttyd.
- Restored the older embedded terminal fallback for legacy sessions while keeping real ttyd iframe sessions on the proper route.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Plugin Addition / Modification
- [ ] Documentation Update
- [ ] Refactor / Chore

## Testing

- `bun test src/components/sessions/terminal/terminalApi.test.ts src/lib/ttydHtmlResponse.test.ts src/lib/bundledTtydFrontend.test.ts`
- `bun run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Enhanced terminal handling with improved fallback behavior when the primary terminal service is unavailable.
  * Terminal connections now utilize an embedded interface for more reliable access.
  * Updated terminal URL routing to support new architecture and error handling.
  * Internal terminal connection logic improved for better stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->