### PR TITLE
fix(web): restore session tab scroll and terminal reload

### DIFF
--- a/packages/web/src/components/sessions/SessionDetail.tsx
+++ b/packages/web/src/components/sessions/SessionDetail.tsx
@@ -94,10 +94,10 @@ interface SessionDetailProps {
 
 type SessionTab = "overview" | "diff" | "dispatcher" | "terminal" | "preview" | "skills";
 
-const STANDARD_TAB_PANEL_CLASS_NAME = "min-h-0 h-full min-w-0 w-full overflow-hidden focus-visible:outline-none [&[hidden]]:block data-[state=inactive]:pointer-events-none data-[state=inactive]:absolute data-[state=inactive]:inset-0 data-[state=inactive]:invisible data-[state=inactive]:opacity-0";
+const STANDARD_TAB_PANEL_CLASS_NAME = "min-h-0 h-full min-w-0 w-full overflow-hidden focus-visible:outline-none [&[hidden]]:block data-[state=active]:relative data-[state=active]:z-10 data-[state=inactive]:pointer-events-none data-[state=inactive]:absolute data-[state=inactive]:inset-0 data-[state=inactive]:z-0 data-[state=inactive]:invisible data-[state=inactive]:opacity-0";
 // Keep terminal-like surfaces painted with opacity only. `visibility:hidden` was causing browser-level
 // suspension / blanking on tab switches even though the panels stayed force-mounted.
-const PRESERVE_LIVE_SURFACE_TAB_PANEL_CLASS_NAME = "min-h-0 h-full min-w-0 w-full overflow-hidden focus-visible:outline-none [&[hidden]]:block data-[state=active]:relative data-[state=active]:z-10 data-[state=inactive]:pointer-events-none data-[state=inactive]:absolute data-[state=inactive]:inset-0 data-[state=inactive]:opacity-0 data-[state=inactive]:select-none";
+const PRESERVE_LIVE_SURFACE_TAB_PANEL_CLASS_NAME = "min-h-0 h-full min-w-0 w-full overflow-hidden focus-visible:outline-none [&[hidden]]:block data-[state=active]:relative data-[state=active]:z-10 data-[state=inactive]:pointer-events-none data-[state=inactive]:absolute data-[state=inactive]:inset-0 data-[state=inactive]:z-0 data-[state=inactive]:opacity-0 data-[state=inactive]:select-none";
 
 function resolveSessionTab(
   value: string | null,

--- a/packages/web/src/components/sessions/SessionTerminal.reload.test.ts
+++ b/packages/web/src/components/sessions/SessionTerminal.reload.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+test("terminal reload button remounts the iframe even when the terminal URL stays the same", () => {
+  const source = readFileSync(new URL("./SessionTerminal.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /const \[iframeReloadNonce, setIframeReloadNonce\] = useState\(0\);/);
+  assert.match(source, /const handleRetry = useCallback\(\(\) => \{/);
+  assert.match(source, /forceTerminalReloadRef\.current = true;/);
+  assert.match(source, /frameLoadedRef\.current = false;/);
+  assert.match(source, /setFrameLoaded\(false\);/);
+  assert.match(source, /setIframeReloadNonce\(\(current\) => current \+ 1\);/);
+  assert.match(source, /key=\{`\$\{sessionId\}:\$\{iframeReloadNonce\}`\}/);
+});

--- a/packages/web/src/components/sessions/SessionTerminal.tsx
+++ b/packages/web/src/components/sessions/SessionTerminal.tsx
@@ -237,6 +237,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
   const [resolvingConnection, setResolvingConnection] = useState(expectsLiveTerminal);
   const [connectionError, setConnectionError] = useState<string | null>(null);
   const [frameLoaded, setFrameLoaded] = useState(false);
+  const [iframeReloadNonce, setIframeReloadNonce] = useState(0);
   const [connectionRefreshTick, setConnectionRefreshTick] = useState(0);
   const [promptMessage, setPromptMessage] = useState("");
   const [promptSending, setPromptSending] = useState(false);
@@ -1053,6 +1054,9 @@ function SessionTerminalView(props: SessionTerminalProps) {
     setConnectionError(null);
     retryAttemptRef.current = 0;
     forceTerminalReloadRef.current = true;
+    frameLoadedRef.current = false;
+    setFrameLoaded(false);
+    setIframeReloadNonce((current) => current + 1);
     setConnectionRefreshTick((current) => current + 1);
   }, []);
 
@@ -1168,7 +1172,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
               </div>
             ) : null}
             <iframe
-              key={sessionId}
+              key={`${sessionId}:${iframeReloadNonce}`}
               ref={ttydIframeRef}
               title={`ttyd terminal for ${sessionId}`}
               src={terminalUrl}

--- a/packages/web/src/components/sessions/sessionMobileScroll.test.ts
+++ b/packages/web/src/components/sessions/sessionMobileScroll.test.ts
@@ -73,3 +73,12 @@ test("preview screen restores app surface scroll ownership", () => {
   assert.match(source, /min-w-0/);
   assert.match(source, /lg:grid/);
 });
+
+test("session detail keeps active tabs above hidden live surfaces", () => {
+  const source = readFileSync(new URL("./SessionDetail.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /STANDARD_TAB_PANEL_CLASS_NAME = ".*data-\[state=active\]:relative.*data-\[state=active\]:z-10/);
+  assert.match(source, /STANDARD_TAB_PANEL_CLASS_NAME = ".*data-\[state=inactive\]:z-0/);
+  assert.match(source, /PRESERVE_LIVE_SURFACE_TAB_PANEL_CLASS_NAME = ".*data-\[state=active\]:relative.*data-\[state=active\]:z-10/);
+  assert.match(source, /PRESERVE_LIVE_SURFACE_TAB_PANEL_CLASS_NAME = ".*data-\[state=inactive\]:z-0/);
+});


### PR DESCRIPTION
## User-Facing Release Notes
- Overview, Review, and Preview tabs scroll correctly again on mobile session pages.
- The Terminal reload button now forces a real terminal frame refresh instead of appearing to do nothing.
- Bridge-backed Preview now uses the hosted preview browser end to end, so paired-device local dev servers can render through the web app instead of falling into dead 404 preview routes.
- Terminal UI copy now stays product-facing and no longer exposes `ttyd` in the visible session chrome.

## Type of Change
- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore
