### PR TITLE
fix: restore bridge ttyd html rendering

### DIFF
--- a/packages/web/src/lib/bridgeTtyd.test.ts
+++ b/packages/web/src/lib/bridgeTtyd.test.ts
@@ -120,6 +120,7 @@ test("buildPatchedTtydHtmlResponse forces html rendering headers for patched tty
   const patched = buildPatchedTtydHtmlResponse(proxied, "<html><body>new</body></html>");
 
   assert.equal(patched.headers.get("content-type"), "text/html; charset=utf-8");
-  assert.equal(patched.headers.get("content-disposition"), null);
+  assert.equal(patched.headers.get("content-disposition"), "inline; filename=ttyd.html");
+  assert.equal(patched.headers.get("x-content-type-options"), "nosniff");
   assert.equal(await patched.text(), "<html><body>new</body></html>");
 });

--- a/packages/web/src/lib/bridgeTtyd.ts
+++ b/packages/web/src/lib/bridgeTtyd.ts
@@ -78,6 +78,8 @@ export function buildPatchedTtydHtmlResponse(proxied: Response, html: string): R
     headers.delete(headerName);
   }
   headers.set("content-type", "text/html; charset=utf-8");
+  headers.set("content-disposition", "inline; filename=ttyd.html");
+  headers.set("x-content-type-options", "nosniff");
   headers.set("cache-control", "no-store, no-cache, must-revalidate, max-age=0");
   headers.set("pragma", "no-cache");
   headers.set("expires", "0");

--- a/packages/web/src/lib/ttydHtmlResponse.test.ts
+++ b/packages/web/src/lib/ttydHtmlResponse.test.ts
@@ -25,11 +25,47 @@ test("readTtydHtmlResponse returns null when the proxied HTML stream errors", as
   assert.equal(html, null);
 });
 
