### PR TITLE
fix: restore full agent terminal iframe experience

### DIFF
--- a/packages/web/src/lib/ttydHtmlResponse.test.ts
+++ b/packages/web/src/lib/ttydHtmlResponse.test.ts
@@ -27,6 +27,31 @@ test("readTtydHtmlResponse returns null when the proxied HTML stream errors", as
   assert.equal(html, null);
 });
 
+test("readTtydHtmlResponse accepts html bodies even when upstream headers mark them as downloads", async () => {
+  const html = "<!DOCTYPE html><html><body>ttyd</body></html>";
+  const proxied = new Response(html, {
+    headers: {
+      "content-type": "application/octet-stream",
+      "content-disposition": 'attachment; filename="ttyd"',
+    },
+  });
+
+  const resolved = await readTtydHtmlResponse(proxied);
+  assert.equal(resolved, html);
+});
+
+test("readTtydHtmlResponse still returns null for non-html download responses", async () => {
+  const proxied = new Response("terminal-bytes", {
+    headers: {
+      "content-type": "application/octet-stream",
+      "content-disposition": 'attachment; filename="ttyd"',
+    },
+  });
+
+  const resolved = await readTtydHtmlResponse(proxied);
+  assert.equal(resolved, null);
+});
+
 test("readTtydHtmlResponse accepts the vendored ttyd frontend size used by the iframe proxy", async () => {
   const ttydFrontendPath = join(
     process.cwd(),

--- a/packages/web/src/lib/ttydHtmlResponse.ts
+++ b/packages/web/src/lib/ttydHtmlResponse.ts
@@ -1,13 +1,17 @@
 // Keep in sync with crates/conductor-server/src/routes/terminal.rs.
 const MAX_TTYD_HTML_RESPONSE_BYTES = 8 * 1024 * 1024;
 const TTYD_HTML_TOO_LARGE_ERROR = "ttyd frontend response is too large";
+const HTML_SNIFF_CHAR_LIMIT = 2048;
+
+function looksLikeHtmlDocument(text: string): boolean {
+  const trimmed = text.trimStart().toLowerCase();
+  return trimmed.startsWith("<!doctype html") || trimmed.startsWith("<html") || trimmed.startsWith("<head") || trimmed.startsWith("<body");
+}
 
 export async function readTtydHtmlResponse(proxied: Response): Promise<string | null> {
   const candidate = proxied.clone();
   const contentType = candidate.headers.get("content-type")?.toLowerCase() ?? "";
-  if (!contentType.startsWith("text/html")) {
-    return null;
-  }
+  const declaredHtml = contentType.startsWith("text/html");
 
   const contentLength = Number.parseInt(candidate.headers.get("content-length") ?? "", 10);
   if (Number.isFinite(contentLength) && contentLength > MAX_TTYD_HTML_RESPONSE_BYTES) {
@@ -23,6 +27,7 @@ export async function readTtydHtmlResponse(proxied: Response): Promise<string | 
     const decoder = new TextDecoder();
     let totalBytes = 0;
     let html = "";
+    let sniffedHtml = declaredHtml;
 
     for (;;) {
       const { done, value } = await reader.read();
@@ -34,9 +39,20 @@ export async function readTtydHtmlResponse(proxied: Response): Promise<string | 
         throw new Error(TTYD_HTML_TOO_LARGE_ERROR);
       }
       html += decoder.decode(value, { stream: true });
+
+      if (!sniffedHtml && html.length >= HTML_SNIFF_CHAR_LIMIT) {
+        sniffedHtml = looksLikeHtmlDocument(html);
+        if (!sniffedHtml) {
+          await reader.cancel().catch(() => undefined);
+          return null;
+        }
+      }
     }
 
     html += decoder.decode();
+    if (!sniffedHtml && !looksLikeHtmlDocument(html)) {
+      return null;
+    }
     return html;
   } catch (error) {
     if (error instanceof Error && error.message === TTYD_HTML_TOO_LARGE_ERROR) {


### PR DESCRIPTION
## Summary

Restores the earlier full agent terminal experience that lived inside the embedded iframe flow. The dashboard terminal panel now goes back to the same `/embed/terminal/:id` path and attachment-first chrome we had in the earlier native PTY iframe implementation, instead of trying to front the session through the newer ttyd web facade path.

This branch also keeps the defensive ttyd HTML sniffing fix for cases where upstream ttyd pages are mislabeled with download headers, but the main product fix is restoring the embedded full-agent iframe flow in `SessionTerminal.tsx`.

## User-Facing Release Notes

- Restored the earlier full agent terminal iframe experience in the dashboard, including the embedded terminal flow with attachment, clipboard, stop, and reload controls.
- Fixed cases where terminal sessions were being routed into the wrong iframe experience instead of the embedded full-agent terminal.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Plugin Addition / Modification
- [ ] Documentation Update
- [ ] Refactor / Chore

## Testing

- `bun test src/lib/ttydHtmlResponse.test.ts src/components/sessions/terminal/terminalApi.test.ts src/lib/bundledTtydFrontend.test.ts src/components/sessions/sessionTerminalRouting.test.ts src/components/sessions/sessionTerminalUtils.test.ts`
- `bun run typecheck`
