### PR TITLE
fix: keep pre-390 ttyd route resilient to html header mismatches

### DIFF
--- a/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
@@ -4,11 +4,13 @@ import { proxyToBridgeDevice } from "@/lib/bridgeApiProxy";
 import { proxyToRustOrUnavailable } from "@/lib/rustBackendProxy";
 import {
   BRIDGE_TTYD_RELAY_WS_QUERY_PARAM,
+  buildPatchedTtydHtmlResponse,
   createBridgeTtydRelayWebSocketUrl,
   injectBridgeTtydRelayShim,
   injectTtydResizeShim,
   resolveBridgeSessionTarget,
 } from "@/lib/bridgeTtyd";
+import { readTtydHtmlResponse } from "@/lib/ttydHtmlResponse";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -17,30 +19,13 @@ type RouteContext = {
   params: Promise<{ id: string }>;
 };
 
-/**
- * Inject the resize coordination shim into a proxied HTML response.
- * Falls back to the original response if the content is not HTML or
- * reading the body fails.
- */
 async function injectResizeShimIntoResponse(proxied: Response): Promise<Response> {
-  const contentType = proxied.headers.get("content-type")?.toLowerCase() ?? "";
-  if (!contentType.startsWith("text/html")) {
+  const html = await readTtydHtmlResponse(proxied);
+  if (html === null) {
     return proxied;
   }
 
-  let html: string;
-  try {
-    html = await proxied.text();
-  } catch {
-    return proxied;
-  }
-
-  const patched = injectTtydResizeShim(html);
-  return new Response(patched, {
-    status: proxied.status,
-    statusText: proxied.statusText,
-    headers: new Headers(proxied.headers),
-  });
+  return buildPatchedTtydHtmlResponse(proxied, injectTtydResizeShim(html));
 }
 
 export async function GET(
@@ -82,8 +67,8 @@ export async function GET(
     },
   );
 
-  const contentType = proxied.headers.get("content-type")?.toLowerCase() ?? "";
-  if (!contentType.startsWith("text/html")) {
+  const html = await readTtydHtmlResponse(proxied);
+  if (html === null) {
     return proxied;
   }
 
@@ -96,13 +81,9 @@ export async function GET(
     );
   }
 
-  let html = await proxied.text();
-  html = injectBridgeTtydRelayShim(html, relayTtydWsUrl);
-  html = injectTtydResizeShim(html);
+  const patchedHtml = injectTtydResizeShim(
+    injectBridgeTtydRelayShim(html, relayTtydWsUrl),
+  );
 
-  return new Response(html, {
-    status: proxied.status,
-    statusText: proxied.statusText,
-    headers: new Headers(proxied.headers),
-  });
+  return buildPatchedTtydHtmlResponse(proxied, patchedHtml);
 }


### PR DESCRIPTION
## Summary

Keeps the restored pre-390 ttyd-backed terminal surface, but fixes the ttyd proxy route so it still works when upstream ttyd HTML is served with bad download-style headers. The merged pre-390 restore put the right terminal surface back, but it also reintroduced the old header check that only trusted `content-type: text/html`.

This hotfix restores HTML sniffing and patched response headers in `packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts` so the ttyd iframe can render instead of going blank in prod.

## User-Facing Release Notes

- Fixed the restored pre-390 terminal so the ttyd iframe loads again in production.
- Prevented blank terminal panels when ttyd HTML is served with incorrect download-style headers.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Plugin addition / modification
- [ ] Documentation update
- [ ] Refactor / chore

## Testing

- `bun run typecheck`
- `bun test src/lib/ttydHtmlResponse.test.ts src/lib/bridgeTtyd.test.ts src/components/sessions/terminal/terminalApi.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization and response handling for terminal functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->