### PR TITLE
fix(preview): restore bridge-backed hosted previews

### DIFF
--- a/packages/web/src/app/api/sessions/[id]/preview/dom/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/preview/dom/route.ts
@@ -1,7 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
 import { guardApiAccess } from "@/lib/auth";
-import { guardAndProxyToBridgeDevice, hasBridgeRelay } from "@/lib/bridgeApiProxy";
-import { decodeBridgeSessionId } from "@/lib/bridgeSessionIds";
 import { buildBridgeRelayAuthHeaders } from "@/lib/bridgeRelayAuth";
 import { getPreviewBrowserManager } from "@/lib/devPreviewBrowser";
 import { buildForwardedAccessHeaders } from "@/lib/guardedRustProxy";
@@ -17,13 +15,6 @@ export async function GET(request: NextRequest, context: RouteParams): Promise<R
   if (denied) return denied;
 
   const { id } = await context.params;
-
-  // Bridge sessions: proxy to the paired device's backend (has local Puppeteer)
-  const bridge = decodeBridgeSessionId(id);
-  if (bridge && hasBridgeRelay()) {
-    const decodedPath = `/api/sessions/${encodeURIComponent(bridge.sessionId)}/preview/dom`;
-    return guardAndProxyToBridgeDevice(request, bridge.bridgeId, decodedPath);
-  }
 
   const forwardedHeaders = await buildForwardedAccessHeaders(request);
   const previewContext = await loadPreviewSessionContext(id, {

--- a/packages/web/src/app/api/sessions/[id]/preview/route.test.ts
+++ b/packages/web/src/app/api/sessions/[id]/preview/route.test.ts
@@ -226,31 +226,6 @@ test("GET resolves bridge-backed preview session context via the paired device a
     };
     seenPaths.push(body.path);
 
-    // The bridge proxy now intercepts preview requests first.
-    // When the paired device returns a preview status, forward it.
-    if (body.path.startsWith("/api/sessions/session-1/preview")) {
-      return new Response(JSON.stringify({
-        connected: false,
-        candidateUrls: [
-          "http://127.0.0.1:3000/",
-          "https://deploy-preview.example.com/",
-          "http://localhost:3002/",
-        ],
-        currentUrl: null,
-        title: null,
-        frames: [],
-        activeFrameId: null,
-        selectedElement: null,
-        consoleLogs: [],
-        networkLogs: [],
-        lastError: null,
-        screenshotKey: `${Date.now()}`,
-      }), {
-        status: 200,
-        headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
-      });
-    }
-
     if (body.path === "/api/sessions/session-1") {
       return new Response(JSON.stringify({
         id: "session-1",
@@ -312,10 +287,10 @@ test("GET resolves bridge-backed preview session context via the paired device a
     );
 
     assert.equal(response.status, 200);
-    // Bridge proxy now intercepts the preview request first.
-    assert.ok(seenPaths.some((p) => p.startsWith("/api/sessions/session-1/preview")));
-    // Verify the bridge proxy intercepted the request
-    assert.equal(seenPaths.length, 1);
+    assert.deepEqual(seenPaths, [
+      "/api/sessions/session-1",
+      "/api/sessions/session-1/output?lines=400",
+    ]);
 
     const payload = await response.json() as {
       connected: boolean;

--- a/packages/web/src/app/api/sessions/[id]/preview/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/preview/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { guardApiAccess, guardApiActionAccess } from "@/lib/auth";
-import { guardAndProxyToBridgeDevice, hasBridgeRelay } from "@/lib/bridgeApiProxy";
 import { buildBridgeRelayAuthHeaders } from "@/lib/bridgeRelayAuth";
-import { decodeBridgeSessionId } from "@/lib/bridgeSessionIds";
 import { getPreviewBrowserManager } from "@/lib/devPreviewBrowser";
 import { buildForwardedAccessHeaders } from "@/lib/guardedRustProxy";
 import { loadPreviewSessionContext } from "@/lib/previewSession";
@@ -13,22 +11,6 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 type RouteParams = { params: Promise<{ id: string }> };
-
-/**
- * For bridge sessions, proxy the entire preview request to the paired device's
- * backend, which runs Puppeteer locally. This makes the preview browser work
- * on Vercel deployments where no local Chrome is available.
- */
-async function tryProxyBridgePreview(request: NextRequest, id: string, options?: { requireActionGuard?: boolean }): Promise<Response | null> {
-  const bridge = decodeBridgeSessionId(id);
-  if (!bridge) return null;
-  if (!hasBridgeRelay()) return null;
-
-  const decodedPath = `/api/sessions/${encodeURIComponent(bridge.sessionId)}/preview`;
-  return guardAndProxyToBridgeDevice(request, bridge.bridgeId, decodedPath, {
-    requireActionGuard: options?.requireActionGuard,
-  });
-}
 
 function withLookupError(
   status: PreviewStatusResponse,
@@ -51,10 +33,6 @@ export async function GET(request: NextRequest, context: RouteParams): Promise<R
   if (denied) return denied;
 
   const { id } = await context.params;
-
-  // Bridge sessions: proxy to the paired device's backend (has local Puppeteer)
-  const bridgeProxy = await tryProxyBridgePreview(request, id);
-  if (bridgeProxy) return bridgeProxy;
 
   const forwardedHeaders = await buildForwardedAccessHeaders(request);
   const previewContext = await loadPreviewSessionContext(id, {
@@ -99,10 +77,6 @@ export async function POST(request: NextRequest, context: RouteParams): Promise<
   if (deniedAction) return deniedAction;
 
   const { id } = await context.params;
-
-  // Bridge sessions: proxy to the paired device's backend
-  const bridgeProxy = await tryProxyBridgePreview(request, id, { requireActionGuard: true });
-  if (bridgeProxy) return bridgeProxy;
 
   const forwardedHeaders = await buildForwardedAccessHeaders(request);
   const previewContext = await loadPreviewSessionContext(id, {

--- a/packages/web/src/app/api/sessions/[id]/preview/screenshot/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/preview/screenshot/route.ts
@@ -1,7 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
 import { guardApiAccess } from "@/lib/auth";
-import { guardAndProxyToBridgeDevice, hasBridgeRelay } from "@/lib/bridgeApiProxy";
-import { decodeBridgeSessionId } from "@/lib/bridgeSessionIds";
 import { buildBridgeRelayAuthHeaders } from "@/lib/bridgeRelayAuth";
 import { getPreviewBrowserManager } from "@/lib/devPreviewBrowser";
 import { buildForwardedAccessHeaders } from "@/lib/guardedRustProxy";
@@ -17,13 +15,6 @@ export async function GET(request: NextRequest, context: RouteParams): Promise<R
   if (denied) return denied;
 
   const { id } = await context.params;
-
-  // Bridge sessions: proxy to the paired device's backend (has local Puppeteer)
-  const bridge = decodeBridgeSessionId(id);
-  if (bridge && hasBridgeRelay()) {
-    const decodedPath = `/api/sessions/${encodeURIComponent(bridge.sessionId)}/preview/screenshot`;
-    return guardAndProxyToBridgeDevice(request, bridge.bridgeId, decodedPath);
-  }
 
   const forwardedHeaders = await buildForwardedAccessHeaders(request);
   const previewContext = await loadPreviewSessionContext(id, {

--- a/packages/web/src/components/sessions/SessionTerminal.reload.test.ts
+++ b/packages/web/src/components/sessions/SessionTerminal.reload.test.ts
@@ -13,3 +13,15 @@ test("terminal reload button remounts the iframe even when the terminal URL stay
   assert.match(source, /setIframeReloadNonce\(\(current\) => current \+ 1\);/);
   assert.match(source, /key=\{`\$\{sessionId\}:\$\{iframeReloadNonce\}`\}/);
 });
+
+test("terminal UI copy stays product-facing and does not expose ttyd wording", () => {
+  const source = readFileSync(new URL("./SessionTerminal.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /aria-label="Reload terminal"/);
+  assert.match(source, /Loading terminal…/);
+  assert.match(source, /title=\{`terminal for \$\{sessionId\}`\}/);
+  assert.match(source, /Open the terminal directly/);
+  assert.doesNotMatch(source, /Reload ttyd terminal/);
+  assert.doesNotMatch(source, /Loading ttyd terminal/);
+  assert.doesNotMatch(source, /Open the ttyd terminal directly/);
+});

--- a/packages/web/src/components/sessions/SessionTerminal.tsx
+++ b/packages/web/src/components/sessions/SessionTerminal.tsx
@@ -531,7 +531,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
           setTerminalRelayWsUrl(null);
           setFrameLoaded(false);
         }
-        setConnectionError(connection.reason ?? "Live ttyd terminal is unavailable.");
+        setConnectionError(connection.reason ?? "Live terminal is unavailable.");
       })
       .catch((error) => {
         if (cancelled || !expectsLiveTerminalRef.current) return;
@@ -546,7 +546,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
           setFrameLoaded(false);
         }
         setConnectionError(
-          error instanceof Error ? error.message : "Failed to resolve ttyd terminal.",
+          error instanceof Error ? error.message : "Failed to resolve terminal.",
         );
         const attempt = retryAttemptRef.current;
         const delay = hasTerminal ? 5000 : Math.min(4000, 500 * 2 ** attempt);
@@ -1068,12 +1068,12 @@ function SessionTerminalView(props: SessionTerminalProps) {
 
   const emptyStateDescription = connectionError
     ?? (expectsLiveTerminal
-      ? "Reconnecting to the existing ttyd terminal."
+      ? "Reconnecting to the existing terminal."
       : ttydBacked
-        ? "This ttyd terminal is no longer attached. It only closes after an explicit kill or archive."
+        ? "This terminal is no longer attached. It only closes after an explicit kill or archive."
       : showPromptBar
-        ? "Send a follow-up below to relaunch the agent in a fresh ttyd terminal."
-        : `Session status is \`${normalizedSessionStatus}\`. Interactive ttyd terminals only run while the agent is active.`);
+        ? "Send a follow-up below to relaunch the agent in a fresh terminal."
+        : `Session status is \`${normalizedSessionStatus}\`. Interactive terminals only run while the agent is active.`);
   const terminalDirectHref = terminalLinkUrl ?? terminalUrl ?? undefined;
   const terminalSessionHref = buildSessionHref(sessionId, { bridgeId, tab: "terminal" });
 
@@ -1141,7 +1141,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
           variant="ghost"
           className="h-9 w-9 rounded-full border border-white/10 bg-[#141010]/92 text-[#c9c0b7] backdrop-blur-sm hover:bg-[#201818] sm:h-7 sm:w-7"
           onClick={handleRetry}
-          aria-label="Reload ttyd terminal"
+          aria-label="Reload terminal"
         >
           {resolvingConnection ? (
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -1167,14 +1167,14 @@ function SessionTerminalView(props: SessionTerminalProps) {
               <div className="absolute inset-0 z-10 flex items-center justify-center bg-[#060404]">
                 <div className="flex items-center gap-2 rounded-full border border-white/10 bg-[#141010]/92 px-3 py-2 text-[12px] text-[#c9c0b7] backdrop-blur-sm">
                   <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                  <span>Loading ttyd terminal…</span>
+                  <span>Loading terminal…</span>
                 </div>
               </div>
             ) : null}
             <iframe
               key={`${sessionId}:${iframeReloadNonce}`}
               ref={ttydIframeRef}
-              title={`ttyd terminal for ${sessionId}`}
+              title={`terminal for ${sessionId}`}
               src={terminalUrl}
               className="block h-full min-h-0 w-full flex-1 border-0 bg-[#060404]"
               allow="clipboard-read; clipboard-write"
@@ -1228,7 +1228,7 @@ function SessionTerminalView(props: SessionTerminalProps) {
                         rel="noreferrer"
                         className="text-[12px] text-[#a79c94] underline underline-offset-4"
                       >
-                        Open the ttyd terminal directly
+                        Open the terminal directly
                       </a>
                     </div>
                   ) : null}

--- a/packages/web/src/lib/previewWorkerClient.test.ts
+++ b/packages/web/src/lib/previewWorkerClient.test.ts
@@ -5,6 +5,7 @@ import { getPreviewWorkerClient } from "./previewWorkerClient";
 const env = process.env as Record<string, string | undefined>;
 const originalWorkerUrl = env.CONDUCTOR_PREVIEW_WORKER_URL;
 const originalWorkerKey = env.CONDUCTOR_PREVIEW_WORKER_KEY;
+const originalRelayUrl = env.CONDUCTOR_BRIDGE_RELAY_URL;
 const originalFetch = global.fetch;
 
 function resetWorkerSingleton(): void {
@@ -24,6 +25,11 @@ function restoreEnv(): void {
     delete env.CONDUCTOR_PREVIEW_WORKER_KEY;
   } else {
     env.CONDUCTOR_PREVIEW_WORKER_KEY = originalWorkerKey;
+  }
+  if (originalRelayUrl === undefined) {
+    delete env.CONDUCTOR_BRIDGE_RELAY_URL;
+  } else {
+    env.CONDUCTOR_BRIDGE_RELAY_URL = originalRelayUrl;
   }
 }
 
@@ -87,4 +93,58 @@ test("runCommand creates a remote session and posts the command to the worker", 
 
   assert.ok(calls.some((c) => c.includes("POST") && c.endsWith("/sessions")));
   assert.ok(calls.some((c) => c.includes("POST") && c.includes("/sessions/remote-1/command")));
+});
+
+
+test("configureBridgePreview forwards bridge relay metadata when creating a remote session", async () => {
+  env.CONDUCTOR_PREVIEW_WORKER_URL = "http://127.0.0.1:3099";
+  env.CONDUCTOR_PREVIEW_WORKER_KEY = "unit-test-key";
+  env.CONDUCTOR_BRIDGE_RELAY_URL = "https://relay.example.com";
+
+  let createBody = null as null | Record<string, unknown>;
+
+  global.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" || input instanceof URL ? String(input) : input.url;
+
+    if (url.endsWith("/sessions") && init?.method === "POST") {
+      createBody = JSON.parse(String(init.body)) as Record<string, unknown>;
+      return new Response(JSON.stringify({ sessionId: "remote-bridge-1" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (url.includes("/sessions/remote-bridge-1/command")) {
+      return new Response(JSON.stringify({ kind: "ok" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response("unexpected", { status: 500 });
+  }) as typeof fetch;
+
+  const client = getPreviewWorkerClient();
+  await client.configureBridgePreview(
+    "session-bridge",
+    {
+      bridgeId: "bridge-1",
+      sessionId: "session-1",
+      allowedOrigins: ["http://127.0.0.1:3000"],
+    },
+    { Authorization: "Bearer relay-token", "x-bridge-user-id": "local-admin" },
+  );
+
+  await client.runCommand("session-bridge", { command: "reload" });
+
+  assert.ok(createBody);
+  assert.deepEqual(createBody, {
+    bridgePreview: {
+      bridgeId: "bridge-1",
+      sessionId: "session-1",
+      allowedOrigins: ["http://127.0.0.1:3000"],
+      relayUrl: "https://relay.example.com/",
+      forwardedHeaders: { authorization: "Bearer relay-token", "x-bridge-user-id": "local-admin" },
+    },
+  });
 });

--- a/packages/web/src/lib/previewWorkerClient.ts
+++ b/packages/web/src/lib/previewWorkerClient.ts
@@ -6,6 +6,7 @@ import type {
   PreviewStatusResponse,
 } from "@/lib/previewTypes";
 import type { PreviewBrowserManagerClient } from "./devPreviewBrowser";
+import { resolveBridgeRelayUrl } from "./bridgeRelayUrl";
 
 type WorkerCommandRequest =
   | PreviewCommandRequest
@@ -18,6 +19,15 @@ type WorkerCommandResponse =
   | ({ kind: "dom" } & PreviewDomResponse)
   | { kind: "screenshot"; imageBase64: string }
   | { kind: "error"; message: string };
+
+type RemoteBridgePreviewConfig = BridgePreviewConfig & {
+  relayUrl: string;
+  forwardedHeaders: Record<string, string>;
+};
+
+type CreatePreviewWorkerSessionPayload = {
+  bridgePreview?: RemoteBridgePreviewConfig | null;
+};
 
 function normalizeWorkerUrl(value: string | null | undefined): string | null {
   const trimmed = value?.trim();
@@ -63,18 +73,49 @@ class PreviewWorkerClient implements PreviewBrowserManagerClient {
   private readonly workerUrl = normalizeWorkerUrl(process.env.CONDUCTOR_PREVIEW_WORKER_URL);
   private readonly workerApiKey = process.env.CONDUCTOR_PREVIEW_WORKER_KEY?.trim() || null;
   private readonly remoteSessionIds = new Map<string, string>();
+  private readonly bridgePreviewConfigs = new Map<string, RemoteBridgePreviewConfig | null>();
 
   async configureBridgePreview(
-    _sessionId: string,
-    _config: BridgePreviewConfig | null,
-    _forwardedHeaders?: HeadersInit,
+    sessionId: string,
+    config: BridgePreviewConfig | null,
+    forwardedHeaders?: HeadersInit,
   ): Promise<void> {
-    // The remote worker handles localhost access through its own tunnel flow.
+    const relayUrl = resolveBridgeRelayUrl();
+    const nextConfig = config && forwardedHeaders && relayUrl
+      ? {
+          ...config,
+          relayUrl,
+          forwardedHeaders: Object.fromEntries(new Headers(forwardedHeaders).entries()),
+        }
+      : null;
+    const previousConfig = this.bridgePreviewConfigs.get(sessionId) ?? null;
+    if (JSON.stringify(previousConfig) === JSON.stringify(nextConfig)) {
+      return;
+    }
+
+    this.bridgePreviewConfigs.set(sessionId, nextConfig);
+
+    const remoteSessionId = this.remoteSessionIds.get(sessionId);
+    if (!remoteSessionId || !this.isConfigured()) {
+      return;
+    }
+
+    this.remoteSessionIds.delete(sessionId);
+    try {
+      await fetch(`${this.workerUrl}/sessions/${encodeURIComponent(remoteSessionId)}`, {
+        method: "DELETE",
+        headers: this.buildHeaders(),
+        cache: "no-store",
+      });
+    } catch {
+      // Swallow worker teardown failures so config refresh never blocks callers.
+    }
   }
 
   async destroySession(sessionId: string): Promise<void> {
     const remoteSessionId = this.remoteSessionIds.get(sessionId);
     this.remoteSessionIds.delete(sessionId);
+    this.bridgePreviewConfigs.delete(sessionId);
     if (!remoteSessionId || !this.isConfigured()) {
       return;
     }
@@ -221,20 +262,25 @@ class PreviewWorkerClient implements PreviewBrowserManagerClient {
       throw new Error(configurationError);
     }
 
+    const payload: CreatePreviewWorkerSessionPayload = {
+      bridgePreview: this.bridgePreviewConfigs.get(sessionId) ?? null,
+    };
+
     try {
       const response = await fetch(`${this.workerUrl}/sessions`, {
         method: "POST",
         headers: this.buildHeaders(),
+        body: JSON.stringify(payload),
         cache: "no-store",
       });
 
-      const payload = await response.json() as { sessionId?: string; error?: string };
-      if (!response.ok || !payload.sessionId) {
-        throw new Error(payload.error || "Preview worker session creation failed");
+      const sessionPayload = await response.json() as { sessionId?: string; error?: string };
+      if (!response.ok || !sessionPayload.sessionId) {
+        throw new Error(sessionPayload.error || "Preview worker session creation failed");
       }
 
-      this.remoteSessionIds.set(sessionId, payload.sessionId);
-      return payload.sessionId;
+      this.remoteSessionIds.set(sessionId, sessionPayload.sessionId);
+      return sessionPayload.sessionId;
     } catch (error) {
       throw new Error(this.networkErrorMessage(error));
     }

--- a/preview-worker/src/browser/BrowserManager.ts
+++ b/preview-worker/src/browser/BrowserManager.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
@@ -20,6 +21,7 @@ import { rewriteLoopbackUrl, startTunnel, stopTunnel } from "./tunnel.js";
 import { SessionStore } from "../sessions/SessionStore.js";
 import {
   PreviewWorkerError,
+  type CreatePreviewSessionRequest,
   type PreviewDomResponse,
   type PreviewFrameInfo,
   type PreviewLogEntry,
@@ -34,6 +36,7 @@ import {
   buildPreviewNavigationCandidates,
   isLocalHost,
   normalizeNavigationHostname,
+  resolvePreviewNavigationMode,
 } from "../lib/security.js";
 
 const VIEWPORT = { width: 1440, height: 960 };
@@ -189,6 +192,95 @@ function urlsShareOrigin(left: string, right: string): boolean {
   }
 }
 
+type BridgePreviewResponse = {
+  status: number;
+  headers: Record<string, string>;
+  bodyBase64?: string | null;
+};
+
+function sanitizeBridgePreviewRequestHeaders(
+  headers: Record<string, string>,
+): Record<string, string> {
+  const sanitized: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    const normalized = name.trim().toLowerCase();
+    if (!normalized) continue;
+    if (
+      normalized === "host"
+      || normalized === "connection"
+      || normalized === "proxy-connection"
+      || normalized === "keep-alive"
+      || normalized === "transfer-encoding"
+      || normalized === "content-length"
+      || normalized === "accept-encoding"
+    ) {
+      continue;
+    }
+    sanitized[normalized] = value;
+  }
+  return sanitized;
+}
+
+async function requestBridgePreview(
+  session: PreviewSession,
+  payload: {
+    method: string;
+    url: string;
+    headers: Record<string, string>;
+    bodyBase64: string | null;
+  },
+): Promise<BridgePreviewResponse> {
+  const bridgePreview = session.bridgePreview;
+  if (!bridgePreview) {
+    throw new Error("Bridge preview is not configured for this session.");
+  }
+
+  const target = new URL(`/api/devices/${encodeURIComponent(bridgePreview.bridgeId)}/preview`, bridgePreview.relayUrl);
+  const headers = new Headers(bridgePreview.forwardedHeaders);
+  headers.set("Content-Type", "application/json");
+
+  const response = await fetch(target, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      session_id: bridgePreview.sessionId,
+      method: payload.method,
+      url: payload.url,
+      headers: payload.headers,
+      body_base64: payload.bodyBase64,
+    }),
+    cache: "no-store",
+    redirect: "manual",
+  });
+
+  const body = await response.json().catch(() => null) as
+    | { status?: number; headers?: Record<string, string>; body_base64?: string | null }
+    | { error?: string }
+    | null;
+
+  if (!response.ok) {
+    throw new Error(
+      body && typeof body === "object" && "error" in body && body.error
+        ? body.error
+        : "Failed to reach paired device preview",
+    );
+  }
+
+  const previewBody = body && typeof body === "object"
+    ? body as { status?: number; headers?: Record<string, string>; body_base64?: string | null }
+    : null;
+
+  return {
+    status: typeof previewBody?.status === "number" ? previewBody.status : 502,
+    headers: previewBody?.headers && typeof previewBody.headers === "object"
+      ? previewBody.headers as Record<string, string>
+      : {},
+    bodyBase64: typeof previewBody?.body_base64 === "string" || previewBody?.body_base64 === null
+      ? previewBody.body_base64 as string | null
+      : undefined,
+  };
+}
+
 export class BrowserManager {
   private readonly cleanupTimer: NodeJS.Timeout;
 
@@ -206,7 +298,7 @@ export class BrowserManager {
     return new PreviewWorkerError(statusCode, message);
   }
 
-  async createSession(apiKey: string): Promise<PreviewSession> {
+  async createSession(apiKey: string, options: CreatePreviewSessionRequest = {}): Promise<PreviewSession> {
     if (this.sessionStore.countByApiKey(apiKey) >= this.config.maxSessions) {
       throw this.error(429, "Preview session limit exceeded for this API key.");
     }
@@ -233,6 +325,7 @@ export class BrowserManager {
       tunnelUrl: null,
       tunnelProcess: null,
       tunnelLocalOrigin: null,
+      bridgePreview: options.bridgePreview ?? null,
       status: "active",
       activeFrameId: null,
       selectedElement: null,
@@ -369,19 +462,32 @@ export class BrowserManager {
     let lastError: unknown = null;
 
     for (const candidate of candidates) {
+      const navigationMode = resolvePreviewNavigationMode(candidate, session.bridgePreview);
+      if (navigationMode === "blocked") {
+        lastError = new Error("Bridge preview only allows navigation to the session's reported local dev server origin.");
+        continue;
+      }
+
       const previousUrl = session.page.url();
 
       try {
-        const targetUrl = await this.resolveNavigationTarget(session, candidate);
+        const targetUrl = navigationMode === "bridge"
+          ? candidate
+          : await this.resolveNavigationTarget(session, candidate);
+        await this.syncRequestInterception(session, navigationMode === "bridge");
         await session.page.goto(targetUrl, { waitUntil: "domcontentloaded" });
+        await this.syncRequestInterception(session, navigationMode === "bridge");
         session.selectedElement = null;
         session.lastError = null;
         session.activeFrameId = this.ensureFrameId(session, session.page.mainFrame());
         session.lastRequestedUrl = candidate;
         return;
       } catch (error) {
-        const targetUrl = session.lastRequestedUrl ?? candidate;
+        const targetUrl = navigationMode === "bridge"
+          ? candidate
+          : (session.lastRequestedUrl ?? candidate);
         if (await this.navigationProducedUsablePage(session.page, targetUrl, previousUrl, error)) {
+          await this.syncRequestInterception(session, navigationMode === "bridge");
           session.selectedElement = null;
           session.lastError = null;
           session.activeFrameId = this.ensureFrameId(session, session.page.mainFrame());
@@ -475,7 +581,6 @@ export class BrowserManager {
       session.tunnelLocalOrigin = tunnel.localOrigin;
     }
 
-    await this.syncRequestInterception(session, true);
     const rewritten = rewriteLoopbackUrl(candidate, session.tunnelUrl);
     if (!rewritten) {
       throw this.error(500, "Failed to rewrite localhost preview URL through the tunnel.");
@@ -558,18 +663,48 @@ export class BrowserManager {
     session: PreviewSession,
     request: HTTPRequest,
   ): Promise<void> {
-    if (!session.tunnelUrl) {
+    const bridgePreview = session.bridgePreview;
+    if (!bridgePreview) {
       await request.continue();
       return;
     }
 
-    const rewritten = rewriteLoopbackUrl(request.url(), session.tunnelUrl);
-    if (!rewritten) {
-      await request.continue();
+    let parsed: URL;
+    try {
+      parsed = new URL(request.url());
+    } catch {
+      await request.abort("blockedbyclient");
       return;
     }
 
-    await request.continue({ url: rewritten });
+    if (parsed.protocol !== "http:" && parsed.protocol != "https:") {
+      await request.abort("blockedbyclient");
+      return;
+    }
+
+    if (!bridgePreview.allowedOrigins.includes(parsed.origin)) {
+      await request.abort("blockedbyclient");
+      return;
+    }
+
+    const postData = request.method() === "GET" || request.method() === "HEAD"
+      ? null
+      : request.postData() ?? null;
+
+    const previewResponse = await requestBridgePreview(session, {
+      method: request.method(),
+      url: parsed.toString(),
+      headers: sanitizeBridgePreviewRequestHeaders(request.headers()),
+      bodyBase64: postData ? Buffer.from(postData).toString("base64") : null,
+    });
+
+    await request.respond({
+      status: previewResponse.status,
+      headers: previewResponse.headers,
+      body: previewResponse.bodyBase64
+        ? Buffer.from(previewResponse.bodyBase64, "base64")
+        : Buffer.alloc(0),
+    });
   }
 
   private async syncRequestInterception(session: PreviewSession, enabled: boolean): Promise<void> {

--- a/preview-worker/src/lib/security.test.ts
+++ b/preview-worker/src/lib/security.test.ts
@@ -7,6 +7,7 @@ import {
   isPrivateNetworkHostname,
   normalizeNavigationHostname,
   normalizeNavigationInput,
+  resolvePreviewNavigationMode,
 } from "./security.js";
 
 const env = process.env as Record<string, string | undefined>;
@@ -82,4 +83,15 @@ test("assertSafeDirectNavigationTarget skips checks when unsafe preview hosts ar
 
 test("assertSafeDirectNavigationTarget allows public http when DNS resolves to public addresses", async () => {
   await assertSafeDirectNavigationTarget("http://example.com/");
+});
+
+
+test("resolvePreviewNavigationMode keeps allowed bridge origins on the relay path", () => {
+  const bridgePreview = {
+    allowedOrigins: ["http://127.0.0.1:3000"],
+  };
+
+  assert.equal(resolvePreviewNavigationMode("http://127.0.0.1:3000/", bridgePreview), "bridge");
+  assert.equal(resolvePreviewNavigationMode("https://preview.example.com/app", bridgePreview), "direct");
+  assert.equal(resolvePreviewNavigationMode("http://localhost:3000/", bridgePreview), "blocked");
 });

--- a/preview-worker/src/lib/security.ts
+++ b/preview-worker/src/lib/security.ts
@@ -1,5 +1,6 @@
 import { lookup } from "node:dns/promises";
 import { isIP } from "node:net";
+import type { BridgePreviewSessionConfig } from "./types.js";
 
 const LOCAL_NAVIGATION_HOSTS = ["127.0.0.1", "localhost", "::1", "0.0.0.0"] as const;
 const URL_SCHEME_PATTERN = /^[a-z][a-z\d+.-]*:\/\//i;
@@ -96,6 +97,28 @@ export async function assertSafeDirectNavigationTarget(value: string): Promise<v
     throw new Error(
       "Preview navigation resolved to a private network address and was blocked. Set CONDUCTOR_ALLOW_UNSAFE_PREVIEW_HOSTS=true only if you intentionally trust that target.",
     );
+  }
+}
+
+export type PreviewNavigationMode = "bridge" | "direct" | "blocked";
+
+export function resolvePreviewNavigationMode(
+  value: string,
+  bridgePreview: Pick<BridgePreviewSessionConfig, "allowedOrigins"> | null,
+): PreviewNavigationMode {
+  if (!bridgePreview) {
+    return "direct";
+  }
+
+  try {
+    const parsed = new URL(value);
+    const isLocal = isLocalHost(normalizeNavigationHostname(parsed.hostname));
+    if (bridgePreview.allowedOrigins.includes(parsed.origin)) {
+      return "bridge";
+    }
+    return isLocal ? "blocked" : "direct";
+  } catch {
+    return "direct";
   }
 }
 

--- a/preview-worker/src/lib/types.ts
+++ b/preview-worker/src/lib/types.ts
@@ -86,6 +86,18 @@ export type PreviewCommandRequest =
   | { command: "selectAtPoint"; x: number; y: number }
   | { command: "selectBySelector"; selector: string; frameId?: string | null };
 
+export interface BridgePreviewSessionConfig {
+  bridgeId: string;
+  sessionId: string;
+  allowedOrigins: string[];
+  relayUrl: string;
+  forwardedHeaders: Record<string, string>;
+}
+
+export interface CreatePreviewSessionRequest {
+  bridgePreview?: BridgePreviewSessionConfig | null;
+}
+
 export type WorkerCommandRequest =
   | PreviewCommandRequest
   | { command: "status"; candidateUrls: string[] }
@@ -118,6 +130,7 @@ export interface PreviewSession {
   tunnelUrl: string | null;
   tunnelProcess: ChildProcessByStdio<null, Readable, Readable> | null;
   tunnelLocalOrigin: string | null;
+  bridgePreview: BridgePreviewSessionConfig | null;
   status: "active" | "closing";
   activeFrameId: string | null;
   selectedElement: PreviewElementSelection | null;
@@ -151,6 +164,45 @@ function isNullableString(value: unknown): value is string | null {
 
 function isFiniteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  return isRecord(value) && Object.values(value).every((entry) => typeof entry === "string");
+}
+
+export function parseCreatePreviewSessionRequest(value: unknown): CreatePreviewSessionRequest | null {
+  if (value === undefined || value === null) {
+    return {};
+  }
+  if (!isRecord(value)) {
+    return null;
+  }
+  if (value.bridgePreview === undefined || value.bridgePreview === null) {
+    return { bridgePreview: null };
+  }
+  const bridgePreview = value.bridgePreview;
+  if (!isRecord(bridgePreview)) {
+    return null;
+  }
+  if (
+    typeof bridgePreview.bridgeId !== "string"
+    || typeof bridgePreview.sessionId !== "string"
+    || typeof bridgePreview.relayUrl !== "string"
+    || !Array.isArray(bridgePreview.allowedOrigins)
+    || !bridgePreview.allowedOrigins.every((entry) => typeof entry === "string")
+    || !isStringRecord(bridgePreview.forwardedHeaders)
+  ) {
+    return null;
+  }
+  return {
+    bridgePreview: {
+      bridgeId: bridgePreview.bridgeId,
+      sessionId: bridgePreview.sessionId,
+      relayUrl: bridgePreview.relayUrl,
+      allowedOrigins: bridgePreview.allowedOrigins,
+      forwardedHeaders: bridgePreview.forwardedHeaders,
+    },
+  };
 }
 
 export function parseWorkerCommandRequest(value: unknown): WorkerCommandRequest | null {

--- a/preview-worker/src/routes/sessions.ts
+++ b/preview-worker/src/routes/sessions.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { BrowserManager } from "../browser/BrowserManager.js";
 import { requireRequestApiKey } from "../lib/auth.js";
-import { PreviewWorkerError } from "../lib/types.js";
+import { PreviewWorkerError, parseCreatePreviewSessionRequest } from "../lib/types.js";
 
 function resolveErrorStatus(error: unknown): number {
   return error instanceof PreviewWorkerError ? error.statusCode : 500;
@@ -15,7 +15,11 @@ export function registerSessionRoutes(app: FastifyInstance, browserManager: Brow
   app.post("/sessions", async (request, reply) => {
     try {
       const apiKey = requireRequestApiKey(request);
-      const session = await browserManager.createSession(apiKey);
+      const payload = parseCreatePreviewSessionRequest(request.body);
+      if (!payload) {
+        return await reply.code(400).send({ error: "Invalid preview session payload." });
+      }
+      const session = await browserManager.createSession(apiKey, payload);
       return await reply.code(201).send({ sessionId: session.id });
     } catch (error) {
       return await reply.code(resolveErrorStatus(error)).send({ error: resolveErrorMessage(error) });


### PR DESCRIPTION
## User-Facing Release Notes
- Overview, Review, and Preview tabs scroll correctly again on mobile session pages.
- The Terminal reload button now forces a real terminal frame refresh instead of appearing to do nothing.
- Bridge-backed Preview now uses the hosted preview browser end to end, so paired-device local dev servers can render through the web app instead of falling into dead 404 preview routes.
- Terminal UI copy now stays product-facing and no longer exposes `ttyd` in the visible session chrome.

## Type of Change
- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated terminal interface labels and messaging to remove product-specific terminology; UI now consistently refers to "terminal" instead of branded variants.

* **Tests**
  * Added verification tests for terminal UI text and interface labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->