### PR TITLE
fix: ship bundled ttyd frontend asset in web build

### DIFF
--- a/packages/web/src/lib/bundledTtydFrontend.ts
+++ b/packages/web/src/lib/bundledTtydFrontend.ts
@@ -1,12 +1,6 @@
 import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
 
-const MODULE_DIRECTORY = dirname(fileURLToPath(import.meta.url));
-const BUNDLED_TTYD_FRONTEND_PATH = join(
-  MODULE_DIRECTORY,
-  "ttyd_frontend_v1.7.7.html",
-);
+const BUNDLED_TTYD_FRONTEND_URL = new URL("./ttyd_frontend_v1.7.7.html", import.meta.url);
 
 const BUNDLED_TTYD_RESPONSE_HEADERS = {
   "content-type": "text/html; charset=utf-8",
@@ -24,7 +18,7 @@ export function loadBundledTtydFrontendHtml(): string {
     return cachedBundledTtydFrontendHtml;
   }
 
-  cachedBundledTtydFrontendHtml = readFileSync(BUNDLED_TTYD_FRONTEND_PATH, "utf8");
+  cachedBundledTtydFrontendHtml = readFileSync(BUNDLED_TTYD_FRONTEND_URL, "utf8");
   return cachedBundledTtydFrontendHtml;
 }
 

--- a/packages/web/src/lib/ttydHtmlResponse.test.ts
+++ b/packages/web/src/lib/ttydHtmlResponse.test.ts
@@ -1,8 +1,7 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import test from "node:test";
 
+import { loadBundledTtydFrontendHtml } from "./bundledTtydFrontend";
 import { readTtydHtmlResponse } from "./ttydHtmlResponse";
 
 test("readTtydHtmlResponse returns null when the proxied HTML stream errors", async () => {
@@ -53,17 +52,7 @@ test("readTtydHtmlResponse still returns null for non-html download responses", 
 });
 
 test("readTtydHtmlResponse accepts the vendored ttyd frontend size used by the iframe proxy", async () => {
-  const ttydFrontendPath = join(
-    process.cwd(),
-    "..",
-    "..",
-    "crates",
-    "conductor-server",
-    "src",
-    "routes",
-    "ttyd_frontend_v1.7.7.html",
-  );
-  const html = readFileSync(ttydFrontendPath, "utf8");
+  const html = loadBundledTtydFrontendHtml();
   const proxied = new Response(html, {
     headers: {
       "content-type": "text/html; charset=utf-8",


### PR DESCRIPTION
## Summary

Ships the bundled ttyd fallback HTML with the Next.js web build by resolving it from the web package itself. Updates the ttyd HTML response test to use the same bundled loader as production.

## User-Facing Release Notes

- Fixed the mobile Safari terminal so the ttyd web client is shipped with the app instead of falling back to a download prompt.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Testing

- `bun test packages/web/src/lib/bundledTtydFrontend.test.ts packages/web/src/lib/ttydHtmlResponse.test.ts`
- `bun run --cwd packages/web typecheck`
- `bun run --cwd packages/web build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized asset loading mechanisms to use URL-based resolution instead of filesystem path computation, while maintaining all existing functionality and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->