+test("readTtydHtmlResponse accepts large ttyd HTML responses up to the backend limit", async () => {
+  const largeHtml = `<!DOCTYPE html><html><body>${"x".repeat(700 * 1024)}</body></html>`;
+  const proxied = new Response(largeHtml, {
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      "content-length": String(Buffer.byteLength(largeHtml, "utf8")),
+    },
+  });
+
+  const html = await readTtydHtmlResponse(proxied);
+  assert.equal(html, largeHtml);
+});
+
+test("readTtydHtmlResponse unwraps bridge-proxied html JSON strings", async () => {
+  const html = "<!DOCTYPE html><html><body>ttyd</body></html>";
+  const proxied = new Response(JSON.stringify(html), {
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+    },
+  });
+
+  assert.equal(await readTtydHtmlResponse(proxied), html);
+});
+
+test("readTtydHtmlResponse accepts html bodies even when upstream headers look like downloads", async () => {
+  const html = "<!DOCTYPE html><html><body>ttyd</body></html>";
+  const proxied = new Response(html, {
+    headers: {
+      "content-type": "application/octet-stream",
+      "content-disposition": 'attachment; filename="ttyd"',
+    },
+  });
+
+  assert.equal(await readTtydHtmlResponse(proxied), html);
+});
+
 test("readTtydHtmlResponse still rejects oversized ttyd HTML responses", async () => {
   const proxied = new Response("<html><body>large</body></html>", {
     headers: {
       "content-type": "text/html; charset=utf-8",
-      "content-length": String(600 * 1024),
+      "content-length": String(9 * 1024 * 1024),
     },
   });
 

--- a/packages/web/src/lib/ttydHtmlResponse.ts
+++ b/packages/web/src/lib/ttydHtmlResponse.ts
@@ -1,12 +1,74 @@
-const MAX_TTYD_HTML_RESPONSE_BYTES = 512 * 1024;
+// Keep in sync with crates/conductor-server/src/routes/terminal.rs.
+const MAX_TTYD_HTML_RESPONSE_BYTES = 8 * 1024 * 1024;
 const TTYD_HTML_TOO_LARGE_ERROR = "ttyd frontend response is too large";
+const HTML_SNIFF_CHAR_LIMIT = 2048;
+const BRIDGE_PROXY_META_KEY = "$bridgeProxy";
+
+function looksLikeHtmlDocument(text: string): boolean {
+  const trimmed = text.trimStart().toLowerCase();
+  return trimmed.startsWith("<!doctype html")
+    || trimmed.startsWith("<html")
+    || trimmed.startsWith("<head")
+    || trimmed.startsWith("<body");
+}
+
+function unwrapBridgeProxyHtmlPayload(payloadText: string): string | null {
+  try {
+    const parsed = JSON.parse(payloadText) as unknown;
+    if (typeof parsed === "string") {
+      return looksLikeHtmlDocument(parsed) ? parsed : null;
+    }
+
+    if (!parsed || typeof parsed !== "object") {
+      return null;
+    }
+
+    const proxyMeta = (parsed as Record<string, unknown>)[BRIDGE_PROXY_META_KEY];
+    if (!proxyMeta || typeof proxyMeta !== "object") {
+      return null;
+    }
+
+    const kind = typeof (proxyMeta as Record<string, unknown>).kind === "string"
+      ? ((proxyMeta as Record<string, unknown>).kind as string).trim().toLowerCase()
+      : "";
+    const contentType = typeof (proxyMeta as Record<string, unknown>).contentType === "string"
+      ? ((proxyMeta as Record<string, unknown>).contentType as string).trim().toLowerCase()
+      : "";
+
+    if (kind === "text") {
+      const text = typeof (proxyMeta as Record<string, unknown>).text === "string"
+        ? (proxyMeta as Record<string, unknown>).text as string
+        : null;
+      if (!text) {
+        return null;
+      }
+      return contentType.startsWith("text/html") || looksLikeHtmlDocument(text)
+        ? text
+        : null;
+    }
+
+    if (kind === "bytes") {
+      const base64 = typeof (proxyMeta as Record<string, unknown>).base64 === "string"
+        ? (proxyMeta as Record<string, unknown>).base64 as string
+        : null;
+      if (!base64 || !(contentType.startsWith("text/html") || contentType.includes("html"))) {
+        return null;
+      }
+      const decoded = Buffer.from(base64, "base64").toString("utf8");
+      return looksLikeHtmlDocument(decoded) ? decoded : null;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 export async function readTtydHtmlResponse(proxied: Response): Promise<string | null> {
   const candidate = proxied.clone();
   const contentType = candidate.headers.get("content-type")?.toLowerCase() ?? "";
-  if (!contentType.startsWith("text/html")) {
-    return null;
-  }
+  const declaredHtml = contentType.startsWith("text/html");
+  const declaredJson = contentType.includes("application/json");
 
   const contentLength = Number.parseInt(candidate.headers.get("content-length") ?? "", 10);
   if (Number.isFinite(contentLength) && contentLength > MAX_TTYD_HTML_RESPONSE_BYTES) {
@@ -22,6 +84,8 @@ export async function readTtydHtmlResponse(proxied: Response): Promise<string | 
     const decoder = new TextDecoder();
     let totalBytes = 0;
     let html = "";
+    let sniffBuffer = "";
+    let sniffedHtml = declaredHtml;
 
     for (;;) {
       const { done, value } = await reader.read();
@@ -32,11 +96,26 @@ export async function readTtydHtmlResponse(proxied: Response): Promise<string | 
       if (totalBytes > MAX_TTYD_HTML_RESPONSE_BYTES) {
         throw new Error(TTYD_HTML_TOO_LARGE_ERROR);
       }
-      html += decoder.decode(value, { stream: true });
+
+      const decodedChunk = decoder.decode(value, { stream: true });
+      html += decodedChunk;
+
+      if (!sniffedHtml && sniffBuffer.length < HTML_SNIFF_CHAR_LIMIT) {
+        sniffBuffer = `${sniffBuffer}${decodedChunk}`.slice(0, HTML_SNIFF_CHAR_LIMIT);
+        sniffedHtml = looksLikeHtmlDocument(sniffBuffer);
+        if (!sniffedHtml && !declaredJson && sniffBuffer.length >= HTML_SNIFF_CHAR_LIMIT) {
+          await reader.cancel().catch(() => undefined);
+          return null;
+        }
+      }
     }
 
     html += decoder.decode();
-    return html;
+    if (sniffedHtml || looksLikeHtmlDocument(html)) {
+      return html;
+    }
+
+    return unwrapBridgeProxyHtmlPayload(html);
   } catch (error) {
     if (error instanceof Error && error.message === TTYD_HTML_TOO_LARGE_ERROR) {
       throw error;


### PR DESCRIPTION
## Summary

Fixes the hosted ttyd iframe path for bridged sessions by accepting the real ttyd HTML size used by the backend, unwrapping bridge-proxied HTML payloads before injecting shims, and forcing inline HTML response headers so Safari renders the terminal instead of treating it like a download.

## User-Facing Release Notes

- Fixed bridged terminal sessions on app.conductross.com so the ttyd iframe renders again instead of failing or prompting Safari to download `ttyd`.
- Improved the terminal proxy so larger ttyd frontend pages and bridge-wrapped HTML responses still load correctly.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Plugin Addition / Modification
- [ ] Documentation Update
- [ ] Refactor / Chore

## Testing

- `bun test packages/web/src/lib/ttydHtmlResponse.test.ts packages/web/src/lib/bridgeTtyd.test.ts packages/web/src/components/sessions/terminal/terminalApi.test.ts`
- `bun run --cwd packages/web typecheck`
- `bun run --cwd packages/web build`
- `vercel logs dpl_9nrDJY6gsdRqcjuiWQP3kUzM67VB --token "$VERCEL_TOKEN" --no-follow --status-code 500 --since 1h` to confirm the live failure was `ttyd frontend response is too large`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Increased maximum supported file size for TTYD responses from 512 KB to 8 MB.
  * Added support for JSON-wrapped HTML responses.

* **Bug Fixes**
  * Improved HTML detection to better identify valid HTML documents.
  * Added security headers to prevent MIME type sniffing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->