### PR TITLE
fix: serve ttyd iframe frontend when upstream html is missing

### DIFF
--- a/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/terminal/ttyd/route.ts
@@ -10,6 +10,10 @@ import {
   injectTtydResizeShim,
   resolveBridgeSessionTarget,
 } from "@/lib/bridgeTtyd";
+import {
+  buildBundledTtydHtmlResponse,
+  loadBundledTtydFrontendHtml,
+} from "@/lib/bundledTtydFrontend";
 import { readTtydHtmlResponse } from "@/lib/ttydHtmlResponse";
 
 export const dynamic = "force-dynamic";
@@ -22,7 +26,9 @@ type RouteContext = {
 async function injectResizeShimIntoResponse(proxied: Response): Promise<Response> {
   const html = await readTtydHtmlResponse(proxied);
   if (html === null) {
-    return proxied;
+    return buildBundledTtydHtmlResponse(
+      injectTtydResizeShim(loadBundledTtydFrontendHtml()),
+    );
   }
 
   return buildPatchedTtydHtmlResponse(proxied, injectTtydResizeShim(html));
@@ -67,11 +73,6 @@ export async function GET(
     },
   );
 
-  const html = await readTtydHtmlResponse(proxied);
-  if (html === null) {
-    return proxied;
-  }
-
   let relayTtydWsUrl = new URL(request.url).searchParams.get(BRIDGE_TTYD_RELAY_WS_QUERY_PARAM)?.trim() ?? "";
   if (!relayTtydWsUrl) {
     relayTtydWsUrl = await createBridgeTtydRelayWebSocketUrl(
@@ -81,9 +82,16 @@ export async function GET(
     );
   }
 
+  const html = await readTtydHtmlResponse(proxied);
+  const ttydHtml = html ?? loadBundledTtydFrontendHtml();
+
   const patchedHtml = injectTtydResizeShim(
-    injectBridgeTtydRelayShim(html, relayTtydWsUrl),
+    injectBridgeTtydRelayShim(ttydHtml, relayTtydWsUrl),
   );
+
+  if (html === null) {
+    return buildBundledTtydHtmlResponse(patchedHtml);
+  }
 
   return buildPatchedTtydHtmlResponse(proxied, patchedHtml);
 }


### PR DESCRIPTION
## Summary

Keeps the merged real ttyd iframe stack from #443, but changes the ttyd route to serve the bundled ttyd frontend when upstream ttyd HTML is missing or unreadable. Right now the app can still show the correct ttyd shell chrome while returning a blank panel if the upstream ttyd page is not present.

This brings back the ttyd frontend alone behavior the user explicitly asked for, while preserving the proxy route, resize shim, relay shim, and current ttyd route hardening.

## User-Facing Release Notes

- Fixed blank terminal panels by serving the ttyd iframe frontend even when upstream ttyd HTML is unavailable.
- Restored the ttyd frontend-only fallback behind the session terminal route.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Plugin addition / modification
- [ ] Documentation update
- [ ] Refactor / chore

## Testing

- `bun run typecheck`
- `bun test src/lib/ttydHtmlResponse.test.ts src/lib/bridgeTtyd.test.ts src/lib/bundledTtydFrontend.test.ts src/components/sessions/terminal/terminalApi.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal session reliability with a fallback mechanism that automatically loads an alternative interface when the primary connection is unavailable, ensuring users maintain uninterrupted access to terminal functionality even during connectivity issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->