### PR TITLE
fix: keep ttyd iframe on the dashboard proxy

### DIFF
--- a/packages/web/src/components/sessions/terminal/terminalApi.test.ts
+++ b/packages/web/src/components/sessions/terminal/terminalApi.test.ts
@@ -86,19 +86,26 @@ test.afterEach(() => {
   }
 });
 
-test("resolveTerminalConnection accepts direct ttyd URLs", async () => {
-  setWindowLocation("http://127.0.0.1:3000/sessions/session-1");
+test("resolveTerminalConnection keeps direct ttyd origins behind the dashboard proxy iframe", async () => {
+  setWindowLocation("https://app.conductross.com/sessions/session-1");
   setFetchResponse({
     required: true,
-    ttydHttpUrl: "http://127.0.0.1:41000/",
-    ttydWsUrl: "ws://127.0.0.1:41000/ws",
+    ttydHttpUrl: "http://127.0.0.1:41000/?token=legacy-token",
+    ttydWsUrl: "ws://127.0.0.1:41000/ws?token=legacy-token",
   });
 
   const connection = await resolveTerminalConnection("session-1");
 
   assert.equal(connection.interactive, true);
   assert.equal(connection.reason, null);
-  assert.equal(connection.terminalUrl, "http://127.0.0.1:41000/");
+  assert.equal(
+    connection.terminalUrl,
+    "https://app.conductross.com/api/sessions/session-1/terminal/ttyd?token=legacy-token",
+  );
+  assert.equal(
+    connection.terminalLinkUrl,
+    "https://app.conductross.com/api/sessions/session-1/terminal/ttyd?token=legacy-token",
+  );
 });
 
 test("resolveTerminalConnection keeps proxied ttyd routes on the dashboard origin even with backend metadata", async () => {

--- a/packages/web/src/components/sessions/terminal/terminalApi.ts
+++ b/packages/web/src/components/sessions/terminal/terminalApi.ts
@@ -165,6 +165,44 @@ function appendBridgeIdToTerminalUrl(
   }
 }
 
+function buildEmbeddedProxyTerminalUrl(
+  sessionId: string,
+  dashboardOrigin: string,
+  bridgeId?: string | null,
+  token?: string | null,
+  resolvedTerminalUrl?: string | null,
+): string {
+  let proxySessionId = sessionId;
+
+  if (resolvedTerminalUrl) {
+    try {
+      const resolved = new URL(resolvedTerminalUrl);
+      const match = resolved.pathname.match(/^\/api\/sessions\/([^/]+)\/terminal\/ttyd(?:\/)?$/);
+      if (match?.[1]) {
+        proxySessionId = decodeURIComponent(match[1]);
+      }
+    } catch {
+    }
+  }
+
+  const url = new URL(
+    `/api/sessions/${encodeURIComponent(proxySessionId)}/terminal/ttyd`,
+    dashboardOrigin,
+  );
+
+  const normalizedBridgeId = bridgeId?.trim();
+  if (normalizedBridgeId) {
+    url.searchParams.set("bridgeId", normalizedBridgeId);
+  }
+
+  const normalizedToken = token?.trim();
+  if (normalizedToken) {
+    url.searchParams.set("token", normalizedToken);
+  }
+
+  return url.toString();
+}
+
 type ResolveTerminalConnectionOptions = {
   bridgeId?: string | null;
   signal?: AbortSignal;
@@ -308,9 +346,10 @@ export async function resolveTerminalConnection(
     };
   }
 
-  // Keep the embedded iframe on the shimmed proxy path so auth sync, resize
-  // coordination, touch, and lifecycle hardening always stay in play. Tunnel
-  // URLs are exposed only as direct-open links for non-bridge sessions.
+  // Keep the embedded iframe on the dashboard ttyd proxy path even when older
+  // backends still advertise a direct ttyd origin. That route applies the HTML
+  // hardening and prevents Safari from treating the terminal shell like a
+  // downloadable file.
   const resolvedTerminalUrl = resolveProvidedTtydHttpUrl(
     auth.ttydHttpUrl,
     auth.ttydWsUrl,
@@ -327,7 +366,13 @@ export async function resolveTerminalConnection(
     };
   }
 
-  const embeddedTerminalUrl = appendBridgeIdToTerminalUrl(resolvedTerminalUrl, options?.bridgeId);
+  const embeddedTerminalUrl = buildEmbeddedProxyTerminalUrl(
+    sessionId,
+    dashboardOrigin,
+    options?.bridgeId,
+    extractResolvedTerminalToken(resolvedTerminalUrl),
+    resolvedTerminalUrl,
+  );
   const terminalLinkUrl = buildDirectTerminalLinkUrl(embeddedTerminalUrl, auth, options?.bridgeId);
 
   return {

--- a/packages/web/src/lib/bridgeTtyd.test.ts
+++ b/packages/web/src/lib/bridgeTtyd.test.ts
@@ -99,10 +99,11 @@ test("buildPatchedTtydHtmlResponse drops stale body headers after html injection
   assert.equal(patched.headers.get("content-length"), null);
   assert.equal(patched.headers.get("content-encoding"), null);
   assert.equal(patched.headers.get("etag"), null);
-  assert.equal(
-    patched.headers.get("cache-control"),
+  assert.equal(patched.headers.get("cache-control"),
     "no-store, no-cache, must-revalidate, max-age=0",
   );
+  assert.equal(patched.headers.get("content-disposition"), "inline; filename=ttyd.html");
+  assert.equal(patched.headers.get("x-content-type-options"), "nosniff");
   assert.equal(patched.headers.get("pragma"), "no-cache");
   assert.equal(patched.headers.get("expires"), "0");
   assert.equal(await patched.text(), "<html><body>new</body></html>");
@@ -120,6 +121,7 @@ test("buildPatchedTtydHtmlResponse forces html rendering headers for patched tty
   const patched = buildPatchedTtydHtmlResponse(proxied, "<html><body>new</body></html>");
 
   assert.equal(patched.headers.get("content-type"), "text/html; charset=utf-8");
-  assert.equal(patched.headers.get("content-disposition"), null);
+  assert.equal(patched.headers.get("content-disposition"), "inline; filename=ttyd.html");
+  assert.equal(patched.headers.get("x-content-type-options"), "nosniff");
   assert.equal(await patched.text(), "<html><body>new</body></html>");
 });

--- a/packages/web/src/lib/bridgeTtyd.ts
+++ b/packages/web/src/lib/bridgeTtyd.ts
@@ -78,6 +78,8 @@ export function buildPatchedTtydHtmlResponse(proxied: Response, html: string): R
     headers.delete(headerName);
   }
   headers.set("content-type", "text/html; charset=utf-8");
+  headers.set("content-disposition", "inline; filename=ttyd.html");
+  headers.set("x-content-type-options", "nosniff");
   headers.set("cache-control", "no-store, no-cache, must-revalidate, max-age=0");
   headers.set("pragma", "no-cache");
   headers.set("expires", "0");

--- a/packages/web/src/lib/bundledTtydFrontend.test.ts
+++ b/packages/web/src/lib/bundledTtydFrontend.test.ts
@@ -19,6 +19,8 @@ test("buildBundledTtydHtmlResponse serves html with no-store headers", async () 
 
   assert.equal(response.status, 200);
   assert.equal(response.headers.get("content-type"), "text/html; charset=utf-8");
+  assert.equal(response.headers.get("content-disposition"), "inline; filename=ttyd.html");
+  assert.equal(response.headers.get("x-content-type-options"), "nosniff");
   assert.equal(response.headers.get("cache-control"), "no-store, no-cache, must-revalidate, max-age=0");
   assert.equal(await response.text(), "<html><body>ok</body></html>");
 });

--- a/packages/web/src/lib/bundledTtydFrontend.ts
+++ b/packages/web/src/lib/bundledTtydFrontend.ts
@@ -10,6 +10,8 @@ const BUNDLED_TTYD_FRONTEND_PATH = join(
 
 const BUNDLED_TTYD_RESPONSE_HEADERS = {
   "content-type": "text/html; charset=utf-8",
+  "content-disposition": "inline; filename=ttyd.html",
+  "x-content-type-options": "nosniff",
   "cache-control": "no-store, no-cache, must-revalidate, max-age=0",
   pragma: "no-cache",
   expires: "0",


### PR DESCRIPTION
## Summary

Keep the embedded ttyd iframe pinned to the dashboard proxy route even when an older backend token payload still advertises a direct ttyd origin. Also force inline HTML headers on patched and bundled ttyd shells so Safari never treats the terminal surface like a file download.

## User-Facing Release Notes

- Fixed a regression where opening the Terminal tab could trigger a ttyd file download instead of rendering the terminal.
- Kept the embedded terminal on the hardened dashboard proxy path so the old ttyd iframe flow stays intact.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Plugin addition / modification
- [ ] Documentation update
- [ ] Refactor / chore

## Testing

Verified locally with targeted ttyd regression tests and `bun run --cwd packages/web typecheck`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal session access through dashboard proxy with proper token and session routing
  * Updated terminal connection handling for embedded proxy iframe access

* **Security**
  * Added security headers to prevent content-type sniffing on terminal responses
  * Enhanced response header handling for terminal access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->