### PR TITLE
fix: restore pre-390 ttyd terminal experience

### DIFF
--- a/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
@@ -1,17 +1,14 @@
-import { NextResponse } from "next/server";
 import { guardApiAccess } from "@/lib/auth";
 import { buildForwardedAccessHeaders } from "@/lib/guardedRustProxy";
 import { proxyToBridgeDevice } from "@/lib/bridgeApiProxy";
 import { proxyToRustOrUnavailable } from "@/lib/rustBackendProxy";
 import {
   BRIDGE_TTYD_RELAY_WS_QUERY_PARAM,
-  buildPatchedTtydHtmlResponse,
   createBridgeTtydRelayWebSocketUrl,
   injectBridgeTtydRelayShim,
   injectTtydResizeShim,
   resolveBridgeSessionTarget,
 } from "@/lib/bridgeTtyd";
-import { readTtydHtmlResponse } from "@/lib/ttydHtmlResponse";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -20,16 +17,30 @@ type RouteContext = {
   params: Promise<{ id: string }>;
 };
 
-function buildEmbeddedTerminalFallbackResponse(
-  request: Request,
-  sessionId: string,
-  bridgeId?: string,
-): Response {
-  const url = new URL(`/embed/terminal/${encodeURIComponent(sessionId)}`, request.url);
-  if (bridgeId) {
-    url.searchParams.set("bridgeId", bridgeId);
+/**
+ * Inject the resize coordination shim into a proxied HTML response.
+ * Falls back to the original response if the content is not HTML or
+ * reading the body fails.
+ */
+async function injectResizeShimIntoResponse(proxied: Response): Promise<Response> {
+  const contentType = proxied.headers.get("content-type")?.toLowerCase() ?? "";
+  if (!contentType.startsWith("text/html")) {
+    return proxied;
   }
-  return NextResponse.redirect(url, { status: 307 });
+
+  let html: string;
+  try {
+    html = await proxied.text();
+  } catch {
+    return proxied;
+  }
+
+  const patched = injectTtydResizeShim(html);
+  return new Response(patched, {
+    status: proxied.status,
+    statusText: proxied.statusText,
+    headers: new Headers(proxied.headers),
+  });
 }
 
 export async function GET(
@@ -53,16 +64,7 @@ export async function GET(
       },
     );
 
-    if (!proxied.ok) {
-      return buildEmbeddedTerminalFallbackResponse(request, id);
-    }
-
-    const html = await readTtydHtmlResponse(proxied);
-    if (html === null) {
-      return buildEmbeddedTerminalFallbackResponse(request, id);
-    }
-
-    return buildPatchedTtydHtmlResponse(proxied, injectTtydResizeShim(html));
+    return injectResizeShimIntoResponse(proxied);
   }
 
   // Bridge session: proxy to bridge device, inject relay shim + resize shim.
@@ -80,6 +82,11 @@ export async function GET(
     },
   );
 
+  const contentType = proxied.headers.get("content-type")?.toLowerCase() ?? "";
+  if (!contentType.startsWith("text/html")) {
+    return proxied;
+  }
+
   let relayTtydWsUrl = new URL(request.url).searchParams.get(BRIDGE_TTYD_RELAY_WS_QUERY_PARAM)?.trim() ?? "";
   if (!relayTtydWsUrl) {
     relayTtydWsUrl = await createBridgeTtydRelayWebSocketUrl(
@@ -89,18 +96,13 @@ export async function GET(
     );
   }
 
-  if (!proxied.ok) {
-    return buildEmbeddedTerminalFallbackResponse(request, id, target.bridgeId);
-  }
+  let html = await proxied.text();
+  html = injectBridgeTtydRelayShim(html, relayTtydWsUrl);
+  html = injectTtydResizeShim(html);
 
-  const html = await readTtydHtmlResponse(proxied);
-  if (html === null) {
-    return buildEmbeddedTerminalFallbackResponse(request, id, target.bridgeId);
-  }
-
-  const patchedHtml = injectTtydResizeShim(
-    injectBridgeTtydRelayShim(html, relayTtydWsUrl),
-  );
-
-  return buildPatchedTtydHtmlResponse(proxied, patchedHtml);
+  return new Response(html, {
+    status: proxied.status,
+    statusText: proxied.statusText,
+    headers: new Headers(proxied.headers),
+  });
 }

--- a/packages/web/src/components/sessions/SessionTerminal.tsx
+++ b/packages/web/src/components/sessions/SessionTerminal.tsx
@@ -3,33 +3,81 @@
 import {
   AlertCircle,
   Clipboard,
-  FileUp,
   Loader2,
+  Paperclip,
   RefreshCw,
+  Send,
   SquareStop,
   X,
 } from "lucide-react";
-import {
-  memo,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ChangeEvent,
-} from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
 import { Button } from "@/components/ui/Button";
 import { uploadProjectAttachments } from "@/components/sessions/attachmentUploads";
-import {
-  calculateMobileTerminalViewportMetrics,
-} from "@/components/sessions/sessionTerminalUtils";
-import type { SessionTerminalProps } from "@/components/sessions/terminal/terminalTypes";
 import { withBridgeQuery } from "@/lib/bridgeQuery";
+import { LIVE_TERMINAL_STATUSES, RESUMABLE_STATUSES } from "./terminal/terminalConstants";
+import { resolveTerminalConnection } from "./terminal/terminalApi";
+import { extractTerminalAuthToken } from "./terminal/terminalToken";
+import { terminalUrlNeedsReload } from "./terminal/terminalUrl";
+import { calculateMobileTerminalViewportMetrics } from "./sessionTerminalUtils";
+import type { SessionTerminalProps } from "./terminal/terminalTypes";
 
-const TTYD_READY_MESSAGE_TYPE = "conductor-ttyd-ready";
-const TERMINAL_RESIZE_MESSAGE_TYPE = "conductor-terminal-resize";
+const TERMINAL_CLOSED_STATUSES = new Set(["archived", "killed", "terminated", "restored"]);
+const TOKEN_REFRESH_LEAD_SECONDS = 10;
+const TTYD_AUTH_TOKEN_MESSAGE_TYPE = "conductor-ttyd-auth-token";
 const TERMINAL_RESIZE_DEBOUNCE_MS = 150;
-const TERMINAL_RESIZE_BURST_DELAYS_MS = [0, 50, 150, 400] as const;
+const TERMINAL_RESIZE_MESSAGE_TYPE = "conductor-terminal-resize";
+/** Staggered fits so xterm catches up after ttyd boot, layout, and fonts. */
+const TERMINAL_RESIZE_BURST_DELAYS_MS = [0, 50, 150, 400, 1000] as const;
+const TERMINAL_LIFECYCLE_REFRESH_THROTTLE_MS = 1_500;
+const TERMINAL_LIFECYCLE_REATTACH_THRESHOLD_MS = 300_000; // 5 minutes - only reload if hidden for 5+ minutes
+const TERMINAL_IFRAME_LOAD_TIMEOUT_MS = 25_000;
+
+function computeTokenRefreshDelayMs(expiresInSeconds: number | null | undefined): number | null {
+  if (typeof expiresInSeconds !== "number" || !Number.isFinite(expiresInSeconds) || expiresInSeconds <= 0) {
+    return null;
+  }
+  const safeSeconds = Math.max(5, expiresInSeconds - TOKEN_REFRESH_LEAD_SECONDS);
+  return safeSeconds * 1000;
+}
+
+/**
+ * Check if the new URL differs from the current URL ONLY in the token parameter.
+ * If true, we can update the token via postMessage without reloading the iframe.
+ */
+function isOnlyTokenChanged(
+  current: string | null | undefined,
+  next: string,
+): boolean {
+  if (!current) return false;
+
+  try {
+    const currentUrl = new URL(current);
+    const nextUrl = new URL(next);
+
+    // Must be same origin, path, and all query params except token
+    if (currentUrl.origin !== nextUrl.origin) return false;
+    if (currentUrl.pathname !== nextUrl.pathname) return false;
+
+    // Compare all params except token
+    const currentParams = new URLSearchParams(currentUrl.searchParams);
+    const nextParams = new URLSearchParams(nextUrl.searchParams);
+
+    currentParams.delete("token");
+    nextParams.delete("token");
+
+    // Check if remaining params are the same
+    const currentStr = currentParams.toString();
+    const nextStr = nextParams.toString();
+    if (currentStr !== nextStr) return false;
+
+    // Token must actually be different
+    const currentToken = new URL(current).searchParams.get("token");
+    const nextToken = new URL(next).searchParams.get("token");
+    return currentToken !== nextToken;
+  } catch {
+    return false;
+  }
+}
 
 async function sendTerminalKeys(
   sessionId: string,
@@ -52,83 +100,549 @@ async function sendTerminalKeys(
   }
 }
 
-function SessionTerminalView({
-  sessionId,
-  projectId,
-  bridgeId,
-  pendingInsert,
-  immersiveMobileMode = false,
-  panelVisible = true,
-  onPendingInsertConsumed,
-}: SessionTerminalProps) {
-  const iframeRef = useRef<HTMLIFrameElement | null>(null);
-  const terminalHostRef = useRef<HTMLDivElement | null>(null);
-  const attachmentInputRef = useRef<HTMLInputElement | null>(null);
-  const lastAppliedInsertNonceRef = useRef(0);
-  const pendingInsertNonceRef = useRef<number | null>(null);
-  const burstResizeTimersRef = useRef<number[]>([]);
-  const resizeSuppressUntilRef = useRef(0);
-  const lastPostedTerminalHostSizeRef = useRef<{ w: number; h: number } | null>(null);
+function postTerminalAuthToken(
+  iframe: HTMLIFrameElement | null | undefined,
+  token: string | null,
+): void {
+  if (!iframe || !token || iframe.contentWindow === null) {
+    return;
+  }
 
+  let targetOrigin: string;
+  try {
+    targetOrigin = new URL(iframe.src).origin;
+  } catch {
+    // Same-origin dashboard: never use "*" for auth tokens (avoids leaking to embedded content).
+    targetOrigin = typeof window !== "undefined" ? window.location.origin : "";
+  }
+  if (!targetOrigin || targetOrigin === "null") {
+    return;
+  }
+
+  iframe.contentWindow.postMessage(
+    { type: TTYD_AUTH_TOKEN_MESSAGE_TYPE, token },
+    targetOrigin,
+  );
+}
+
+function postTerminalResizeMessage(iframe: HTMLIFrameElement | null | undefined): void {
+  if (!iframe?.contentWindow) {
+    return;
+  }
+  let targetOrigin: string;
+  try {
+    targetOrigin = new URL(iframe.src).origin;
+  } catch {
+    targetOrigin = typeof window !== "undefined" ? window.location.origin : "";
+  }
+  if (!targetOrigin || targetOrigin === "null") {
+    return;
+  }
+  try {
+    iframe.contentWindow.postMessage({ type: TERMINAL_RESIZE_MESSAGE_TYPE }, targetOrigin);
+  } catch {
+    // Iframe may have navigated or origin may be opaque.
+  }
+}
+
+function SessionTerminalView(props: SessionTerminalProps) {
+  const {
+    sessionId,
+    projectId,
+    bridgeId,
+    sessionState,
+    runtimeMode,
+    pendingInsert,
+    immersiveMobileMode = false,
+    panelVisible = true,
+    onPendingInsertConsumed,
+  } = props;
+
+  const promptInputRef = useRef<HTMLInputElement>(null);
+  const attachmentInputRef = useRef<HTMLInputElement>(null);
+  const lastAppliedInsertNonceRef = useRef(0);
+  const retryAttemptRef = useRef(0);
+  const terminalHostRef = useRef<HTMLDivElement>(null);
+  const ttydIframeRef = useRef<HTMLIFrameElement | null>(null);
+  const burstResizeTimersRef = useRef<number[]>([]);
+  const frameLoadedRef = useRef(false);
+  const pageHiddenAtRef = useRef<number | null>(null);
+  const lastLifecycleRefreshAtRef = useRef(0);
+
+  const normalizedSessionStatus = useMemo(
+    () => sessionState.trim().toLowerCase(),
+    [sessionState],
+  );
+  const normalizedRuntimeMode = runtimeMode?.trim().toLowerCase() ?? null;
+  const ttydBacked = normalizedRuntimeMode === "ttyd";
+  const expectsLiveTerminal = ttydBacked
+    ? !TERMINAL_CLOSED_STATUSES.has(normalizedSessionStatus)
+    : LIVE_TERMINAL_STATUSES.has(normalizedSessionStatus);
+  const showPromptBar =
+    !ttydBacked && !immersiveMobileMode && RESUMABLE_STATUSES.has(normalizedSessionStatus);
+
+  const [terminalUrl, setTerminalUrl] = useState<string | null>(null);
+  const [terminalLinkUrl, setTerminalLinkUrl] = useState<string | null>(null);
+  const [resolvingConnection, setResolvingConnection] = useState(expectsLiveTerminal);
+  const [connectionError, setConnectionError] = useState<string | null>(null);
   const [frameLoaded, setFrameLoaded] = useState(false);
-  const [, setKeyboardVisible] = useState(false);
+  const [connectionRefreshTick, setConnectionRefreshTick] = useState(0);
+  const [promptMessage, setPromptMessage] = useState("");
+  const [promptSending, setPromptSending] = useState(false);
+  const [promptError, setPromptError] = useState<string | null>(null);
   const [queuedInsertError, setQueuedInsertError] = useState<string | null>(null);
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
   const [attachmentUploading, setAttachmentUploading] = useState(false);
-  const [reloadNonce, setReloadNonce] = useState(0);
-
-  const iframeSrc = useMemo(
-    () => withBridgeQuery(`/embed/terminal/${encodeURIComponent(sessionId)}`, bridgeId),
-    [bridgeId, sessionId],
-  );
+  const [keyboardVisible, setKeyboardVisible] = useState(false);
+  const terminalUrlRef = useRef<string | null>(null);
+  const forceTerminalReloadRef = useRef(false);
+  const resizeSuppressUntilRef = useRef(0);
+  /** Last host box we told the ttyd iframe to fit to — avoids spamming resize (xterm refit jumps scroll). */
+  const lastPostedTerminalHostSizeRef = useRef<{ w: number; h: number } | null>(null);
+  const prevPanelVisibleRef = useRef<boolean | null>(null);
 
   const clearBurstResizeTimers = useCallback(() => {
     if (typeof window === "undefined") {
       return;
     }
-    for (const timerId of burstResizeTimersRef.current) {
-      window.clearTimeout(timerId);
+    for (const id of burstResizeTimersRef.current) {
+      window.clearTimeout(id);
     }
     burstResizeTimersRef.current = [];
   }, []);
 
-  const postTerminalResizeMessage = useCallback(() => {
-    const iframe = iframeRef.current;
+  const maybePostTerminalResize = useCallback(() => {
+    const iframe = ttydIframeRef.current;
     const host = terminalHostRef.current;
-    if (!iframe?.contentWindow || !host) {
+    if (typeof window === "undefined" || !iframe?.contentWindow || !host) {
       return;
     }
     const rect = host.getBoundingClientRect();
-    const width = Math.round(rect.width);
-    const height = Math.round(rect.height);
-    if (width < 10 || height < 10) {
+    const w = Math.round(rect.width);
+    const h = Math.round(rect.height);
+    if (w < 10 || h < 10) {
       return;
     }
-    const previous = lastPostedTerminalHostSizeRef.current;
-    if (previous && previous.w === width && previous.h === height) {
+    const last = lastPostedTerminalHostSizeRef.current;
+    if (last && last.w === w && last.h === h) {
       return;
     }
-    lastPostedTerminalHostSizeRef.current = { w: width, h: height };
-    try {
-      iframe.contentWindow.postMessage({ type: TERMINAL_RESIZE_MESSAGE_TYPE }, window.location.origin);
-    } catch {
-      // Ignore navigation races while the iframe reloads.
-    }
+    lastPostedTerminalHostSizeRef.current = { w, h };
+    postTerminalResizeMessage(iframe);
   }, []);
 
   const scheduleTerminalResizeBurst = useCallback(() => {
-    if (typeof window === "undefined" || !iframeRef.current?.contentWindow) {
+    if (typeof window === "undefined") {
+      return;
+    }
+    if (!ttydIframeRef.current?.contentWindow) {
       return;
     }
     clearBurstResizeTimers();
     for (const delay of TERMINAL_RESIZE_BURST_DELAYS_MS) {
       burstResizeTimersRef.current.push(
         window.setTimeout(() => {
-          postTerminalResizeMessage();
+          maybePostTerminalResize();
         }, delay),
       );
     }
-  }, [clearBurstResizeTimers, postTerminalResizeMessage]);
+  }, [clearBurstResizeTimers, maybePostTerminalResize]);
+
+  const syncTerminalAuthToken = useCallback(() => {
+    const token = extractTerminalAuthToken(terminalLinkUrl);
+    if (!token) {
+      return;
+    }
+
+    const iframe = ttydIframeRef.current;
+    postTerminalAuthToken(iframe, token);
+  }, [terminalLinkUrl]);
+
+  useEffect(() => {
+    terminalUrlRef.current = terminalUrl;
+  }, [terminalUrl]);
+
+  useEffect(() => {
+    frameLoadedRef.current = frameLoaded;
+  }, [frameLoaded]);
+
+  useEffect(() => {
+    lastAppliedInsertNonceRef.current = 0;
+    retryAttemptRef.current = 0;
+    setTerminalUrl(null);
+    setTerminalLinkUrl(null);
+    setResolvingConnection(expectsLiveTerminal);
+    setConnectionError(null);
+    setFrameLoaded(false);
+    setConnectionRefreshTick(0);
+    setPromptMessage("");
+    setPromptSending(false);
+    setPromptError(null);
+    setQueuedInsertError(null);
+    setAttachmentError(null);
+    setAttachmentUploading(false);
+    forceTerminalReloadRef.current = false;
+    frameLoadedRef.current = false;
+    pageHiddenAtRef.current = null;
+    lastLifecycleRefreshAtRef.current = 0;
+    resizeSuppressUntilRef.current = 0;
+    lastPostedTerminalHostSizeRef.current = null;
+    clearBurstResizeTimers();
+  }, [clearBurstResizeTimers, expectsLiveTerminal, sessionId]);
+
+  useEffect(() => {
+    lastPostedTerminalHostSizeRef.current = null;
+  }, [terminalUrl]);
+
+  useEffect(() => {
+    return () => clearBurstResizeTimers();
+  }, [clearBurstResizeTimers]);
+
+  useEffect(() => {
+    if (!expectsLiveTerminal) {
+      setResolvingConnection(false);
+      setConnectionError(null);
+      return;
+    }
+
+    let cancelled = false;
+    let retryTimer: number | null = null;
+    let refreshTimer: number | null = null;
+    const abortController = new AbortController();
+    const showBlockingConnectionUi =
+      !terminalUrlRef.current || forceTerminalReloadRef.current;
+    if (showBlockingConnectionUi) {
+      setResolvingConnection(true);
+    }
+    setConnectionError(null);
+
+    void resolveTerminalConnection(sessionId, {
+      signal: abortController.signal,
+      bridgeId,
+    })
+      .then((connection) => {
+        if (cancelled) return;
+        retryAttemptRef.current = 0;
+        if (connection.interactive && connection.terminalUrl) {
+          const shouldReloadTerminal =
+            forceTerminalReloadRef.current ||
+            terminalUrlNeedsReload(terminalUrlRef.current, connection.terminalUrl);
+          forceTerminalReloadRef.current = false;
+
+          // Always update the external link URL
+          setTerminalLinkUrl(connection.terminalUrl);
+
+          // Check if only the token changed - we can sync without iframe reload
+          const onlyTokenChanged = !shouldReloadTerminal &&
+            terminalUrlRef.current &&
+            isOnlyTokenChanged(terminalUrlRef.current, connection.terminalUrl);
+
+          if (shouldReloadTerminal || !terminalUrlRef.current) {
+            // Full reload needed - either first load, forced reload, or structural URL change
+            if (!terminalUrlRef.current) {
+              setFrameLoaded(false);
+            }
+            setTerminalUrl(connection.terminalUrl);
+          } else if (onlyTokenChanged) {
+            // Token-only refresh: sync via postMessage without reloading iframe
+            const newToken = (() => {
+              try {
+                return new URL(connection.terminalUrl).searchParams.get("token");
+              } catch {
+                return null;
+              }
+            })();
+            if (newToken) {
+              const iframe = ttydIframeRef.current;
+              if (iframe) {
+                postTerminalAuthToken(iframe, newToken);
+              }
+            }
+          }
+          setConnectionError(null);
+
+          const delayMs = computeTokenRefreshDelayMs(connection.expiresInSeconds);
+          if (delayMs !== null) {
+            refreshTimer = window.setTimeout(() => {
+              setConnectionRefreshTick((current) => current + 1);
+            }, delayMs);
+          }
+          return;
+        }
+
+        if (!terminalUrlRef.current) {
+          setTerminalUrl(null);
+          setTerminalLinkUrl(null);
+          setFrameLoaded(false);
+        }
+        setConnectionError(connection.reason ?? "Live ttyd terminal is unavailable.");
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return;
+        }
+        const hasTerminal = !!terminalUrlRef.current;
+        if (!hasTerminal) {
+          setTerminalUrl(null);
+          setTerminalLinkUrl(null);
+          setFrameLoaded(false);
+        }
+        setConnectionError(
+          error instanceof Error ? error.message : "Failed to resolve ttyd terminal.",
+        );
+        const attempt = retryAttemptRef.current;
+        const delay = hasTerminal ? 5000 : Math.min(4000, 500 * 2 ** attempt);
+        retryAttemptRef.current = hasTerminal ? 0 : Math.min(attempt + 1, 3);
+        retryTimer = window.setTimeout(() => {
+          setConnectionRefreshTick((current) => current + 1);
+        }, delay);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setResolvingConnection(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      abortController.abort();
+      if (retryTimer !== null) {
+        window.clearTimeout(retryTimer);
+      }
+      if (refreshTimer !== null) {
+        window.clearTimeout(refreshTimer);
+      }
+    };
+  }, [bridgeId, connectionRefreshTick, expectsLiveTerminal, sessionId]);
+
+  useEffect(() => {
+    const previous = prevPanelVisibleRef.current;
+    prevPanelVisibleRef.current = panelVisible;
+    if (!panelVisible) {
+      return;
+    }
+    // Radix keeps inactive tabs mounted but hidden (0×0). Cached host size would skip
+    // maybePostTerminalResize when the user returns — clear and refit after layout.
+    if (previous === false) {
+      lastPostedTerminalHostSizeRef.current = null;
+      if (typeof window !== "undefined") {
+        resizeSuppressUntilRef.current = window.Date.now() + 120;
+      }
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          syncTerminalAuthToken();
+          scheduleTerminalResizeBurst();
+        });
+      });
+    }
+  }, [panelVisible, scheduleTerminalResizeBurst, syncTerminalAuthToken]);
+
+  const requestLifecycleRefresh = useCallback(() => {
+    if (!expectsLiveTerminal || typeof window === "undefined") {
+      return;
+    }
+
+    const now = window.Date.now();
+    if (now - lastLifecycleRefreshAtRef.current < TERMINAL_LIFECYCLE_REFRESH_THROTTLE_MS) {
+      return;
+    }
+    lastLifecycleRefreshAtRef.current = now;
+
+    const hiddenDuration = pageHiddenAtRef.current === null
+      ? 0
+      : now - pageHiddenAtRef.current;
+    pageHiddenAtRef.current = null;
+
+    // Do not bump connectionRefreshTick here: refetching the token endpoint on every
+    // focus/visibility event causes resolving-state flicker and fights the iframe.
+    // Token rotation stays on its timer; we only re-sync the known token and refit xterm.
+    syncTerminalAuthToken();
+    scheduleTerminalResizeBurst();
+    if (
+      hiddenDuration >= TERMINAL_LIFECYCLE_REATTACH_THRESHOLD_MS
+      && frameLoadedRef.current
+      && terminalUrlRef.current
+    ) {
+      forceTerminalReloadRef.current = true;
+      setConnectionRefreshTick((current) => current + 1);
+    }
+  }, [expectsLiveTerminal, scheduleTerminalResizeBurst, syncTerminalAuthToken]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof document === "undefined") {
+      return;
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        pageHiddenAtRef.current = window.Date.now();
+        // Suppress resize for 250ms to avoid ResizeObserver firing with
+        // zero/intermediate heights during tab switch transitions.
+        resizeSuppressUntilRef.current = window.Date.now() + 250;
+        return;
+      }
+
+      if (document.visibilityState === "visible") {
+        // Briefly suppress on visible too so layout settles before we fit.
+        resizeSuppressUntilRef.current = window.Date.now() + 100;
+        requestLifecycleRefresh();
+      }
+    };
+    const handlePageShow = () => {
+      requestLifecycleRefresh();
+    };
+
+    const handleOnline = () => {
+      // Network back: refresh token URL from the server (silent if already connected).
+      setConnectionRefreshTick((current) => current + 1);
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("pageshow", handlePageShow);
+    window.addEventListener("online", handleOnline);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("pageshow", handlePageShow);
+      window.removeEventListener("online", handleOnline);
+    };
+  }, [requestLifecycleRefresh]);
+
+  useEffect(() => {
+    if (!pendingInsert || pendingInsert.nonce <= lastAppliedInsertNonceRef.current) {
+      return;
+    }
+
+    lastAppliedInsertNonceRef.current = pendingInsert.nonce;
+    const inlineText = pendingInsert.inlineText.trim();
+    if (inlineText.length === 0) {
+      return;
+    }
+
+    let cancelled = false;
+    void sendTerminalKeys(sessionId, `${inlineText} `, bridgeId)
+      .then(() => {
+        if (!cancelled) {
+          setQueuedInsertError(null);
+          onPendingInsertConsumed?.();
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setQueuedInsertError(
+            error instanceof Error ? error.message : "Failed to queue terminal input.",
+          );
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [bridgeId, onPendingInsertConsumed, pendingInsert, sessionId]);
+
+  useEffect(() => {
+    if (!frameLoaded) {
+      return;
+    }
+
+    syncTerminalAuthToken();
+  }, [frameLoaded, syncTerminalAuthToken]);
+
+  useEffect(() => {
+    if (!expectsLiveTerminal || !terminalUrl || frameLoaded) {
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      if (!frameLoadedRef.current) {
+        setConnectionError(
+          "The terminal view did not finish loading in time. Try reload or open in a new tab.",
+        );
+      }
+    }, TERMINAL_IFRAME_LOAD_TIMEOUT_MS);
+    return () => window.clearTimeout(timer);
+  }, [expectsLiveTerminal, frameLoaded, terminalUrl]);
+
+  const handlePromptSend = useCallback(async () => {
+    const message = promptMessage.trim();
+    if (message.length === 0 || promptSending) return;
+
+    setPromptSending(true);
+    setPromptError(null);
+    try {
+      const response = await fetch(
+        withBridgeQuery(`/api/sessions/${encodeURIComponent(sessionId)}/actions`, bridgeId),
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ action: "send", message }),
+        },
+      );
+      if (!response.ok) {
+        const data = (await response.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(data?.error ?? `Failed to send message (${response.status})`);
+      }
+      setPromptMessage("");
+      promptInputRef.current?.focus();
+    } catch (error) {
+      setPromptError(error instanceof Error ? error.message : "Failed to send message");
+    } finally {
+      setPromptSending(false);
+    }
+  }, [bridgeId, promptMessage, promptSending, sessionId]);
+
+  const handleMobilePaste = useCallback(async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      if (text) {
+        await sendTerminalKeys(sessionId, text, bridgeId);
+      }
+    } catch {
+      // Clipboard read may fail due to permissions or unsupported browser
+    }
+  }, [bridgeId, sessionId]);
+
+  const handleAttachmentPick = useCallback(() => {
+    attachmentInputRef.current?.click();
+  }, []);
+
+  const handleAttachmentFiles = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const { files } = event.target;
+      event.target.value = "";
+      if (!files || files.length === 0) {
+        return;
+      }
+
+      setAttachmentError(null);
+      setAttachmentUploading(true);
+      try {
+        const uploadedPaths = await uploadProjectAttachments({
+          files: Array.from(files),
+          projectId,
+          taskRef: sessionId,
+          bridgeId,
+        });
+        for (const path of uploadedPaths) {
+          await sendTerminalKeys(sessionId, `\r\n[attached file: ${path}]\r\n`, bridgeId);
+        }
+      } catch (error) {
+        setAttachmentError(
+          error instanceof Error ? error.message : "Failed to upload attachment.",
+        );
+      } finally {
+        setAttachmentUploading(false);
+      }
+    },
+    [bridgeId, projectId, sessionId],
+  );
+
+  const handleSoftStop = useCallback(async () => {
+    // Send Ctrl+C (0x03) to interrupt the running process
+    await sendTerminalKeys(sessionId, "\x03", bridgeId);
+  }, [bridgeId, sessionId]);
 
   const applyKeyboardAwareTerminalHeight = useCallback(() => {
     const host = terminalHostRef.current;
@@ -138,21 +652,25 @@ function SessionTerminalView({
 
     const visualViewport = window.visualViewport;
     if (!visualViewport) {
-      host.style.height = "100%";
-      setKeyboardVisible(false);
       return;
     }
 
-    const { usableHeight, keyboardVisible: nextKeyboardVisible } = calculateMobileTerminalViewportMetrics(
+    const { usableHeight, keyboardVisible } = calculateMobileTerminalViewportMetrics(
       window.innerHeight,
       visualViewport.height,
       visualViewport.offsetTop,
       host.getBoundingClientRect().top,
     );
 
-    if (!nextKeyboardVisible || usableHeight <= 0) {
+    if (!keyboardVisible) {
+      // When keyboard is not visible, use 100% to let flex sizing work properly
       host.style.height = "100%";
       setKeyboardVisible(false);
+      return;
+    }
+
+    if (usableHeight <= 0) {
+      host.style.height = "100%";
       return;
     }
 
@@ -161,142 +679,8 @@ function SessionTerminalView({
   }, []);
 
   useEffect(() => {
-    setFrameLoaded(false);
-    lastPostedTerminalHostSizeRef.current = null;
-  }, [iframeSrc, reloadNonce]);
-
-  useEffect(() => {
-    if (!pendingInsert) {
-      return;
-    }
-    if (pendingInsert.nonce <= lastAppliedInsertNonceRef.current) {
-      return;
-    }
-    if (pendingInsertNonceRef.current === pendingInsert.nonce) {
-      return;
-    }
-
-    const inlineText = pendingInsert.inlineText.trim();
-    if (inlineText.length === 0) {
-      lastAppliedInsertNonceRef.current = pendingInsert.nonce;
-      onPendingInsertConsumed?.();
-      return;
-    }
-
-    pendingInsertNonceRef.current = pendingInsert.nonce;
-    let cancelled = false;
-    void sendTerminalKeys(sessionId, `${inlineText} `, bridgeId)
-      .then(() => {
-        if (cancelled) {
-          return;
-        }
-        lastAppliedInsertNonceRef.current = pendingInsert.nonce;
-        pendingInsertNonceRef.current = null;
-        setQueuedInsertError(null);
-        onPendingInsertConsumed?.();
-      })
-      .catch((error) => {
-        if (cancelled) {
-          return;
-        }
-        pendingInsertNonceRef.current = null;
-        setQueuedInsertError(
-          error instanceof Error ? error.message : "Failed to queue terminal input.",
-        );
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [bridgeId, onPendingInsertConsumed, pendingInsert, sessionId]);
-
-  const handleRetry = useCallback(() => {
-    setFrameLoaded(false);
-    setReloadNonce((value) => value + 1);
-  }, []);
-
-  const handleAttachmentPick = useCallback(() => {
-    attachmentInputRef.current?.click();
-  }, []);
-
-  const handleAttachmentFiles = useCallback(async (event: ChangeEvent<HTMLInputElement>) => {
-    const { files } = event.target;
-    event.target.value = "";
-    if (!files || files.length === 0) {
-      return;
-    }
-
-    setAttachmentUploading(true);
-    setAttachmentError(null);
-    try {
-      const uploadedPaths = await uploadProjectAttachments({
-        files: Array.from(files),
-        projectId,
-        taskRef: sessionId,
-        bridgeId,
-      });
-      for (const path of uploadedPaths) {
-        await sendTerminalKeys(sessionId, `\r\n[attached file: ${path}]\r\n`, bridgeId);
-      }
-    } catch (error) {
-      setAttachmentError(
-        error instanceof Error ? error.message : "Failed to upload attachment.",
-      );
-    } finally {
-      setAttachmentUploading(false);
-    }
-  }, [bridgeId, projectId, sessionId]);
-
-  const handleMobilePaste = useCallback(async () => {
-    try {
-      const text = await navigator.clipboard.readText();
-      if (text) {
-        await sendTerminalKeys(sessionId, text, bridgeId);
-        setQueuedInsertError(null);
-      }
-    } catch {
-      setQueuedInsertError("Clipboard paste failed.");
-    }
-  }, [bridgeId, sessionId]);
-
-  const handleSoftStop = useCallback(async () => {
-    try {
-      await sendTerminalKeys(sessionId, "\x03", bridgeId);
-      setQueuedInsertError(null);
-    } catch (error) {
-      setQueuedInsertError(
-        error instanceof Error ? error.message : "Failed to send Ctrl+C.",
-      );
-    }
-  }, [bridgeId, sessionId]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-
-    const handleMessage = (event: MessageEvent) => {
-      if (event.source !== iframeRef.current?.contentWindow || event.origin !== window.location.origin) {
-        return;
-      }
-      if ((event.data as { type?: string } | null)?.type !== TTYD_READY_MESSAGE_TYPE) {
-        return;
-      }
-      setFrameLoaded(true);
-      lastPostedTerminalHostSizeRef.current = null;
-      scheduleTerminalResizeBurst();
-      postTerminalResizeMessage();
-    };
-
-    window.addEventListener("message", handleMessage);
-    return () => {
-      window.removeEventListener("message", handleMessage);
-    };
-  }, [postTerminalResizeMessage, scheduleTerminalResizeBurst]);
-
-  useEffect(() => {
     const host = terminalHostRef.current;
-    if (!host || typeof window === "undefined") {
+    if (!host) {
       return;
     }
 
@@ -305,46 +689,62 @@ function SessionTerminalView({
       if (!panelVisible) {
         return;
       }
-      if (window.Date.now() < resizeSuppressUntilRef.current) {
+      // Guard: skip if we're in the suppression window after a tab switch.
+      // This prevents ResizeObserver from fitting to zero/intermediate
+      // heights that occur when the container is briefly hidden.
+      if (typeof window !== "undefined" && window.Date.now() < resizeSuppressUntilRef.current) {
         return;
       }
-      const rect = host.getBoundingClientRect();
-      if (rect.width < 10 || rect.height < 10) {
+
+      // Guard: skip if the host container has collapsed to near-zero height.
+      // This happens during tab switches or when the terminal is in a hidden
+      // tab panel. Fitting to zero causes xterm to lose its content layout.
+      const hostRect = host.getBoundingClientRect();
+      if (hostRect.height < 10 || hostRect.width < 10) {
         return;
       }
+
+      // Trailing debounce: reset the timer on every resize so the final
+      // layout wins after bursts (split view, keyboard, animations).
       if (debounceTimer !== null) {
         window.clearTimeout(debounceTimer);
+        debounceTimer = null;
       }
       debounceTimer = window.setTimeout(() => {
         debounceTimer = null;
-        if (window.Date.now() < resizeSuppressUntilRef.current) {
+        // Re-check suppression and minimum size after debounce elapses.
+        if (typeof window !== "undefined" && window.Date.now() < resizeSuppressUntilRef.current) {
           return;
         }
         const currentRect = host.getBoundingClientRect();
-        if (currentRect.width < 10 || currentRect.height < 10) {
+        if (currentRect.height < 10 || currentRect.width < 10) {
           return;
         }
+
         applyKeyboardAwareTerminalHeight();
-        postTerminalResizeMessage();
+
+        // After the host div has resized, tell the ttyd iframe to
+        // re-fit its internal xterm.js in the same coordinated step.
+        maybePostTerminalResize();
       }, TERMINAL_RESIZE_DEBOUNCE_MS);
     };
 
     applyGeometry();
 
-    const resizeObserver = typeof ResizeObserver === "undefined"
+    const observer = typeof ResizeObserver === "undefined"
       ? null
       : new ResizeObserver(() => {
         applyGeometry();
       });
-    const visualViewport = window.visualViewport;
+    const visualViewport = typeof window === "undefined" ? null : window.visualViewport;
 
-    resizeObserver?.observe(host);
+    observer?.observe(host);
     window.addEventListener("resize", applyGeometry);
     visualViewport?.addEventListener("resize", applyGeometry);
     visualViewport?.addEventListener("scroll", applyGeometry);
 
     return () => {
-      resizeObserver?.disconnect();
+      observer?.disconnect();
       window.removeEventListener("resize", applyGeometry);
       visualViewport?.removeEventListener("resize", applyGeometry);
       visualViewport?.removeEventListener("scroll", applyGeometry);
@@ -353,61 +753,75 @@ function SessionTerminalView({
       }
       host.style.removeProperty("height");
     };
-  }, [applyKeyboardAwareTerminalHeight, panelVisible, postTerminalResizeMessage]);
+  }, [
+    applyKeyboardAwareTerminalHeight,
+    expectsLiveTerminal,
+    maybePostTerminalResize,
+    panelVisible,
+    terminalUrl,
+  ]);
 
   useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
+    if (process.env.NODE_ENV !== "development") return;
 
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === "hidden") {
-        resizeSuppressUntilRef.current = window.Date.now() + 250;
-        return;
+    window.__conductorSessionTerminalDebug = {
+      sessionId,
+      getState: () => ({
+        mode: "ttyd-iframe",
+        expectsLiveTerminal,
+        runtimeMode: normalizedRuntimeMode,
+        ttydBacked,
+        terminalUrl,
+        terminalLinkUrl,
+        frameLoaded,
+        resolvingConnection,
+        connectionError,
+        promptError,
+        queuedInsertError,
+      }),
+    };
+
+    return () => {
+      if (window.__conductorSessionTerminalDebug?.sessionId === sessionId) {
+        delete window.__conductorSessionTerminalDebug;
       }
-      resizeSuppressUntilRef.current = window.Date.now() + 100;
-      lastPostedTerminalHostSizeRef.current = null;
-      applyKeyboardAwareTerminalHeight();
-      scheduleTerminalResizeBurst();
     };
+  }, [
+    connectionError,
+    expectsLiveTerminal,
+    frameLoaded,
+    normalizedRuntimeMode,
+    promptError,
+    queuedInsertError,
+    resolvingConnection,
+    sessionId,
+    terminalUrl,
+    terminalLinkUrl,
+    ttydBacked,
+  ]);
 
-    const handleFocus = () => {
-      resizeSuppressUntilRef.current = window.Date.now() + 120;
-      lastPostedTerminalHostSizeRef.current = null;
-      applyKeyboardAwareTerminalHeight();
-      scheduleTerminalResizeBurst();
-    };
+  const handleRetry = useCallback(() => {
+    setConnectionError(null);
+    retryAttemptRef.current = 0;
+    forceTerminalReloadRef.current = true;
+    setConnectionRefreshTick((current) => current + 1);
+  }, []);
 
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-    window.addEventListener("focus", handleFocus);
-    return () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-      window.removeEventListener("focus", handleFocus);
-    };
-  }, [applyKeyboardAwareTerminalHeight, scheduleTerminalResizeBurst]);
+  const emptyStateTitle = expectsLiveTerminal
+    ? "Connecting live terminal"
+    : showPromptBar
+      ? "Session is waiting for input"
+      : "Live terminal is not active";
 
-  useEffect(() => {
-    if (!panelVisible) {
-      return;
-    }
-    let outerRaf = 0;
-    let innerRaf = 0;
-    outerRaf = window.requestAnimationFrame(() => {
-      innerRaf = window.requestAnimationFrame(() => {
-        lastPostedTerminalHostSizeRef.current = null;
-        applyKeyboardAwareTerminalHeight();
-        scheduleTerminalResizeBurst();
-      });
-    });
-    return () => {
-      window.cancelAnimationFrame(outerRaf);
-      window.cancelAnimationFrame(innerRaf);
-    };
-  }, [applyKeyboardAwareTerminalHeight, panelVisible, reloadNonce, scheduleTerminalResizeBurst]);
-
-  useEffect(() => () => {
-    clearBurstResizeTimers();
-  }, [clearBurstResizeTimers]);
+  const emptyStateDescription = connectionError
+    ?? (expectsLiveTerminal
+      ? "Reconnecting to the existing ttyd terminal."
+      : ttydBacked
+        ? "This ttyd terminal is no longer attached. It only closes after an explicit kill or archive."
+      : showPromptBar
+        ? "Send a follow-up below to relaunch the agent in a fresh ttyd terminal."
+        : `Session status is \`${normalizedSessionStatus}\`. Interactive ttyd terminals only run while the agent is active.`);
+  const terminalHref = terminalLinkUrl ?? terminalUrl ?? undefined;
 
   return (
     <div
@@ -415,7 +829,7 @@ function SessionTerminalView({
         ? "group/terminal relative flex min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden bg-[#060404]"
         : "group/terminal relative flex min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden rounded-none border-0 bg-[#060404] lg:rounded-[14px] lg:border lg:border-white/10 lg:shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]"}
     >
-      <div className="absolute right-2 top-2 z-20 flex items-center gap-2 sm:right-3 sm:top-3">
+      <div className="absolute right-2 top-2 z-10 flex items-center gap-2 sm:right-3 sm:top-3">
         <input
           ref={attachmentInputRef}
           type="file"
@@ -423,41 +837,47 @@ function SessionTerminalView({
           accept="*/*"
           className="sr-only"
           tabIndex={-1}
-          aria-hidden="true"
+          aria-hidden
           onChange={(event) => void handleAttachmentFiles(event)}
         />
         <Button
           type="button"
           size="icon"
           variant="ghost"
+          disabled={
+            !expectsLiveTerminal
+            || !terminalUrl
+            || attachmentUploading
+          }
           className="h-9 w-9 rounded-full border border-white/10 bg-[#141010]/92 text-[#c9c0b7] backdrop-blur-sm hover:bg-[#201818] disabled:opacity-40 sm:h-7 sm:w-7"
           onClick={handleAttachmentPick}
           aria-label="Attach photos or files"
-          disabled={attachmentUploading}
         >
           {attachmentUploading ? (
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
           ) : (
-            <FileUp className="h-3.5 w-3.5" />
+            <Paperclip className="h-3.5 w-3.5" />
           )}
         </Button>
+        {typeof window !== "undefined" && window.matchMedia?.("(pointer: coarse)").matches ? (
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            className="h-9 w-9 rounded-full border border-white/10 bg-[#141010]/92 text-[#c9c0b7] backdrop-blur-sm hover:bg-[#201818] sm:h-7 sm:w-7"
+            onClick={handleMobilePaste}
+            aria-label="Paste from clipboard"
+          >
+            <Clipboard className="h-3.5 w-3.5" />
+          </Button>
+        ) : null}
         <Button
           type="button"
           size="icon"
           variant="ghost"
           className="h-9 w-9 rounded-full border border-white/10 bg-[#141010]/92 text-[#c9c0b7] backdrop-blur-sm hover:bg-[#201818] sm:h-7 sm:w-7"
-          onClick={() => void handleMobilePaste()}
-          aria-label="Paste from clipboard"
-        >
-          <Clipboard className="h-3.5 w-3.5" />
-        </Button>
-        <Button
-          type="button"
-          size="icon"
-          variant="ghost"
-          className="h-9 w-9 rounded-full border border-white/10 bg-[#141010]/92 text-[#c9c0b7] backdrop-blur-sm hover:bg-[#201818] sm:h-7 sm:w-7"
-          onClick={() => void handleSoftStop()}
-          aria-label="Soft stop terminal"
+          onClick={handleSoftStop}
+          aria-label="Soft stop (Ctrl+C)"
         >
           <SquareStop className="h-3.5 w-3.5" />
         </Button>
@@ -467,9 +887,9 @@ function SessionTerminalView({
           variant="ghost"
           className="h-9 w-9 rounded-full border border-white/10 bg-[#141010]/92 text-[#c9c0b7] backdrop-blur-sm hover:bg-[#201818] sm:h-7 sm:w-7"
           onClick={handleRetry}
-          aria-label="Reload terminal"
+          aria-label="Reload ttyd terminal"
         >
-          {!frameLoaded ? (
+          {resolvingConnection ? (
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
           ) : (
             <RefreshCw className="h-3.5 w-3.5" />
@@ -478,48 +898,79 @@ function SessionTerminalView({
       </div>
 
       <div
-        className={immersiveMobileMode
-          ? "min-h-0 min-w-0 h-0 flex-1 overflow-hidden px-0 pb-[env(safe-area-inset-bottom)] pt-0 w-full"
-          : "min-h-0 min-w-0 h-0 flex-1 overflow-hidden px-0.5 pb-0 pt-0.5 lg:px-1.5 lg:pb-1 lg:pt-3 w-full"}
+        className={
+          immersiveMobileMode
+            ? "min-h-0 min-w-0 h-0 flex-1 overflow-hidden px-0 pb-[env(safe-area-inset-bottom)] pt-0 w-full"
+            : "min-h-0 min-w-0 h-0 flex-1 overflow-hidden px-0.5 pb-0 pt-0.5 lg:px-1.5 lg:pb-1 lg:pt-3 w-full"
+        }
       >
-        <div
-          ref={terminalHostRef}
-          className="relative flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden rounded-[10px] bg-[#060404] pb-[env(safe-area-inset-bottom)]"
-        >
-          {!frameLoaded ? (
-            <div className="absolute inset-0 z-10 flex items-center justify-center bg-[#060404]">
-              <div className="flex items-center gap-2 rounded-full border border-white/10 bg-[#141010]/92 px-3 py-2 text-[12px] text-[#c9c0b7] backdrop-blur-sm">
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                <span>Loading terminal…</span>
+        {expectsLiveTerminal && terminalUrl ? (
+          <div
+            ref={terminalHostRef}
+            className="relative flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden rounded-[10px] bg-[#060404] pb-[env(safe-area-inset-bottom)]"
+          >
+            {!frameLoaded ? (
+              <div className="absolute inset-0 z-10 flex items-center justify-center bg-[#060404]">
+                <div className="flex items-center gap-2 rounded-full border border-white/10 bg-[#141010]/92 px-3 py-2 text-[12px] text-[#c9c0b7] backdrop-blur-sm">
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  <span>Loading ttyd terminal…</span>
+                </div>
+              </div>
+            ) : null}
+            <iframe
+              key={sessionId}
+              ref={ttydIframeRef}
+              title={`ttyd terminal for ${sessionId}`}
+              src={terminalUrl}
+              className="block h-full min-h-0 w-full flex-1 border-0 bg-[#060404]"
+              allow="clipboard-read; clipboard-write"
+              loading="eager"
+              onError={() => {
+                setConnectionError("Failed to load the terminal frame. Try reload or open in a new tab.");
+              }}
+              onLoad={() => {
+                setFrameLoaded(true);
+                setConnectionError(null);
+                applyKeyboardAwareTerminalHeight();
+                syncTerminalAuthToken();
+                scheduleTerminalResizeBurst();
+              }}
+            />
+          </div>
+        ) : (
+          <div className="flex h-full items-center justify-center p-4">
+            <div className="max-w-lg rounded-[16px] border border-white/10 bg-[#141010]/92 p-5 text-[#efe8e1] shadow-[0_24px_48px_rgba(0,0,0,0.34)]">
+              <div className="flex items-start gap-3">
+                <div className="mt-0.5 rounded-full border border-white/10 bg-[#201818] p-2 text-[#c9c0b7]">
+                  {connectionError ? (
+                    <AlertCircle className="h-4 w-4" />
+                  ) : (
+                    <Loader2 className={`h-4 w-4 ${resolvingConnection ? "animate-spin" : ""}`} />
+                  )}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="text-[14px] font-medium">{emptyStateTitle}</div>
+                  <div className="mt-1 text-[12px] leading-5 text-[#a79c94]">{emptyStateDescription}</div>
+                  {terminalHref ? (
+                    <div className="mt-3">
+                      <a
+                        href={terminalHref}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-[12px] text-[#d7c6b7] underline underline-offset-4"
+                      >
+                        Open the ttyd terminal directly
+                      </a>
+                    </div>
+                  ) : null}
+                </div>
               </div>
             </div>
-          ) : null}
-          <iframe
-            key={`${sessionId}:${reloadNonce}`}
-            ref={iframeRef}
-            src={iframeSrc}
-            title={`Conductor terminal ${sessionId}`}
-            className="block h-full min-h-0 w-full flex-1 border-0 bg-[#060404]"
-            allow="clipboard-read; clipboard-write"
-            loading="eager"
-            onError={() => {
-              setFrameLoaded(false);
-            }}
-            onLoad={() => {
-              setFrameLoaded(true);
-              lastPostedTerminalHostSizeRef.current = null;
-              applyKeyboardAwareTerminalHeight();
-              scheduleTerminalResizeBurst();
-              postTerminalResizeMessage();
-            }}
-          />
-          {!panelVisible && !frameLoaded ? (
-            <div className="pointer-events-none absolute inset-0 bg-[#060404]" />
-          ) : null}
-        </div>
+          </div>
+        )}
       </div>
 
-      {queuedInsertError || attachmentError ? (
+      {!showPromptBar && (queuedInsertError || attachmentError) ? (
         <div className="absolute inset-x-0 bottom-0 z-10 border-t border-white/12 bg-[#161212] px-3 py-2 text-[11px] text-[#ffb39e] backdrop-blur-sm [padding-bottom:env(safe-area-inset-bottom)]">
           {queuedInsertError ? (
             <div className="flex items-center gap-1.5">
@@ -529,7 +980,6 @@ function SessionTerminalView({
                 type="button"
                 className="ml-auto shrink-0 text-[#8e847d] hover:text-[#c9c0b7]"
                 onClick={() => setQueuedInsertError(null)}
-                aria-label="Dismiss queued insert error"
               >
                 <X className="h-3 w-3" />
               </button>
@@ -543,7 +993,6 @@ function SessionTerminalView({
                 type="button"
                 className="ml-auto shrink-0 text-[#8e847d] hover:text-[#c9c0b7]"
                 onClick={() => setAttachmentError(null)}
-                aria-label="Dismiss attachment error"
               >
                 <X className="h-3 w-3" />
               </button>
@@ -551,8 +1000,119 @@ function SessionTerminalView({
           ) : null}
         </div>
       ) : null}
+
+      {showPromptBar ? (
+        <div className="absolute inset-x-0 bottom-0 z-10 border-t border-white/12 bg-[#161212] backdrop-blur-sm [padding-bottom:env(safe-area-inset-bottom)]">
+          {queuedInsertError ? (
+            <div className="flex items-center gap-1.5 px-3 pt-1.5 text-[11px] text-[#ffb39e]">
+              <AlertCircle className="h-3 w-3 shrink-0" />
+              <span className="truncate">{queuedInsertError}</span>
+              <button
+                type="button"
+                className="ml-auto shrink-0 text-[#8e847d] hover:text-[#c9c0b7]"
+                onClick={() => setQueuedInsertError(null)}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          ) : null}
+          {attachmentError ? (
+            <div className="flex items-center gap-1.5 px-3 pt-1.5 text-[11px] text-[#ffb39e]">
+              <AlertCircle className="h-3 w-3 shrink-0" />
+              <span className="truncate">{attachmentError}</span>
+              <button
+                type="button"
+                className="ml-auto shrink-0 text-[#8e847d] hover:text-[#c9c0b7]"
+                onClick={() => setAttachmentError(null)}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          ) : null}
+          {promptError ? (
+            <div className="flex items-center gap-1.5 px-3 pt-1.5 text-[11px] text-[#ff8f7a]">
+              <AlertCircle className="h-3 w-3 shrink-0" />
+              <span className="truncate">{promptError}</span>
+              <button
+                type="button"
+                className="ml-auto shrink-0 text-[#8e847d] hover:text-[#c9c0b7]"
+                onClick={() => setPromptError(null)}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          ) : null}
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              void handlePromptSend();
+            }}
+            className="flex items-center gap-2 px-2 py-2 lg:px-3"
+          >
+            <input
+              ref={promptInputRef}
+              type="text"
+              value={promptMessage}
+              onChange={(event) => setPromptMessage(event.target.value)}
+              placeholder="Send a follow-up message…"
+              enterKeyHint="done"
+              disabled={promptSending}
+              className="h-8 min-w-0 flex-1 rounded-md border border-white/10 bg-[#0c0808] px-2.5 text-[12px] text-[#efe8e1] outline-none placeholder:text-[#7d746e] focus:border-white/20 disabled:opacity-50"
+              onKeyDown={(event) => {
+                if (event.key === "Escape") {
+                  event.preventDefault();
+                  event.currentTarget.blur();
+                }
+              }}
+            />
+            <Button
+              type="submit"
+              size="icon"
+              variant="ghost"
+              disabled={promptSending || promptMessage.trim().length === 0}
+              className="h-8 w-8 shrink-0 rounded-md border border-white/10 bg-[#0c0808] text-[#c9c0b7] hover:bg-[#201818] disabled:opacity-30"
+              aria-label="Send message"
+            >
+              {promptSending ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Send className="h-3.5 w-3.5" />
+              )}
+            </Button>
+          </form>
+        </div>
+      ) : null}
     </div>
   );
 }
 
-export const SessionTerminal = memo(SessionTerminalView);
+function arePendingInsertRequestsEqual(
+  left: SessionTerminalProps["pendingInsert"],
+  right: SessionTerminalProps["pendingInsert"],
+): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  return left.nonce === right.nonce && left.inlineText === right.inlineText;
+}
+
+function sessionTerminalPropsEqual(
+  previous: SessionTerminalProps,
+  next: SessionTerminalProps,
+): boolean {
+  return (
+    previous.sessionId === next.sessionId
+    && previous.projectId === next.projectId
+    && previous.bridgeId === next.bridgeId
+    && previous.sessionState === next.sessionState
+    && previous.runtimeMode === next.runtimeMode
+    && previous.immersiveMobileMode === next.immersiveMobileMode
+    && (previous.panelVisible ?? true) === (next.panelVisible ?? true)
+    && arePendingInsertRequestsEqual(previous.pendingInsert, next.pendingInsert)
+  );
+}
+
+function SessionTerminalContainer(props: SessionTerminalProps) {
+  return <SessionTerminalView {...props} />;
+}
+
+export const SessionTerminal = memo(SessionTerminalContainer, sessionTerminalPropsEqual);

--- a/packages/web/src/components/sessions/SessionTerminal.tsx
+++ b/packages/web/src/components/sessions/SessionTerminal.tsx
@@ -1,91 +1,35 @@
 "use client";
 
-/**
- * Supported live terminal: one iframe to the ttyd HTML/WebSocket facade. Wired from
- * `SessionDetail` via `sessionTerminalRouting` (same-origin embed; Polyscope and similar hosts depend on this path).
- */
-
 import {
   AlertCircle,
   Clipboard,
   FileUp,
   Loader2,
   RefreshCw,
-  Send,
   SquareStop,
   X,
 } from "lucide-react";
-import { memo, useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+} from "react";
 import { Button } from "@/components/ui/Button";
 import { uploadProjectAttachments } from "@/components/sessions/attachmentUploads";
+import {
+  calculateMobileTerminalViewportMetrics,
+} from "@/components/sessions/sessionTerminalUtils";
+import type { SessionTerminalProps } from "@/components/sessions/terminal/terminalTypes";
 import { withBridgeQuery } from "@/lib/bridgeQuery";
-import { buildSessionHref } from "@/lib/dashboardHref";
-import { LIVE_TERMINAL_STATUSES } from "./terminal/terminalConstants";
-import { resolveTerminalConnection } from "./terminal/terminalApi";
-import { extractTerminalAuthToken } from "./terminal/terminalToken";
-import { terminalUrlNeedsReload } from "./terminal/terminalUrl";
-import { calculateMobileTerminalViewportMetrics } from "./sessionTerminalUtils";
-import type { SessionTerminalProps } from "./terminal/terminalTypes";
 
-const TERMINAL_CLOSED_STATUSES = new Set(["archived", "killed", "terminated", "restored"]);
-const TOKEN_REFRESH_LEAD_SECONDS = 30;
-const TTYD_AUTH_TOKEN_MESSAGE_TYPE = "conductor-ttyd-auth-token";
-const TTYD_AUTH_TOKEN_REQUEST_MESSAGE_TYPE = "conductor-ttyd-auth-token-request";
 const TTYD_READY_MESSAGE_TYPE = "conductor-ttyd-ready";
-const TTYD_RELAY_URL_MESSAGE_TYPE = "conductor-ttyd-relay-url";
-const TERMINAL_RESIZE_DEBOUNCE_MS = 150;
 const TERMINAL_RESIZE_MESSAGE_TYPE = "conductor-terminal-resize";
-/** Staggered fits so xterm catches up after ttyd boot, layout, and fonts. */
-const TERMINAL_RESIZE_BURST_DELAYS_MS = [0, 50, 150, 400, 1000] as const;
-const TERMINAL_LIFECYCLE_REFRESH_THROTTLE_MS = 1_500;
-const TERMINAL_IFRAME_LOAD_TIMEOUT_MS = 25_000;
-
-function computeTokenRefreshDelayMs(expiresInSeconds: number | null | undefined): number | null {
-  if (typeof expiresInSeconds !== "number" || !Number.isFinite(expiresInSeconds) || expiresInSeconds <= 0) {
-    return null;
-  }
-  const safeSeconds = Math.max(5, expiresInSeconds - TOKEN_REFRESH_LEAD_SECONDS);
-  return safeSeconds * 1000;
-}
-
-/**
- * Check if the new URL differs from the current URL ONLY in the token parameter.
- * If true, we can update the token via postMessage without reloading the iframe.
- */
-function isOnlyTokenChanged(
-  current: string | null | undefined,
-  next: string,
-): boolean {
-  if (!current) return false;
-
-  try {
-    const currentUrl = new URL(current);
-    const nextUrl = new URL(next);
-
-    // Must be same origin, path, and all query params except token
-    if (currentUrl.origin !== nextUrl.origin) return false;
-    if (currentUrl.pathname !== nextUrl.pathname) return false;
-
-    // Compare all params except token
-    const currentParams = new URLSearchParams(currentUrl.searchParams);
-    const nextParams = new URLSearchParams(nextUrl.searchParams);
-
-    currentParams.delete("token");
-    nextParams.delete("token");
-
-    // Check if remaining params are the same
-    const currentStr = currentParams.toString();
-    const nextStr = nextParams.toString();
-    if (currentStr !== nextStr) return false;
-
-    // Token must actually be different
-    const currentToken = new URL(current).searchParams.get("token");
-    const nextToken = new URL(next).searchParams.get("token");
-    return currentToken !== nextToken;
-  } catch {
-    return false;
-  }
-}
+const TERMINAL_RESIZE_DEBOUNCE_MS = 150;
+const TERMINAL_RESIZE_BURST_DELAYS_MS = [0, 50, 150, 400] as const;
 
 async function sendTerminalKeys(
   sessionId: string,
@@ -108,771 +52,83 @@ async function sendTerminalKeys(
   }
 }
 
-function postTerminalAuthToken(
-  iframe: HTMLIFrameElement | null | undefined,
-  token: string | null,
-): void {
-  if (!iframe || !token || iframe.contentWindow === null) {
-    return;
-  }
-
-  let targetOrigin: string;
-  try {
-    targetOrigin = new URL(iframe.src).origin;
-  } catch {
-    // Same-origin dashboard: never use "*" for auth tokens (avoids leaking to embedded content).
-    targetOrigin = typeof window !== "undefined" ? window.location.origin : "";
-  }
-  if (!targetOrigin || targetOrigin === "null") {
-    return;
-  }
-
-  iframe.contentWindow.postMessage(
-    { type: TTYD_AUTH_TOKEN_MESSAGE_TYPE, token },
-    targetOrigin,
-  );
-}
-
-function postTerminalResizeMessage(iframe: HTMLIFrameElement | null | undefined): void {
-  if (!iframe?.contentWindow) {
-    return;
-  }
-  let targetOrigin: string;
-  try {
-    targetOrigin = new URL(iframe.src).origin;
-  } catch {
-    targetOrigin = typeof window !== "undefined" ? window.location.origin : "";
-  }
-  if (!targetOrigin || targetOrigin === "null") {
-    return;
-  }
-  try {
-    iframe.contentWindow.postMessage({ type: TERMINAL_RESIZE_MESSAGE_TYPE }, targetOrigin);
-  } catch {
-    // Iframe may have navigated or origin may be opaque.
-  }
-}
-
-function postBridgeRelayUrl(
-  iframe: HTMLIFrameElement | null | undefined,
-  relayTtydWsUrl: string | null,
-): void {
-  if (!iframe?.contentWindow || !relayTtydWsUrl) {
-    return;
-  }
-
-  let targetOrigin: string;
-  try {
-    targetOrigin = new URL(iframe.src).origin;
-  } catch {
-    targetOrigin = typeof window !== "undefined" ? window.location.origin : "";
-  }
-  if (!targetOrigin || targetOrigin === "null") {
-    return;
-  }
-
-  try {
-    iframe.contentWindow.postMessage(
-      { type: TTYD_RELAY_URL_MESSAGE_TYPE, relayTtydWsUrl },
-      targetOrigin,
-    );
-  } catch {
-    // Iframe may have navigated or origin may be opaque.
-  }
-}
-
-function SessionTerminalView(props: SessionTerminalProps) {
-  const {
-    sessionId,
-    projectId,
-    bridgeId,
-    sessionState,
-    runtimeMode,
-    pendingInsert,
-    immersiveMobileMode = false,
-    panelVisible = true,
-    onPendingInsertConsumed,
-  } = props;
-
-  const promptInputRef = useRef<HTMLInputElement>(null);
-  const attachmentInputRef = useRef<HTMLInputElement>(null);
+function SessionTerminalView({
+  sessionId,
+  projectId,
+  bridgeId,
+  pendingInsert,
+  immersiveMobileMode = false,
+  panelVisible = true,
+  onPendingInsertConsumed,
+}: SessionTerminalProps) {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const terminalHostRef = useRef<HTMLDivElement | null>(null);
+  const attachmentInputRef = useRef<HTMLInputElement | null>(null);
   const lastAppliedInsertNonceRef = useRef(0);
-  const retryAttemptRef = useRef(0);
-  const terminalHostRef = useRef<HTMLDivElement>(null);
-  const ttydIframeRef = useRef<HTMLIFrameElement | null>(null);
+  const pendingInsertNonceRef = useRef<number | null>(null);
   const burstResizeTimersRef = useRef<number[]>([]);
-  const frameLoadedRef = useRef(false);
-  const pageHiddenAtRef = useRef<number | null>(null);
-  const lastLifecycleRefreshAtRef = useRef(0);
-  const mountedAtRef = useRef(Date.now());
-  const firstFrameLoadedAtRef = useRef<number | null>(null);
-  const lastFrameLoadedAtRef = useRef<number | null>(null);
-  const iframeLoadCountRef = useRef(0);
-  const silentRefreshCountRef = useRef(0);
-  const resolvingRefreshCountRef = useRef(0);
-  const iframeRefreshRequestCountRef = useRef(0);
-  const retryCountRef = useRef(0);
-  const refreshTimerRef = useRef<number | null>(null);
+  const resizeSuppressUntilRef = useRef(0);
+  const lastPostedTerminalHostSizeRef = useRef<{ w: number; h: number } | null>(null);
 
-  const normalizedSessionStatus = useMemo(
-    () => sessionState.trim().toLowerCase(),
-    [sessionState],
-  );
-  const normalizedRuntimeMode = runtimeMode?.trim().toLowerCase() ?? null;
-  const ttydBacked = normalizedRuntimeMode === "ttyd";
-  const expectsLiveTerminal = ttydBacked
-    ? !TERMINAL_CLOSED_STATUSES.has(normalizedSessionStatus)
-    : LIVE_TERMINAL_STATUSES.has(normalizedSessionStatus);
-  const showPromptBar = false;
-
-  /** Read inside async token resolution so SSE churn does not abort in-flight fetches. */
-  const expectsLiveTerminalRef = useRef(expectsLiveTerminal);
-  expectsLiveTerminalRef.current = expectsLiveTerminal;
-  const terminalTokenFetchAbortRef = useRef<AbortController | null>(null);
-  const prevExpectsLiveTerminalRef = useRef<boolean | null>(null);
-
-  const [terminalUrl, setTerminalUrl] = useState<string | null>(null);
-  const [terminalLinkUrl, setTerminalLinkUrl] = useState<string | null>(null);
-  const [terminalRelayWsUrl, setTerminalRelayWsUrl] = useState<string | null>(null);
-  const [resolvingConnection, setResolvingConnection] = useState(expectsLiveTerminal);
-  const [connectionError, setConnectionError] = useState<string | null>(null);
   const [frameLoaded, setFrameLoaded] = useState(false);
-  const [connectionRefreshTick, setConnectionRefreshTick] = useState(0);
-  const [promptMessage, setPromptMessage] = useState("");
-  const [promptSending, setPromptSending] = useState(false);
-  const [promptError, setPromptError] = useState<string | null>(null);
+  const [, setKeyboardVisible] = useState(false);
   const [queuedInsertError, setQueuedInsertError] = useState<string | null>(null);
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
   const [attachmentUploading, setAttachmentUploading] = useState(false);
-  const [keyboardVisible, setKeyboardVisible] = useState(false);
-  const terminalUrlRef = useRef<string | null>(null);
-  const terminalRelayWsUrlRef = useRef<string | null>(null);
-  const forceTerminalReloadRef = useRef(false);
-  const resizeSuppressUntilRef = useRef(0);
-  /** Last host box we told the ttyd iframe to fit to — avoids spamming resize (xterm refit jumps scroll). */
-  const lastPostedTerminalHostSizeRef = useRef<{ w: number; h: number } | null>(null);
-  const prevPanelVisibleRef = useRef<boolean | null>(null);
+  const [reloadNonce, setReloadNonce] = useState(0);
+
+  const iframeSrc = useMemo(
+    () => withBridgeQuery(`/embed/terminal/${encodeURIComponent(sessionId)}`, bridgeId),
+    [bridgeId, sessionId],
+  );
 
   const clearBurstResizeTimers = useCallback(() => {
     if (typeof window === "undefined") {
       return;
     }
-    for (const id of burstResizeTimersRef.current) {
-      window.clearTimeout(id);
+    for (const timerId of burstResizeTimersRef.current) {
+      window.clearTimeout(timerId);
     }
     burstResizeTimersRef.current = [];
   }, []);
 
-  const maybePostTerminalResize = useCallback(() => {
-    const iframe = ttydIframeRef.current;
+  const postTerminalResizeMessage = useCallback(() => {
+    const iframe = iframeRef.current;
     const host = terminalHostRef.current;
-    if (typeof window === "undefined" || !iframe?.contentWindow || !host) {
+    if (!iframe?.contentWindow || !host) {
       return;
     }
     const rect = host.getBoundingClientRect();
-    const w = Math.round(rect.width);
-    const h = Math.round(rect.height);
-    if (w < 10 || h < 10) {
+    const width = Math.round(rect.width);
+    const height = Math.round(rect.height);
+    if (width < 10 || height < 10) {
       return;
     }
-    const last = lastPostedTerminalHostSizeRef.current;
-    if (last && last.w === w && last.h === h) {
+    const previous = lastPostedTerminalHostSizeRef.current;
+    if (previous && previous.w === width && previous.h === height) {
       return;
     }
-    lastPostedTerminalHostSizeRef.current = { w, h };
-    postTerminalResizeMessage(iframe);
+    lastPostedTerminalHostSizeRef.current = { w: width, h: height };
+    try {
+      iframe.contentWindow.postMessage({ type: TERMINAL_RESIZE_MESSAGE_TYPE }, window.location.origin);
+    } catch {
+      // Ignore navigation races while the iframe reloads.
+    }
   }, []);
 
   const scheduleTerminalResizeBurst = useCallback(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-    if (!ttydIframeRef.current?.contentWindow) {
+    if (typeof window === "undefined" || !iframeRef.current?.contentWindow) {
       return;
     }
     clearBurstResizeTimers();
     for (const delay of TERMINAL_RESIZE_BURST_DELAYS_MS) {
       burstResizeTimersRef.current.push(
         window.setTimeout(() => {
-          maybePostTerminalResize();
+          postTerminalResizeMessage();
         }, delay),
       );
     }
-  }, [clearBurstResizeTimers, maybePostTerminalResize]);
-
-  const syncTerminalAuthToken = useCallback(() => {
-    const token = extractTerminalAuthToken(terminalLinkUrl);
-    if (!token) {
-      return;
-    }
-
-    const iframe = ttydIframeRef.current;
-    postTerminalAuthToken(iframe, token);
-  }, [terminalLinkUrl]);
-
-  const syncBridgeRelayUrl = useCallback(() => {
-    const iframe = ttydIframeRef.current;
-    postBridgeRelayUrl(iframe, terminalRelayWsUrl);
-  }, [terminalRelayWsUrl]);
-
-  const requestSilentConnectionRefresh = useCallback((options?: {
-    force?: boolean;
-    resetResizeCache?: boolean;
-    syncCurrentToken?: boolean;
-    resolveConnection?: boolean;
-  }) => {
-    if (!expectsLiveTerminal || typeof window === "undefined") {
-      return;
-    }
-
-    const now = window.Date.now();
-    const force = options?.force === true;
-    if (!force && now - lastLifecycleRefreshAtRef.current < TERMINAL_LIFECYCLE_REFRESH_THROTTLE_MS) {
-      return;
-    }
-
-    lastLifecycleRefreshAtRef.current = now;
-
-    if (options?.resetResizeCache) {
-      lastPostedTerminalHostSizeRef.current = null;
-      resizeSuppressUntilRef.current = now + 120;
-    }
-
-    if (options?.syncCurrentToken !== false) {
-      syncTerminalAuthToken();
-      syncBridgeRelayUrl();
-      scheduleTerminalResizeBurst();
-    }
-
-    if (options?.resolveConnection) {
-      resolvingRefreshCountRef.current += 1;
-      setConnectionRefreshTick((current) => current + 1);
-    } else {
-      silentRefreshCountRef.current += 1;
-    }
-  }, [expectsLiveTerminal, scheduleTerminalResizeBurst, syncBridgeRelayUrl, syncTerminalAuthToken]);
-
-  useEffect(() => {
-    terminalUrlRef.current = terminalUrl;
-  }, [terminalUrl]);
-
-  useEffect(() => {
-    terminalRelayWsUrlRef.current = terminalRelayWsUrl;
-  }, [terminalRelayWsUrl]);
-
-  useEffect(() => {
-    frameLoadedRef.current = frameLoaded;
-  }, [frameLoaded]);
-
-  // Reset only when navigating to a different session. Including `expectsLiveTerminal`
-  // here caused full iframe teardown whenever status/metadata flickered during SSE
-  // updates — wiping the live ttyd attach and showing a false "reconnecting" state.
-  useEffect(() => {
-    lastAppliedInsertNonceRef.current = 0;
-    retryAttemptRef.current = 0;
-    setTerminalUrl(null);
-    setTerminalLinkUrl(null);
-    setTerminalRelayWsUrl(null);
-    setResolvingConnection(expectsLiveTerminal);
-    setConnectionError(null);
-    setFrameLoaded(false);
-    setConnectionRefreshTick(0);
-    setPromptMessage("");
-    setPromptSending(false);
-    setPromptError(null);
-    setQueuedInsertError(null);
-    setAttachmentError(null);
-    setAttachmentUploading(false);
-    forceTerminalReloadRef.current = false;
-    frameLoadedRef.current = false;
-    pageHiddenAtRef.current = null;
-    lastLifecycleRefreshAtRef.current = 0;
-    resizeSuppressUntilRef.current = 0;
-    lastPostedTerminalHostSizeRef.current = null;
-    firstFrameLoadedAtRef.current = null;
-    lastFrameLoadedAtRef.current = null;
-    iframeLoadCountRef.current = 0;
-    silentRefreshCountRef.current = 0;
-    resolvingRefreshCountRef.current = 0;
-    iframeRefreshRequestCountRef.current = 0;
-    retryCountRef.current = 0;
-    mountedAtRef.current = Date.now();
-    clearBurstResizeTimers();
-  }, [clearBurstResizeTimers, sessionId]);
-
-  useEffect(() => {
-    if (!TERMINAL_CLOSED_STATUSES.has(normalizedSessionStatus)) {
-      return;
-    }
-    setTerminalUrl(null);
-    setTerminalLinkUrl(null);
-    setTerminalRelayWsUrl(null);
-    setFrameLoaded(false);
-    setConnectionError(null);
-    forceTerminalReloadRef.current = false;
-  }, [normalizedSessionStatus, sessionId]);
-
-  useEffect(() => {
-    lastPostedTerminalHostSizeRef.current = null;
-  }, [terminalUrl]);
-
-  useEffect(() => {
-    return () => clearBurstResizeTimers();
-  }, [clearBurstResizeTimers]);
-
-  // When the session stops being live, abort token fetch; when it becomes live again, refetch.
-  // Debounced so rapid SSE status flickers don't tear down/rebuild the terminal connection.
-  useEffect(() => {
-    const timer = window.setTimeout(() => {
-      // Seed the ref on the very first invocation so the debounce logic
-      // always has a valid previous value to compare against.
-      if (prevExpectsLiveTerminalRef.current === null || prevExpectsLiveTerminalRef.current === undefined) {
-        prevExpectsLiveTerminalRef.current = expectsLiveTerminal;
-      }
-      const prev = prevExpectsLiveTerminalRef.current;
-      prevExpectsLiveTerminalRef.current = expectsLiveTerminal;
-      if (!expectsLiveTerminal && prev === true) {
-        terminalTokenFetchAbortRef.current?.abort();
-        setResolvingConnection(false);
-        setConnectionError(null);
-      }
-      if (expectsLiveTerminal && prev === false) {
-        setConnectionRefreshTick((current) => current + 1);
-      }
-    }, 500);
-    return () => window.clearTimeout(timer);
-  }, [expectsLiveTerminal]);
-
-  useEffect(() => {
-    if (!expectsLiveTerminalRef.current) {
-      setResolvingConnection(false);
-      return;
-    }
-
-    let cancelled = false;
-    let retryTimer: number | null = null;
-    let refreshTimer: number | null = null;
-    const abortController = new AbortController();
-    terminalTokenFetchAbortRef.current = abortController;
-    const showBlockingConnectionUi =
-      !terminalUrlRef.current || forceTerminalReloadRef.current;
-    if (showBlockingConnectionUi) {
-      setResolvingConnection(true);
-    }
-    setConnectionError(null);
-
-    void resolveTerminalConnection(sessionId, {
-      signal: abortController.signal,
-      bridgeId,
-    })
-      .then((connection) => {
-        if (cancelled || !expectsLiveTerminalRef.current) return;
-        retryAttemptRef.current = 0;
-        if (connection.interactive && connection.terminalUrl) {
-          const nextTerminalLinkUrl = connection.terminalLinkUrl ?? connection.terminalUrl;
-          const nextRelayTtydWsUrl = connection.relayTtydWsUrl ?? null;
-          const relayUrlChanged = terminalRelayWsUrlRef.current !== nextRelayTtydWsUrl;
-          const shouldReloadTerminal =
-            forceTerminalReloadRef.current ||
-            terminalUrlNeedsReload(terminalUrlRef.current, connection.terminalUrl);
-          forceTerminalReloadRef.current = false;
-
-          // Always update the external link URL and relay metadata.
-          setTerminalLinkUrl(nextTerminalLinkUrl);
-          setTerminalRelayWsUrl(nextRelayTtydWsUrl);
-
-          // Check if only the token changed - we can sync without iframe reload.
-          const onlyTokenChanged = !shouldReloadTerminal &&
-            terminalUrlRef.current &&
-            isOnlyTokenChanged(terminalUrlRef.current, connection.terminalUrl);
-
-          if (shouldReloadTerminal || !terminalUrlRef.current) {
-            // Full reload needed - either first load, forced reload, or structural URL change.
-            if (!terminalUrlRef.current) {
-              setFrameLoaded(false);
-            }
-            setTerminalUrl(connection.terminalUrl);
-          } else {
-            const iframe = ttydIframeRef.current;
-            if (onlyTokenChanged && iframe) {
-              const newToken = (() => {
-                try {
-                  return new URL(connection.terminalUrl).searchParams.get("token");
-                } catch {
-                  return null;
-                }
-              })();
-              if (newToken) {
-                postTerminalAuthToken(iframe, newToken);
-              }
-            }
-            if (relayUrlChanged && iframe) {
-              postBridgeRelayUrl(iframe, nextRelayTtydWsUrl);
-            }
-          }
-          setConnectionError(null);
-
-          const delayMs = computeTokenRefreshDelayMs(connection.expiresInSeconds);
-          if (delayMs !== null) {
-            refreshTimer = window.setTimeout(() => {
-              refreshTimerRef.current = null;
-              setConnectionRefreshTick((current) => current + 1);
-            }, delayMs);
-            refreshTimerRef.current = refreshTimer;
-          }
-          return;
-        }
-
-        if (!expectsLiveTerminalRef.current) return;
-        if (!terminalUrlRef.current) {
-          setTerminalUrl(null);
-          setTerminalLinkUrl(null);
-          setTerminalRelayWsUrl(null);
-          setFrameLoaded(false);
-        }
-        setConnectionError(connection.reason ?? "Live ttyd terminal is unavailable.");
-      })
-      .catch((error) => {
-        if (cancelled || !expectsLiveTerminalRef.current) return;
-        if (error instanceof DOMException && error.name === "AbortError") {
-          return;
-        }
-        const hasTerminal = !!terminalUrlRef.current;
-        if (!hasTerminal) {
-          setTerminalUrl(null);
-          setTerminalLinkUrl(null);
-          setTerminalRelayWsUrl(null);
-          setFrameLoaded(false);
-        }
-        setConnectionError(
-          error instanceof Error ? error.message : "Failed to resolve ttyd terminal.",
-        );
-        const attempt = retryAttemptRef.current;
-        const delay = hasTerminal ? 5000 : Math.min(4000, 500 * 2 ** attempt);
-        retryAttemptRef.current = hasTerminal ? 0 : Math.min(attempt + 1, 3);
-        retryTimer = window.setTimeout(() => {
-          setConnectionRefreshTick((current) => current + 1);
-        }, delay);
-      })
-      .finally(() => {
-        if (!cancelled && expectsLiveTerminalRef.current) {
-          setResolvingConnection(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-      abortController.abort();
-      if (terminalTokenFetchAbortRef.current === abortController) {
-        terminalTokenFetchAbortRef.current = null;
-      }
-      if (retryTimer !== null) {
-        window.clearTimeout(retryTimer);
-      }
-      if (refreshTimer !== null) {
-        window.clearTimeout(refreshTimer);
-      }
-      if (refreshTimerRef.current !== null) {
-        window.clearTimeout(refreshTimerRef.current);
-        refreshTimerRef.current = null;
-      }
-    };
-  }, [bridgeId, connectionRefreshTick, sessionId]);
-
-  useEffect(() => {
-    const previous = prevPanelVisibleRef.current;
-    prevPanelVisibleRef.current = panelVisible;
-    if (!panelVisible) {
-      return;
-    }
-    // When the terminal panel becomes visible again, silently refresh auth/cookie state
-    // instead of showing a blocking reload path. This keeps reconnects feeling attached
-    // to the same terminal surface.
-    let outerRaf = 0;
-    let innerRaf = 0;
-    if (previous === false) {
-      requestSilentConnectionRefresh({ resetResizeCache: true, resolveConnection: false });
-      // Radix tabs keep inactive panels mounted (`forceMount`) with opacity/pointer-events
-      // toggles; layout can settle after the first paint. A double-rAF gives ttyd's
-      // FitAddon a stable host box instead of a transient zero or collapsed size.
-      outerRaf = requestAnimationFrame(() => {
-        innerRaf = requestAnimationFrame(() => {
-          lastPostedTerminalHostSizeRef.current = null;
-          scheduleTerminalResizeBurst();
-          maybePostTerminalResize();
-        });
-      });
-    }
-    return () => {
-      cancelAnimationFrame(outerRaf);
-      cancelAnimationFrame(innerRaf);
-    };
-  }, [
-    maybePostTerminalResize,
-    panelVisible,
-    requestSilentConnectionRefresh,
-    scheduleTerminalResizeBurst,
-  ]);
-
-  const requestLifecycleRefresh = useCallback(() => {
-    if (!expectsLiveTerminal || typeof window === "undefined") {
-      return;
-    }
-
-    const now = window.Date.now();
-    const hiddenDuration = pageHiddenAtRef.current === null
-      ? 0
-      : now - pageHiddenAtRef.current;
-    pageHiddenAtRef.current = null;
-
-    // Passive lifecycle events should keep the current terminal identity hot without
-    // minting a brand-new ttyd/relay target. If the embedded terminal actually lost
-    // its websocket, the iframe shim will request an active refresh explicitly.
-    requestSilentConnectionRefresh({
-      force: hiddenDuration > 0,
-      resetResizeCache: hiddenDuration > 0,
-      resolveConnection: false,
-    });
-  }, [expectsLiveTerminal, requestSilentConnectionRefresh]);
-
-  useEffect(() => {
-    if (typeof window === "undefined" || typeof document === "undefined") {
-      return;
-    }
-
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === "hidden") {
-        pageHiddenAtRef.current = window.Date.now();
-        // Suppress resize to avoid ResizeObserver fitting while the browser/webview
-        // reports zero or intermediate sizes during tab or window transitions.
-        resizeSuppressUntilRef.current = window.Date.now() + 320;
-        // Pause token refresh while the page is hidden to avoid wasted fetches.
-        if (refreshTimerRef.current !== null) {
-          window.clearTimeout(refreshTimerRef.current);
-          refreshTimerRef.current = null;
-        }
-        return;
-      }
-
-      if (document.visibilityState === "visible") {
-        // Let layout settle (Radix tabs, split view, embedded webviews) before xterm fit.
-        resizeSuppressUntilRef.current = window.Date.now() + 200;
-        requestLifecycleRefresh();
-        // Bump connectionRefreshTick to force a fresh token resolve and
-        // re-establish the proactive refresh schedule that was cancelled
-        // when the page went hidden.
-        setConnectionRefreshTick((current) => current + 1);
-      }
-    };
-    const handlePageShow = () => {
-      requestLifecycleRefresh();
-    };
-
-    const handleOnline = () => {
-      requestLifecycleRefresh();
-    };
-
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-    window.addEventListener("pageshow", handlePageShow);
-    window.addEventListener("online", handleOnline);
-
-    return () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-      window.removeEventListener("pageshow", handlePageShow);
-      window.removeEventListener("online", handleOnline);
-    };
-  }, [requestLifecycleRefresh]);
-
-  useEffect(() => {
-    if (typeof window === "undefined" || !panelVisible || !expectsLiveTerminal) {
-      return;
-    }
-
-    const handleWindowFocus = () => {
-      resizeSuppressUntilRef.current = window.Date.now() + 120;
-      lastPostedTerminalHostSizeRef.current = null;
-      scheduleTerminalResizeBurst();
-      requestAnimationFrame(() => {
-        maybePostTerminalResize();
-      });
-    };
-
-    window.addEventListener("focus", handleWindowFocus);
-    return () => {
-      window.removeEventListener("focus", handleWindowFocus);
-    };
-  }, [expectsLiveTerminal, maybePostTerminalResize, panelVisible, scheduleTerminalResizeBurst]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-
-    const handleMessage = (event: MessageEvent) => {
-      if (!event.data || typeof event.data !== "object") {
-        return;
-      }
-      if (event.source !== ttydIframeRef.current?.contentWindow) {
-        return;
-      }
-
-      const type = (event.data as { type?: string }).type;
-      if (type === TTYD_READY_MESSAGE_TYPE) {
-        setFrameLoaded(true);
-        setConnectionError(null);
-        scheduleTerminalResizeBurst();
-        maybePostTerminalResize();
-        return;
-      }
-      if (type !== TTYD_AUTH_TOKEN_REQUEST_MESSAGE_TYPE) {
-        return;
-      }
-
-      iframeRefreshRequestCountRef.current += 1;
-      requestSilentConnectionRefresh({ force: true, resetResizeCache: true, resolveConnection: true });
-    };
-
-    window.addEventListener("message", handleMessage);
-    return () => {
-      window.removeEventListener("message", handleMessage);
-    };
-  }, [maybePostTerminalResize, requestSilentConnectionRefresh, scheduleTerminalResizeBurst]);
-
-  useEffect(() => {
-    if (!pendingInsert || pendingInsert.nonce <= lastAppliedInsertNonceRef.current) {
-      return;
-    }
-
-    lastAppliedInsertNonceRef.current = pendingInsert.nonce;
-    const inlineText = pendingInsert.inlineText.trim();
-    if (inlineText.length === 0) {
-      return;
-    }
-
-    let cancelled = false;
-    void sendTerminalKeys(sessionId, `${inlineText} `, bridgeId)
-      .then(() => {
-        if (!cancelled) {
-          setQueuedInsertError(null);
-          onPendingInsertConsumed?.();
-        }
-      })
-      .catch((error) => {
-        if (!cancelled) {
-          setQueuedInsertError(
-            error instanceof Error ? error.message : "Failed to queue terminal input.",
-          );
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [bridgeId, onPendingInsertConsumed, pendingInsert, sessionId]);
-
-  useEffect(() => {
-    if (!frameLoaded) {
-      return;
-    }
-
-    syncTerminalAuthToken();
-    syncBridgeRelayUrl();
-  }, [frameLoaded, syncBridgeRelayUrl, syncTerminalAuthToken]);
-
-  useEffect(() => {
-    if (!expectsLiveTerminal || !terminalUrl || frameLoaded) {
-      return;
-    }
-    const timer = window.setTimeout(() => {
-      if (!frameLoadedRef.current) {
-        setConnectionError(
-          "The terminal view did not finish loading in time. Try reload or open in a new tab.",
-        );
-      }
-    }, TERMINAL_IFRAME_LOAD_TIMEOUT_MS);
-    return () => window.clearTimeout(timer);
-  }, [expectsLiveTerminal, frameLoaded, terminalUrl]);
-
-  const handlePromptSend = useCallback(async () => {
-    const message = promptMessage.trim();
-    if (message.length === 0 || promptSending) return;
-
-    setPromptSending(true);
-    setPromptError(null);
-    try {
-      const response = await fetch(
-        withBridgeQuery(`/api/sessions/${encodeURIComponent(sessionId)}/actions`, bridgeId),
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ action: "send", message }),
-        },
-      );
-      if (!response.ok) {
-        const data = (await response.json().catch(() => null)) as { error?: string } | null;
-        throw new Error(data?.error ?? `Failed to send message (${response.status})`);
-      }
-      setPromptMessage("");
-      promptInputRef.current?.focus();
-    } catch (error) {
-      setPromptError(error instanceof Error ? error.message : "Failed to send message");
-    } finally {
-      setPromptSending(false);
-    }
-  }, [bridgeId, promptMessage, promptSending, sessionId]);
-
-  const handleMobilePaste = useCallback(async () => {
-    try {
-      const text = await navigator.clipboard.readText();
-      if (text) {
-        await sendTerminalKeys(sessionId, text, bridgeId);
-      }
-    } catch {
-      // Clipboard read may fail due to permissions or unsupported browser
-    }
-  }, [bridgeId, sessionId]);
-
-  const handleAttachmentPick = useCallback(() => {
-    attachmentInputRef.current?.click();
-  }, []);
-
-  const handleAttachmentFiles = useCallback(
-    async (event: ChangeEvent<HTMLInputElement>) => {
-      const { files } = event.target;
-      event.target.value = "";
-      if (!files || files.length === 0) {
-        return;
-      }
-
-      setAttachmentError(null);
-      setAttachmentUploading(true);
-      try {
-        const uploadedPaths = await uploadProjectAttachments({
-          files: Array.from(files),
-          projectId,
-          taskRef: sessionId,
-          bridgeId,
-        });
-        for (const path of uploadedPaths) {
-          await sendTerminalKeys(sessionId, `\r\n[attached file: ${path}]\r\n`, bridgeId);
-        }
-      } catch (error) {
-        setAttachmentError(
-          error instanceof Error ? error.message : "Failed to upload attachment.",
-        );
-      } finally {
-        setAttachmentUploading(false);
-      }
-    },
-    [bridgeId, projectId, sessionId],
-  );
-
-  const handleSoftStop = useCallback(async () => {
-    // Send Ctrl+C (0x03) to interrupt the running process
-    await sendTerminalKeys(sessionId, "\x03", bridgeId);
-  }, [bridgeId, sessionId]);
+  }, [clearBurstResizeTimers, postTerminalResizeMessage]);
 
   const applyKeyboardAwareTerminalHeight = useCallback(() => {
     const host = terminalHostRef.current;
@@ -882,25 +138,21 @@ function SessionTerminalView(props: SessionTerminalProps) {
 
     const visualViewport = window.visualViewport;
     if (!visualViewport) {
+      host.style.height = "100%";
+      setKeyboardVisible(false);
       return;
     }
 
-    const { usableHeight, keyboardVisible } = calculateMobileTerminalViewportMetrics(
+    const { usableHeight, keyboardVisible: nextKeyboardVisible } = calculateMobileTerminalViewportMetrics(
       window.innerHeight,
       visualViewport.height,
       visualViewport.offsetTop,
       host.getBoundingClientRect().top,
     );
 
-    if (!keyboardVisible) {
-      // When keyboard is not visible, use 100% to let flex sizing work properly
+    if (!nextKeyboardVisible || usableHeight <= 0) {
       host.style.height = "100%";
       setKeyboardVisible(false);
-      return;
-    }
-
-    if (usableHeight <= 0) {
-      host.style.height = "100%";
       return;
     }
 
@@ -909,8 +161,142 @@ function SessionTerminalView(props: SessionTerminalProps) {
   }, []);
 
   useEffect(() => {
+    setFrameLoaded(false);
+    lastPostedTerminalHostSizeRef.current = null;
+  }, [iframeSrc, reloadNonce]);
+
+  useEffect(() => {
+    if (!pendingInsert) {
+      return;
+    }
+    if (pendingInsert.nonce <= lastAppliedInsertNonceRef.current) {
+      return;
+    }
+    if (pendingInsertNonceRef.current === pendingInsert.nonce) {
+      return;
+    }
+
+    const inlineText = pendingInsert.inlineText.trim();
+    if (inlineText.length === 0) {
+      lastAppliedInsertNonceRef.current = pendingInsert.nonce;
+      onPendingInsertConsumed?.();
+      return;
+    }
+
+    pendingInsertNonceRef.current = pendingInsert.nonce;
+    let cancelled = false;
+    void sendTerminalKeys(sessionId, `${inlineText} `, bridgeId)
+      .then(() => {
+        if (cancelled) {
+          return;
+        }
+        lastAppliedInsertNonceRef.current = pendingInsert.nonce;
+        pendingInsertNonceRef.current = null;
+        setQueuedInsertError(null);
+        onPendingInsertConsumed?.();
+      })
+      .catch((error) => {
+        if (cancelled) {
+          return;
+        }
+        pendingInsertNonceRef.current = null;
+        setQueuedInsertError(
+          error instanceof Error ? error.message : "Failed to queue terminal input.",
+        );
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [bridgeId, onPendingInsertConsumed, pendingInsert, sessionId]);
+
+  const handleRetry = useCallback(() => {
+    setFrameLoaded(false);
+    setReloadNonce((value) => value + 1);
+  }, []);
+
+  const handleAttachmentPick = useCallback(() => {
+    attachmentInputRef.current?.click();
+  }, []);
+
+  const handleAttachmentFiles = useCallback(async (event: ChangeEvent<HTMLInputElement>) => {
+    const { files } = event.target;
+    event.target.value = "";
+    if (!files || files.length === 0) {
+      return;
+    }
+
+    setAttachmentUploading(true);
+    setAttachmentError(null);
+    try {
+      const uploadedPaths = await uploadProjectAttachments({
+        files: Array.from(files),
+        projectId,
+        taskRef: sessionId,
+        bridgeId,
+      });
+      for (const path of uploadedPaths) {
+        await sendTerminalKeys(sessionId, `\r\n[attached file: ${path}]\r\n`, bridgeId);
+      }
+    } catch (error) {
+      setAttachmentError(
+        error instanceof Error ? error.message : "Failed to upload attachment.",
+      );
+    } finally {
+      setAttachmentUploading(false);
+    }
+  }, [bridgeId, projectId, sessionId]);
+
+  const handleMobilePaste = useCallback(async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      if (text) {
+        await sendTerminalKeys(sessionId, text, bridgeId);
+        setQueuedInsertError(null);
+      }
+    } catch {
+      setQueuedInsertError("Clipboard paste failed.");
+    }
+  }, [bridgeId, sessionId]);
+
+  const handleSoftStop = useCallback(async () => {
+    try {
+      await sendTerminalKeys(sessionId, "\x03", bridgeId);
+      setQueuedInsertError(null);
+    } catch (error) {
+      setQueuedInsertError(
+        error instanceof Error ? error.message : "Failed to send Ctrl+C.",
+      );
+    }
+  }, [bridgeId, sessionId]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleMessage = (event: MessageEvent) => {
+      if (event.source !== iframeRef.current?.contentWindow || event.origin !== window.location.origin) {
+        return;
+      }
+      if ((event.data as { type?: string } | null)?.type !== TTYD_READY_MESSAGE_TYPE) {
+        return;
+      }
+      setFrameLoaded(true);
+      lastPostedTerminalHostSizeRef.current = null;
+      scheduleTerminalResizeBurst();
+      postTerminalResizeMessage();
+    };
+
+    window.addEventListener("message", handleMessage);
+    return () => {
+      window.removeEventListener("message", handleMessage);
+    };
+  }, [postTerminalResizeMessage, scheduleTerminalResizeBurst]);
+
+  useEffect(() => {
     const host = terminalHostRef.current;
-    if (!host) {
+    if (!host || typeof window === "undefined") {
       return;
     }
 
@@ -919,62 +305,46 @@ function SessionTerminalView(props: SessionTerminalProps) {
       if (!panelVisible) {
         return;
       }
-      // Guard: skip if we're in the suppression window after a tab switch.
-      // This prevents ResizeObserver from fitting to zero/intermediate
-      // heights that occur when the container is briefly hidden.
-      if (typeof window !== "undefined" && window.Date.now() < resizeSuppressUntilRef.current) {
+      if (window.Date.now() < resizeSuppressUntilRef.current) {
         return;
       }
-
-      // Guard: skip if the host container has collapsed to near-zero height.
-      // This happens during tab switches or when the terminal is in a hidden
-      // tab panel. Fitting to zero causes xterm to lose its content layout.
-      const hostRect = host.getBoundingClientRect();
-      if (hostRect.height < 10 || hostRect.width < 10) {
+      const rect = host.getBoundingClientRect();
+      if (rect.width < 10 || rect.height < 10) {
         return;
       }
-
-      // Trailing debounce: reset the timer on every resize so the final
-      // layout wins after bursts (split view, keyboard, animations).
       if (debounceTimer !== null) {
         window.clearTimeout(debounceTimer);
-        debounceTimer = null;
       }
       debounceTimer = window.setTimeout(() => {
         debounceTimer = null;
-        // Re-check suppression and minimum size after debounce elapses.
-        if (typeof window !== "undefined" && window.Date.now() < resizeSuppressUntilRef.current) {
+        if (window.Date.now() < resizeSuppressUntilRef.current) {
           return;
         }
         const currentRect = host.getBoundingClientRect();
-        if (currentRect.height < 10 || currentRect.width < 10) {
+        if (currentRect.width < 10 || currentRect.height < 10) {
           return;
         }
-
         applyKeyboardAwareTerminalHeight();
-
-        // After the host div has resized, tell the ttyd iframe to
-        // re-fit its internal xterm.js in the same coordinated step.
-        maybePostTerminalResize();
+        postTerminalResizeMessage();
       }, TERMINAL_RESIZE_DEBOUNCE_MS);
     };
 
     applyGeometry();
 
-    const observer = typeof ResizeObserver === "undefined"
+    const resizeObserver = typeof ResizeObserver === "undefined"
       ? null
       : new ResizeObserver(() => {
         applyGeometry();
       });
-    const visualViewport = typeof window === "undefined" ? null : window.visualViewport;
+    const visualViewport = window.visualViewport;
 
-    observer?.observe(host);
+    resizeObserver?.observe(host);
     window.addEventListener("resize", applyGeometry);
     visualViewport?.addEventListener("resize", applyGeometry);
     visualViewport?.addEventListener("scroll", applyGeometry);
 
     return () => {
-      observer?.disconnect();
+      resizeObserver?.disconnect();
       window.removeEventListener("resize", applyGeometry);
       visualViewport?.removeEventListener("resize", applyGeometry);
       visualViewport?.removeEventListener("scroll", applyGeometry);
@@ -983,94 +353,61 @@ function SessionTerminalView(props: SessionTerminalProps) {
       }
       host.style.removeProperty("height");
     };
-  }, [
-    applyKeyboardAwareTerminalHeight,
-    expectsLiveTerminal,
-    maybePostTerminalResize,
-    panelVisible,
-    terminalUrl,
-  ]);
+  }, [applyKeyboardAwareTerminalHeight, panelVisible, postTerminalResizeMessage]);
 
   useEffect(() => {
-    if (process.env.NODE_ENV !== "development") return;
+    if (typeof window === "undefined") {
+      return;
+    }
 
-    window.__conductorSessionTerminalDebug = {
-      sessionId,
-      getState: () => ({
-        mode: "ttyd-iframe",
-        expectsLiveTerminal,
-        runtimeMode: normalizedRuntimeMode,
-        ttydBacked,
-        terminalUrl,
-        terminalLinkUrl,
-        terminalRelayWsUrl,
-        frameLoaded,
-        resolvingConnection,
-        connectionError,
-        promptError,
-        queuedInsertError,
-        metrics: {
-          mountedAt: new Date(mountedAtRef.current).toISOString(),
-          mountedAgeMs: Date.now() - mountedAtRef.current,
-          firstFrameLoadLatencyMs: firstFrameLoadedAtRef.current === null
-            ? null
-            : firstFrameLoadedAtRef.current - mountedAtRef.current,
-          lastFrameLoadAt: lastFrameLoadedAtRef.current === null
-            ? null
-            : new Date(lastFrameLoadedAtRef.current).toISOString(),
-          iframeLoadCount: iframeLoadCountRef.current,
-          silentRefreshCount: silentRefreshCountRef.current,
-          resolvingRefreshCount: resolvingRefreshCountRef.current,
-          iframeRequestedRefreshCount: iframeRefreshRequestCountRef.current,
-          retryCount: retryCountRef.current,
-        },
-      }),
-    };
-
-    return () => {
-      if (window.__conductorSessionTerminalDebug?.sessionId === sessionId) {
-        delete window.__conductorSessionTerminalDebug;
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        resizeSuppressUntilRef.current = window.Date.now() + 250;
+        return;
       }
+      resizeSuppressUntilRef.current = window.Date.now() + 100;
+      lastPostedTerminalHostSizeRef.current = null;
+      applyKeyboardAwareTerminalHeight();
+      scheduleTerminalResizeBurst();
     };
-  }, [
-    connectionError,
-    expectsLiveTerminal,
-    frameLoaded,
-    normalizedRuntimeMode,
-    promptError,
-    queuedInsertError,
-    resolvingConnection,
-    sessionId,
-    terminalUrl,
-    terminalLinkUrl,
-    terminalRelayWsUrl,
-    ttydBacked,
-  ]);
 
-  const handleRetry = useCallback(() => {
-    retryCountRef.current += 1;
-    setConnectionError(null);
-    retryAttemptRef.current = 0;
-    forceTerminalReloadRef.current = true;
-    setConnectionRefreshTick((current) => current + 1);
-  }, []);
+    const handleFocus = () => {
+      resizeSuppressUntilRef.current = window.Date.now() + 120;
+      lastPostedTerminalHostSizeRef.current = null;
+      applyKeyboardAwareTerminalHeight();
+      scheduleTerminalResizeBurst();
+    };
 
-  const emptyStateTitle = expectsLiveTerminal
-    ? "Connecting live terminal"
-    : showPromptBar
-      ? "Session is waiting for input"
-      : "Live terminal is not active";
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("focus", handleFocus);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("focus", handleFocus);
+    };
+  }, [applyKeyboardAwareTerminalHeight, scheduleTerminalResizeBurst]);
 
-  const emptyStateDescription = connectionError
-    ?? (expectsLiveTerminal
-      ? "Reconnecting to the existing ttyd terminal."
-      : ttydBacked
-        ? "This ttyd terminal is no longer attached. It only closes after an explicit kill or archive."
-      : showPromptBar
-        ? "Send a follow-up below to relaunch the agent in a fresh ttyd terminal."
-        : `Session status is \`${normalizedSessionStatus}\`. Interactive ttyd terminals only run while the agent is active.`);
-  const terminalDirectHref = terminalLinkUrl ?? terminalUrl ?? undefined;
-  const terminalSessionHref = buildSessionHref(sessionId, { bridgeId, tab: "terminal" });
+  useEffect(() => {
+    if (!panelVisible) {
+      return;
+    }
+    let outerRaf = 0;
+    let innerRaf = 0;
+    outerRaf = window.requestAnimationFrame(() => {
+      innerRaf = window.requestAnimationFrame(() => {
+        lastPostedTerminalHostSizeRef.current = null;
+        applyKeyboardAwareTerminalHeight();
+        scheduleTerminalResizeBurst();
+      });
+    });
+    return () => {
+      window.cancelAnimationFrame(outerRaf);
+      window.cancelAnimationFrame(innerRaf);
+    };
+  }, [applyKeyboardAwareTerminalHeight, panelVisible, reloadNonce, scheduleTerminalResizeBurst]);
+
+  useEffect(() => () => {
+    clearBurstResizeTimers();
+  }, [clearBurstResizeTimers]);
 
   return (
     <div
@@ -1086,21 +423,17 @@ function SessionTerminalView(props: SessionTerminalProps) {
           accept="*/*"
           className="sr-only"
           tabIndex={-1}
-          aria-hidden
+          aria-hidden="true"
           onChange={(event) => void handleAttachmentFiles(event)}
         />
         <Button
           type="button"
           size="icon"
           variant="ghost"
-          disabled={
-            !expectsLiveTerminal
-            || !terminalUrl
-            || attachmentUploading
-          }
           className="h-9 w-9 rounded-full border border-white/10 bg-[#141010]/92 text-[#c9c0b7] backdrop-blur-sm hover:bg-[#201818] disabled:opacity-40 sm:h-7 sm:w-7"
           onClick={handleAttachmentPick}
           aria-label="Attach photos or files"
+          disabled={attachmentUploading}
         >
           {attachmentUploading ? (
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -1108,25 +441,23 @@ function SessionTerminalView(props: SessionTerminalProps) {
             <FileUp className="h-3.5 w-3.5" />
           )}
         </Button>
-        {typeof window !== "undefined" && window.matchMedia?.("(pointer: coarse)").matches ? (
-          <Button
-            type="button"
-            size="icon"
-            variant="ghost"
-            className="h-9 w-9 rounded-full border border-white/10 bg-[#141010]/92 text-[#c9c0b7] backdrop-blur-sm hover:bg-[#201818] sm:h-7 sm:w-7"
-            onClick={handleMobilePaste}
-            aria-label="Paste from clipboard"
-          >
-            <Clipboard className="h-3.5 w-3.5" />
-          </Button>
-        ) : null}
         <Button
           type="button"
           size="icon"
           variant="ghost"
           className="h-9 w-9 rounded-full border border-white/10 bg-[#141010]/92 text-[#c9c0b7] backdrop-blur-sm hover:bg-[#201818] sm:h-7 sm:w-7"
-          onClick={handleSoftStop}
-          aria-label="Soft stop (Ctrl+C)"
+          onClick={() => void handleMobilePaste()}
+          aria-label="Paste from clipboard"
+        >
+          <Clipboard className="h-3.5 w-3.5" />
+        </Button>
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className="h-9 w-9 rounded-full border border-white/10 bg-[#141010]/92 text-[#c9c0b7] backdrop-blur-sm hover:bg-[#201818] sm:h-7 sm:w-7"
+          onClick={() => void handleSoftStop()}
+          aria-label="Soft stop terminal"
         >
           <SquareStop className="h-3.5 w-3.5" />
         </Button>
@@ -1136,9 +467,9 @@ function SessionTerminalView(props: SessionTerminalProps) {
           variant="ghost"
           className="h-9 w-9 rounded-full border border-white/10 bg-[#141010]/92 text-[#c9c0b7] backdrop-blur-sm hover:bg-[#201818] sm:h-7 sm:w-7"
           onClick={handleRetry}
-          aria-label="Reload ttyd terminal"
+          aria-label="Reload terminal"
         >
-          {resolvingConnection ? (
+          {!frameLoaded ? (
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
           ) : (
             <RefreshCw className="h-3.5 w-3.5" />
@@ -1147,94 +478,48 @@ function SessionTerminalView(props: SessionTerminalProps) {
       </div>
 
       <div
-        className={
-          immersiveMobileMode
-            ? "min-h-0 min-w-0 h-0 flex-1 overflow-hidden px-0 pb-[env(safe-area-inset-bottom)] pt-0 w-full"
-            : "min-h-0 min-w-0 h-0 flex-1 overflow-hidden px-0.5 pb-0 pt-0.5 lg:px-1.5 lg:pb-1 lg:pt-3 w-full"
-        }
+        className={immersiveMobileMode
+          ? "min-h-0 min-w-0 h-0 flex-1 overflow-hidden px-0 pb-[env(safe-area-inset-bottom)] pt-0 w-full"
+          : "min-h-0 min-w-0 h-0 flex-1 overflow-hidden px-0.5 pb-0 pt-0.5 lg:px-1.5 lg:pb-1 lg:pt-3 w-full"}
       >
-        {expectsLiveTerminal && terminalUrl ? (
-          <div
-            ref={terminalHostRef}
-            className="relative flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden rounded-[10px] bg-[#060404] pb-[env(safe-area-inset-bottom)]"
-          >
-            {!frameLoaded ? (
-              <div className="absolute inset-0 z-10 flex items-center justify-center bg-[#060404]">
-                <div className="flex items-center gap-2 rounded-full border border-white/10 bg-[#141010]/92 px-3 py-2 text-[12px] text-[#c9c0b7] backdrop-blur-sm">
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                  <span>Loading ttyd terminal…</span>
-                </div>
-              </div>
-            ) : null}
-            <iframe
-              key={sessionId}
-              ref={ttydIframeRef}
-              title={`ttyd terminal for ${sessionId}`}
-              src={terminalUrl}
-              className="block h-full min-h-0 w-full flex-1 border-0 bg-[#060404]"
-              allow="clipboard-read; clipboard-write"
-              loading="eager"
-              onError={() => {
-                setConnectionError("Failed to load the terminal frame. Try reload or open in a new tab.");
-              }}
-              onLoad={() => {
-                const now = Date.now();
-                iframeLoadCountRef.current += 1;
-                lastFrameLoadedAtRef.current = now;
-                if (firstFrameLoadedAtRef.current === null) {
-                  firstFrameLoadedAtRef.current = now;
-                }
-                setFrameLoaded(true);
-                setConnectionError(null);
-                applyKeyboardAwareTerminalHeight();
-                syncTerminalAuthToken();
-                syncBridgeRelayUrl();
-                scheduleTerminalResizeBurst();
-              }}
-            />
-          </div>
-        ) : (
-          <div className="flex h-full items-center justify-center p-4">
-            <div className="max-w-lg rounded-[16px] border border-white/10 bg-[#141010]/92 p-5 text-[#efe8e1] shadow-[0_24px_48px_rgba(0,0,0,0.34)]">
-              <div className="flex items-start gap-3">
-                <div className="mt-0.5 rounded-full border border-white/10 bg-[#201818] p-2 text-[#c9c0b7]">
-                  {connectionError ? (
-                    <AlertCircle className="h-4 w-4" />
-                  ) : (
-                    <Loader2 className={`h-4 w-4 ${resolvingConnection ? "animate-spin" : ""}`} />
-                  )}
-                </div>
-                <div className="min-w-0 flex-1">
-                  <div className="text-[14px] font-medium">{emptyStateTitle}</div>
-                  <div className="mt-1 text-[12px] leading-5 text-[#a79c94]">{emptyStateDescription}</div>
-                  {terminalDirectHref ? (
-                    <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1">
-                      <a
-                        href={terminalSessionHref}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="text-[12px] text-[#d7c6b7] underline underline-offset-4"
-                      >
-                        Open the full terminal page
-                      </a>
-                      <a
-                        href={terminalDirectHref}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="text-[12px] text-[#a79c94] underline underline-offset-4"
-                      >
-                        Open the ttyd terminal directly
-                      </a>
-                    </div>
-                  ) : null}
-                </div>
+        <div
+          ref={terminalHostRef}
+          className="relative flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden rounded-[10px] bg-[#060404] pb-[env(safe-area-inset-bottom)]"
+        >
+          {!frameLoaded ? (
+            <div className="absolute inset-0 z-10 flex items-center justify-center bg-[#060404]">
+              <div className="flex items-center gap-2 rounded-full border border-white/10 bg-[#141010]/92 px-3 py-2 text-[12px] text-[#c9c0b7] backdrop-blur-sm">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                <span>Loading terminal…</span>
               </div>
             </div>
-          </div>
-        )}
+          ) : null}
+          <iframe
+            key={`${sessionId}:${reloadNonce}`}
+            ref={iframeRef}
+            src={iframeSrc}
+            title={`Conductor terminal ${sessionId}`}
+            className="block h-full min-h-0 w-full flex-1 border-0 bg-[#060404]"
+            allow="clipboard-read; clipboard-write"
+            loading="eager"
+            onError={() => {
+              setFrameLoaded(false);
+            }}
+            onLoad={() => {
+              setFrameLoaded(true);
+              lastPostedTerminalHostSizeRef.current = null;
+              applyKeyboardAwareTerminalHeight();
+              scheduleTerminalResizeBurst();
+              postTerminalResizeMessage();
+            }}
+          />
+          {!panelVisible && !frameLoaded ? (
+            <div className="pointer-events-none absolute inset-0 bg-[#060404]" />
+          ) : null}
+        </div>
       </div>
 
-      {!showPromptBar && (queuedInsertError || attachmentError) ? (
+      {queuedInsertError || attachmentError ? (
         <div className="absolute inset-x-0 bottom-0 z-10 border-t border-white/12 bg-[#161212] px-3 py-2 text-[11px] text-[#ffb39e] backdrop-blur-sm [padding-bottom:env(safe-area-inset-bottom)]">
           {queuedInsertError ? (
             <div className="flex items-center gap-1.5">
@@ -1244,6 +529,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
                 type="button"
                 className="ml-auto shrink-0 text-[#8e847d] hover:text-[#c9c0b7]"
                 onClick={() => setQueuedInsertError(null)}
+                aria-label="Dismiss queued insert error"
               >
                 <X className="h-3 w-3" />
               </button>
@@ -1257,141 +543,16 @@ function SessionTerminalView(props: SessionTerminalProps) {
                 type="button"
                 className="ml-auto shrink-0 text-[#8e847d] hover:text-[#c9c0b7]"
                 onClick={() => setAttachmentError(null)}
+                aria-label="Dismiss attachment error"
               >
                 <X className="h-3 w-3" />
               </button>
             </div>
           ) : null}
-        </div>
-      ) : null}
-
-      {showPromptBar ? (
-        <div className="absolute inset-x-0 bottom-0 z-10 border-t border-white/12 bg-[#161212] backdrop-blur-sm [padding-bottom:env(safe-area-inset-bottom)]">
-          {queuedInsertError ? (
-            <div className="flex items-center gap-1.5 px-3 pt-1.5 text-[11px] text-[#ffb39e]">
-              <AlertCircle className="h-3 w-3 shrink-0" />
-              <span className="truncate">{queuedInsertError}</span>
-              <button
-                type="button"
-                className="ml-auto shrink-0 text-[#8e847d] hover:text-[#c9c0b7]"
-                onClick={() => setQueuedInsertError(null)}
-              >
-                <X className="h-3 w-3" />
-              </button>
-            </div>
-          ) : null}
-          {attachmentError ? (
-            <div className="flex items-center gap-1.5 px-3 pt-1.5 text-[11px] text-[#ffb39e]">
-              <AlertCircle className="h-3 w-3 shrink-0" />
-              <span className="truncate">{attachmentError}</span>
-              <button
-                type="button"
-                className="ml-auto shrink-0 text-[#8e847d] hover:text-[#c9c0b7]"
-                onClick={() => setAttachmentError(null)}
-              >
-                <X className="h-3 w-3" />
-              </button>
-            </div>
-          ) : null}
-          {promptError ? (
-            <div className="flex items-center gap-1.5 px-3 pt-1.5 text-[11px] text-[#ff8f7a]">
-              <AlertCircle className="h-3 w-3 shrink-0" />
-              <span className="truncate">{promptError}</span>
-              <button
-                type="button"
-                className="ml-auto shrink-0 text-[#8e847d] hover:text-[#c9c0b7]"
-                onClick={() => setPromptError(null)}
-              >
-                <X className="h-3 w-3" />
-              </button>
-            </div>
-          ) : null}
-          <form
-            onSubmit={(event) => {
-              event.preventDefault();
-              void handlePromptSend();
-            }}
-            className="flex items-center gap-2 px-2 py-2 lg:px-3"
-          >
-            <input
-              ref={promptInputRef}
-              type="text"
-              value={promptMessage}
-              onChange={(event) => setPromptMessage(event.target.value)}
-              placeholder="Send a follow-up message…"
-              enterKeyHint="done"
-              disabled={promptSending}
-              className="h-8 min-w-0 flex-1 rounded-md border border-white/10 bg-[#0c0808] px-2.5 text-[12px] text-[#efe8e1] outline-none placeholder:text-[#7d746e] focus:border-white/20 disabled:opacity-50"
-              onKeyDown={(event) => {
-                if (event.key === "Escape") {
-                  event.preventDefault();
-                  event.currentTarget.blur();
-                }
-              }}
-            />
-            <Button
-              type="submit"
-              size="icon"
-              variant="ghost"
-              disabled={promptSending || promptMessage.trim().length === 0}
-              className="h-8 w-8 shrink-0 rounded-md border border-white/10 bg-[#0c0808] text-[#c9c0b7] hover:bg-[#201818] disabled:opacity-30"
-              aria-label="Send message"
-            >
-              {promptSending ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <Send className="h-3.5 w-3.5" />
-              )}
-            </Button>
-          </form>
         </div>
       ) : null}
     </div>
   );
 }
 
-function arePendingInsertRequestsEqual(
-  left: SessionTerminalProps["pendingInsert"],
-  right: SessionTerminalProps["pendingInsert"],
-): boolean {
-  if (left === right) return true;
-  if (!left || !right) return false;
-  return left.nonce === right.nonce && left.inlineText === right.inlineText;
-}
-
-function sessionTerminalPropsEqual(
-  previous: SessionTerminalProps,
-  next: SessionTerminalProps,
-): boolean {
-  const previousPanelVisible = previous.panelVisible ?? true;
-  const nextPanelVisible = next.panelVisible ?? true;
-
-  if (
-    previous.sessionId !== next.sessionId
-    || previous.projectId !== next.projectId
-    || previous.bridgeId !== next.bridgeId
-    || previousPanelVisible !== nextPanelVisible
-    || !arePendingInsertRequestsEqual(previous.pendingInsert, next.pendingInsert)
-  ) {
-    return false;
-  }
-
-  // Keep inactive terminal surfaces stable so tab switches do not thrash the embedded iframe.
-  // background session-status churn. Apply the latest runtime/status only when it becomes
-  // visible again.
-  if (!previousPanelVisible && !nextPanelVisible) {
-    return true;
-  }
-
-  return (
-    previous.sessionState === next.sessionState
-    && previous.runtimeMode === next.runtimeMode
-    && previous.immersiveMobileMode === next.immersiveMobileMode
-  );
-}
-
-function SessionTerminalContainer(props: SessionTerminalProps) {
-  return <SessionTerminalView {...props} />;
-}
-
-export const SessionTerminal = memo(SessionTerminalContainer, sessionTerminalPropsEqual);
+export const SessionTerminal = memo(SessionTerminalView);

--- a/packages/web/src/components/sessions/terminal/terminalApi.test.ts
+++ b/packages/web/src/components/sessions/terminal/terminalApi.test.ts
@@ -157,7 +157,7 @@ test("resolveTerminalConnection resolves proxy ttyd paths against the current da
   );
 });
 
-test("resolveTerminalConnection falls back to the embedded iframe page when only the native terminal websocket exists", async () => {
+test("resolveTerminalConnection keeps the pre-390 direct terminal path when only the native terminal websocket exists", async () => {
   setWindowLocation("https://dashboard.example.com/sessions/session-3");
   setFetchResponse({
     required: true,
@@ -171,12 +171,9 @@ test("resolveTerminalConnection falls back to the embedded iframe page when only
   assert.equal(connection.reason, null);
   assert.equal(
     connection.terminalUrl,
-    "https://dashboard.example.com/embed/terminal/session-3",
+    "https://dashboard.example.com/api/sessions/session-3/terminal?token=native-token",
   );
-  assert.equal(
-    connection.terminalLinkUrl,
-    "https://dashboard.example.com/embed/terminal/session-3",
-  );
+  assert.equal(connection.terminalLinkUrl, undefined);
 });
 
 test("resolveTerminalConnection preserves bridge scope on proxied ttyd routes", async () => {
@@ -198,7 +195,7 @@ test("resolveTerminalConnection preserves bridge scope on proxied ttyd routes", 
   );
 });
 
-test("resolveTerminalConnection keeps the embedded iframe on the proxied ttyd path even when a tunnel url exists", async () => {
+test("resolveTerminalConnection uses the direct ttyd tunnel url when one is available", async () => {
   setWindowLocation("https://dashboard.example.com/sessions/session-4");
   setBackendOriginMeta("https://api.example.com/internal");
   setFetchResponse({
@@ -213,15 +210,12 @@ test("resolveTerminalConnection keeps the embedded iframe on the proxied ttyd pa
   assert.equal(connection.interactive, true);
   assert.equal(
     connection.terminalUrl,
-    "https://dashboard.example.com/api/sessions/session-4/terminal/ttyd?token=proxy-token",
-  );
-  assert.equal(
-    connection.terminalLinkUrl,
     "https://violet-waterfall.trycloudflare.com/?token=proxy-token",
   );
+  assert.equal(connection.terminalLinkUrl, undefined);
 });
 
-test("resolveTerminalConnection keeps direct terminal links on the proxy origin when auth is cookie-scoped", async () => {
+test("resolveTerminalConnection keeps cookie-scoped ttyd sessions on the direct terminal tunnel when available", async () => {
   setWindowLocation("https://dashboard.example.com/sessions/session-cookie");
   setBackendOriginMeta("https://api.example.com/internal");
   setFetchResponse({
@@ -237,15 +231,12 @@ test("resolveTerminalConnection keeps direct terminal links on the proxy origin 
   assert.equal(connection.interactive, true);
   assert.equal(
     connection.terminalUrl,
-    "https://dashboard.example.com/api/sessions/session-cookie/terminal/ttyd",
+    "https://violet-waterfall.trycloudflare.com/",
   );
-  assert.equal(
-    connection.terminalLinkUrl,
-    "https://dashboard.example.com/api/sessions/session-cookie/terminal/ttyd",
-  );
+  assert.equal(connection.terminalLinkUrl, undefined);
 });
 
-test("resolveTerminalConnection keeps bridge iframe urls stable and exposes relay websocket refresh metadata", async () => {
+test("resolveTerminalConnection keeps the pre-390 bridge ttyd iframe path and does not expose relay refresh metadata", async () => {
   setWindowLocation("https://app.conductross.com/sessions/bridge-session");
   setBackendOriginMeta("https://api.conductross.com");
   setFetchResponse({
@@ -262,12 +253,6 @@ test("resolveTerminalConnection keeps bridge iframe urls stable and exposes rela
     connection.terminalUrl,
     "https://app.conductross.com/api/sessions/bridge%3Adevice-1%3Asession-9/terminal/ttyd?bridgeId=device-1",
   );
-  assert.equal(
-    connection.terminalLinkUrl,
-    "https://app.conductross.com/api/sessions/bridge%3Adevice-1%3Asession-9/terminal/ttyd?bridgeId=device-1",
-  );
-  assert.equal(
-    connection.relayTtydWsUrl,
-    "wss://relay.example.com/terminal/new/browser?jwt=new",
-  );
+  assert.equal(connection.terminalLinkUrl, undefined);
+  assert.equal(connection.relayTtydWsUrl, undefined);
 });

--- a/packages/web/src/components/sessions/terminal/terminalApi.ts
+++ b/packages/web/src/components/sessions/terminal/terminalApi.ts
@@ -94,17 +94,9 @@ type TerminalTokenResult =
     ttydHttpUrl: string | null;
     ttydWsUrl: string | null;
     tunnelUrl: string | null;
-    relayTtydWsUrl: string | null;
     expiresInSeconds: number | null;
   }
-  | {
-    interactive: false;
-    ttydHttpUrl: null;
-    ttydWsUrl: null;
-    tunnelUrl: null;
-    relayTtydWsUrl: null;
-    reason: string | null;
-  };
+  | { interactive: false; ttydHttpUrl: null; ttydWsUrl: null; tunnelUrl: null; reason: string | null };
 
 function resolveProvidedTtydHttpUrl(
   ttydHttpUrl: string | null,
@@ -165,19 +157,6 @@ function appendBridgeIdToTerminalUrl(
   }
 }
 
-function buildEmbeddedTerminalUrl(
-  sessionId: string,
-  dashboardOrigin: string,
-  bridgeId?: string | null,
-): string {
-  const url = new URL(`/embed/terminal/${encodeURIComponent(sessionId)}`, dashboardOrigin);
-  const normalizedBridgeId = bridgeId?.trim();
-  if (normalizedBridgeId) {
-    url.searchParams.set("bridgeId", normalizedBridgeId);
-  }
-  return url.toString();
-}
-
 type ResolveTerminalConnectionOptions = {
   bridgeId?: string | null;
   signal?: AbortSignal;
@@ -191,7 +170,6 @@ async function fetchTerminalToken(
     withBridgeQuery(`/api/sessions/${encodeURIComponent(sessionId)}/terminal/token`, options?.bridgeId),
     {
       cache: "no-store",
-      credentials: "same-origin",
       signal: options?.signal,
     },
   );
@@ -201,7 +179,6 @@ async function fetchTerminalToken(
       ttydHttpUrl?: string;
       ttydWsUrl?: string;
       tunnelUrl?: string;
-      relayTtydWsUrl?: string;
       expiresInSeconds?: number | string | null;
       error?: string;
     }
@@ -217,10 +194,6 @@ async function fetchTerminalToken(
   const tunnelUrl =
     typeof data?.tunnelUrl === "string" && data.tunnelUrl.trim().length > 0
       ? data.tunnelUrl.trim()
-      : null;
-  const relayTtydWsUrl =
-    typeof data?.relayTtydWsUrl === "string" && data.relayTtydWsUrl.trim().length > 0
-      ? data.relayTtydWsUrl.trim()
       : null;
   const expiresInSeconds = (() => {
     const raw = data?.expiresInSeconds;
@@ -242,7 +215,6 @@ async function fetchTerminalToken(
       ttydHttpUrl: null,
       ttydWsUrl: null,
       tunnelUrl: null,
-      relayTtydWsUrl: null,
       reason: data?.error ?? "Terminal access denied",
     };
   }
@@ -253,7 +225,6 @@ async function fetchTerminalToken(
       ttydHttpUrl: null,
       ttydWsUrl: null,
       tunnelUrl: null,
-      relayTtydWsUrl: null,
       reason: data?.error ?? "Terminal unavailable",
     };
   }
@@ -263,43 +234,8 @@ async function fetchTerminalToken(
     ttydHttpUrl,
     ttydWsUrl,
     tunnelUrl,
-    relayTtydWsUrl,
     expiresInSeconds,
   };
-}
-
-function extractResolvedTerminalToken(terminalUrl: string | null): string | null {
-  if (!terminalUrl) {
-    return null;
-  }
-
-  try {
-    return new URL(terminalUrl).searchParams.get("token");
-  } catch {
-    return null;
-  }
-}
-
-function buildDirectTerminalLinkUrl(
-  embeddedTerminalUrl: string,
-  auth: Extract<TerminalTokenResult, { interactive: true }>,
-  bridgeId?: string | null,
-): string {
-  if (bridgeId?.trim() || !auth.tunnelUrl) {
-    return embeddedTerminalUrl;
-  }
-
-  try {
-    const directUrl = new URL(auth.tunnelUrl);
-    const token = extractResolvedTerminalToken(embeddedTerminalUrl);
-    if (!token) {
-      return embeddedTerminalUrl;
-    }
-    directUrl.searchParams.set("token", token);
-    return directUrl.toString();
-  } catch {
-    return embeddedTerminalUrl;
-  }
 }
 
 export async function resolveTerminalConnection(
@@ -309,11 +245,9 @@ export async function resolveTerminalConnection(
   const backendOrigin = resolveBackendOrigin();
   const dashboardOrigin = resolveDashboardOrigin();
   const auth = await fetchTerminalToken(sessionId, options);
-  if (auth.interactive === false) {
+  if (!auth.interactive) {
     return {
       terminalUrl: null,
-      terminalLinkUrl: null,
-      relayTtydWsUrl: null,
       interactive: false,
       reason: auth.reason,
       expiresInSeconds: null,
@@ -321,53 +255,50 @@ export async function resolveTerminalConnection(
     };
   }
 
-  // Keep the embedded iframe on the shimmed proxy path so auth sync, resize
-  // coordination, touch, and lifecycle hardening always stay in play. Tunnel
-  // URLs are exposed only as direct-open links for non-bridge sessions.
+  // When a cloudflare tunnel URL is available, use it directly instead of the
+  // proxied path. Tunnel URLs bypass the Next.js proxy entirely and connect
+  // the browser straight to ttyd through the tunnel, eliminating proxy
+  // latency and resize coordination overhead.
+  if (auth.tunnelUrl) {
+    try {
+      const tunnelTerminalUrl = new URL(auth.tunnelUrl);
+      // Preserve any token parameter from the backend response.
+      const ttydUrl = new URL(auth.ttydHttpUrl ?? auth.ttydWsUrl ?? "", backendOrigin);
+      const token = ttydUrl.searchParams.get("token");
+      if (token) {
+        tunnelTerminalUrl.searchParams.set("token", token);
+      }
+      return {
+        terminalUrl: appendBridgeIdToTerminalUrl(tunnelTerminalUrl.toString(), options?.bridgeId),
+        interactive: true,
+        reason: null,
+        expiresInSeconds: auth.expiresInSeconds,
+        tunnelUrl: auth.tunnelUrl,
+      };
+    } catch {
+      // If tunnel URL is malformed, fall through to the proxy path.
+    }
+  }
+
+  // Keep dashboard proxy ttyd routes on the dashboard origin so hosted auth
+  // and bridge-aware Next.js proxying stay in the request path. Only direct
+  // backend ttyd URLs should resolve against the backend origin.
   const resolvedTerminalUrl = resolveProvidedTtydHttpUrl(
     auth.ttydHttpUrl,
     auth.ttydWsUrl,
     backendOrigin,
     dashboardOrigin,
   );
-
-  // Frontend-only iframe path: when the backend exposes only the native terminal
-  // websocket contract, render the existing iframe page instead of trying to open a
-  // ttyd HTML route that does not exist on the current backend.
-  if (!auth.ttydHttpUrl && auth.ttydWsUrl) {
-    const embeddedTerminalUrl = buildEmbeddedTerminalUrl(
-      sessionId,
-      dashboardOrigin,
-      options?.bridgeId,
-    );
-    return {
-      terminalUrl: embeddedTerminalUrl,
-      terminalLinkUrl: embeddedTerminalUrl,
-      relayTtydWsUrl: auth.relayTtydWsUrl,
-      interactive: true,
-      reason: null,
-      expiresInSeconds: auth.expiresInSeconds,
-      tunnelUrl: auth.tunnelUrl,
-    };
-  }
-
   if (!resolvedTerminalUrl) {
     return {
       terminalUrl: null,
-      terminalLinkUrl: null,
-      relayTtydWsUrl: null,
       interactive: false,
       reason: "Failed to resolve the ttyd terminal URL.",
     };
   }
 
-  const embeddedTerminalUrl = appendBridgeIdToTerminalUrl(resolvedTerminalUrl, options?.bridgeId);
-  const terminalLinkUrl = buildDirectTerminalLinkUrl(embeddedTerminalUrl, auth, options?.bridgeId);
-
   return {
-    terminalUrl: embeddedTerminalUrl,
-    terminalLinkUrl,
-    relayTtydWsUrl: auth.relayTtydWsUrl,
+    terminalUrl: appendBridgeIdToTerminalUrl(resolvedTerminalUrl, options?.bridgeId),
     interactive: true,
     reason: null,
     expiresInSeconds: auth.expiresInSeconds,


### PR DESCRIPTION
## Summary

Restores the ttyd-backed session terminal flow that existed before PR #390 and before the later Apr 11 native embedded terminal rewrite. `SessionTerminal.tsx`, `terminalApi.ts`, and the ttyd route now match the earlier full agent terminal surface instead of the newer `/embed/terminal/:id` restore that turned out to be the wrong target.

This puts the session panel back on the older pre-#390 terminal behavior the user actually wanted.

## User-Facing Release Notes

- Restored the earlier ttyd-backed terminal experience in the session panel.
- Fixed the terminal iframe so it uses the older pre-#390 terminal surface instead of the wrong later embed flow.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Plugin addition / modification
- [ ] Documentation update
- [ ] Refactor / chore

## Testing

- `bun run typecheck`
- `bun test src/components/sessions/terminal/terminalApi.test.ts src/components/sessions/terminal/terminalUrl.test.ts src/components/sessions/terminal/terminalClientUrls.test.ts src/components/sessions/terminal/terminalToken.test.ts src/lib/ttydHtmlResponse.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal resize handling in embedded sessions.
  * Reduced unnecessary terminal reloads by adding a 5‑minute reattach threshold and quieter token refreshes.

* **Refactor**
  * Streamlined session iframe coordination and initialization logic.

* **UI**
  * Removed the “Open the full terminal page” link and replaced the attachment icon with a paperclip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->