### PR TITLE
fix(preview): honor manual bridge preview urls

### DIFF
--- a/packages/web/src/app/api/sessions/[id]/preview/route.test.ts
+++ b/packages/web/src/app/api/sessions/[id]/preview/route.test.ts
@@ -315,3 +315,88 @@ test("GET resolves bridge-backed preview session context via the paired device a
     global.fetch = originalFetch;
   }
 });
+
+test("GET uses an explicit previewUrlHint for bridge sessions that did not report a local dev server", async () => {
+  resetEnv();
+  process.env.CONDUCTOR_BACKEND_URL = "http://127.0.0.1:4749";
+  process.env.CONDUCTOR_BRIDGE_RELAY_URL = "https://relay.example.com";
+  process.env.RELAY_JWT_SECRET = "preview-route-test-secret";
+  const seenPaths: string[] = [];
+
+  global.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" || input instanceof URL
+      ? String(input)
+      : input.url;
+
+    assert.equal(url, "https://relay.example.com/api/devices/bridge-1/proxy");
+    assert.equal(init?.method, "POST");
+
+    const body = JSON.parse(String(init?.body)) as { path: string };
+    seenPaths.push(body.path);
+
+    if (body.path === "/api/sessions/session-1") {
+      return new Response(JSON.stringify({
+        id: "session-1",
+        projectId: "demo",
+        status: "working",
+        activity: "active",
+        branch: "feature/demo",
+        issueId: null,
+        summary: null,
+        createdAt: new Date().toISOString(),
+        lastActivityAt: new Date().toISOString(),
+        pr: null,
+        metadata: {},
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (body.path === "/api/sessions/session-1/output?lines=400") {
+      return new Response(JSON.stringify({ output: "" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (body.path === "/api/repositories") {
+      return new Response(JSON.stringify({ repositories: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify({ error: "not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  try {
+    const response = await GET(
+      new NextRequest("http://127.0.0.1:3000/api/sessions/bridge%3Abridge-1%3Asession-1/preview?previewUrlHint=http%3A%2F%2Flocalhost%3A3002%2F"),
+      { params: Promise.resolve({ id: "bridge:bridge-1:session-1" }) },
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(seenPaths, [
+      "/api/sessions/session-1",
+      "/api/sessions/session-1/output?lines=400",
+    ]);
+
+    const payload = await response.json() as {
+      connected: boolean;
+      candidateUrls: string[];
+      currentUrl: string | null;
+      lastError: string | null;
+    };
+
+    assert.equal(payload.connected, false);
+    assert.deepEqual(payload.candidateUrls, ["http://localhost:3002/"]);
+    assert.equal(payload.currentUrl, null);
+    assert.equal(payload.lastError, null);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});

--- a/packages/web/src/app/api/sessions/[id]/preview/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/preview/route.ts
@@ -28,6 +28,20 @@ function withLookupError(
 
 const MISSING_SESSION_PREVIEW_ERROR = "Session is no longer available.";
 
+function readPreviewUrlHint(request: NextRequest): string | null {
+  const value = request.nextUrl.searchParams.get("previewUrlHint");
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function resolveCommandPreviewUrlHint(command: PreviewCommandRequest): string | null {
+  if (command.command === "connect" || command.command === "navigate") {
+    const trimmed = command.url.trim();
+    return trimmed ? trimmed : null;
+  }
+  return null;
+}
+
 export async function GET(request: NextRequest, context: RouteParams): Promise<Response> {
   const denied = await guardApiAccess(request, "viewer");
   if (denied) return denied;
@@ -38,6 +52,7 @@ export async function GET(request: NextRequest, context: RouteParams): Promise<R
   const previewContext = await loadPreviewSessionContext(id, {
     request,
     headers: forwardedHeaders,
+    previewUrlHint: readPreviewUrlHint(request),
   });
   const manager = getPreviewBrowserManager();
   if (!previewContext.session && !previewContext.error) {
@@ -78,22 +93,23 @@ export async function POST(request: NextRequest, context: RouteParams): Promise<
 
   const { id } = await context.params;
 
-  const forwardedHeaders = await buildForwardedAccessHeaders(request);
-  const previewContext = await loadPreviewSessionContext(id, {
-    request,
-    headers: forwardedHeaders,
-  });
-  const manager = getPreviewBrowserManager();
-  if (!previewContext.session && !previewContext.error) {
-    await manager.destroySession(id);
-    return NextResponse.json({ error: MISSING_SESSION_PREVIEW_ERROR }, { status: 404 });
-  }
-
   let body: PreviewCommandRequest;
   try {
     body = await request.json() as PreviewCommandRequest;
   } catch {
     return NextResponse.json({ error: "Invalid preview command payload" }, { status: 400 });
+  }
+
+  const forwardedHeaders = await buildForwardedAccessHeaders(request);
+  const previewContext = await loadPreviewSessionContext(id, {
+    request,
+    headers: forwardedHeaders,
+    previewUrlHint: resolveCommandPreviewUrlHint(body) ?? readPreviewUrlHint(request),
+  });
+  const manager = getPreviewBrowserManager();
+  if (!previewContext.session && !previewContext.error) {
+    await manager.destroySession(id);
+    return NextResponse.json({ error: MISSING_SESSION_PREVIEW_ERROR }, { status: 404 });
   }
 
   await manager.configureBridgePreview(

--- a/packages/web/src/components/sessions/SessionPreview.tsx
+++ b/packages/web/src/components/sessions/SessionPreview.tsx
@@ -374,6 +374,16 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
   const showMobileInspector = mobileViewport && mobileInspectorOpen;
   const showCandidateChips = !mobileViewport || mobileInspectorOpen;
 
+  const buildPreviewRequestPath = useCallback((previewUrlHint?: string | null) => {
+    const searchParams = new URLSearchParams();
+    const trimmedHint = previewUrlHint?.trim();
+    if (trimmedHint) {
+      searchParams.set("previewUrlHint", trimmedHint);
+    }
+    const query = searchParams.toString();
+    return `/api/sessions/${encodeURIComponent(sessionId)}/preview${query ? `?${query}` : ""}`;
+  }, [sessionId]);
+
   useEffect(() => {
     const handleVisibilityChange = () => {
       setPageVisible(!document.hidden);
@@ -425,7 +435,26 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
     autoConnectAttemptCountRef.current = 0;
     screenshotLoadCountRef.current = 0;
     setMobileInspectorOpen(false);
+
+    if (typeof window === "undefined") {
+      return;
+    }
+    const stored = window.sessionStorage.getItem(`conductor-preview-url:${sessionId}`)?.trim();
+    setUrlInput(stored ?? "");
   }, [sessionId]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const key = `conductor-preview-url:${sessionId}`;
+    const trimmed = urlInput.trim();
+    if (trimmed) {
+      window.sessionStorage.setItem(key, trimmed);
+    } else {
+      window.sessionStorage.removeItem(key);
+    }
+  }, [sessionId, urlInput]);
 
   useEffect(() => {
     if (!mobileViewport) {
@@ -440,7 +469,7 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
     }
 
     try {
-      const response = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/preview`, {
+      const response = await fetch(buildPreviewRequestPath(urlInput), {
         cache: "no-store",
       });
       const payload = await response.json().catch(() => null) as
@@ -472,14 +501,17 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
       statusLoadFailureCountRef.current += 1;
       throw error;
     }
-  }, [sessionId]);
+  }, [buildPreviewRequestPath, urlInput]);
 
   const runCommand = useCallback(async (command: PreviewCommandRequest): Promise<PreviewStatusResponse> => {
     commandCountRef.current += 1;
     setBusy(true);
     setCommandError(null);
     try {
-      const response = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/preview`, {
+      const previewUrlHint = command.command === "connect" || command.command === "navigate"
+        ? command.url
+        : urlInput;
+      const response = await fetch(buildPreviewRequestPath(previewUrlHint), {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -507,7 +539,7 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
     } finally {
       setBusy(false);
     }
-  }, [sessionId]);
+  }, [buildPreviewRequestPath, urlInput]);
 
   const queuePreviewCommand = useCallback((command: PreviewCommandRequest, fallbackMessage: string) => {
     previewCommandQueueRef.current = previewCommandQueueRef.current

--- a/packages/web/src/lib/previewSession.test.ts
+++ b/packages/web/src/lib/previewSession.test.ts
@@ -124,6 +124,80 @@ test("discoverPreviewCandidateUrls skips bridge output without request context",
   }
 });
 
+test("discoverPreviewCandidateUrls falls back to project dev server config when session metadata lacks a loopback url", async () => {
+  const previousBackendUrl = process.env.CONDUCTOR_BACKEND_URL;
+  const previousFetch = global.fetch;
+
+  process.env.CONDUCTOR_BACKEND_URL = "http://127.0.0.1:4749";
+  global.fetch = (async (input: string | URL) => {
+    const url = String(input);
+    if (url.endsWith("/api/sessions/session-1/output?lines=400")) {
+      return new Response(JSON.stringify({ output: "" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (url.endsWith("/api/repositories")) {
+      return new Response(JSON.stringify({
+        repositories: [{
+          id: "demo",
+          devServerUrl: "",
+          devServerPort: "3002",
+          devServerHost: "0.0.0.0",
+          devServerPath: "/app",
+          devServerHttps: true,
+        }],
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response("not found", { status: 404 });
+  }) as typeof fetch;
+
+  try {
+    const session = buildSession({});
+    const urls = await discoverPreviewCandidateUrls(session);
+
+    assert.deepEqual(urls, [
+      "https://127.0.0.1:3002/app",
+      "https://deploy-preview.example.com/",
+    ]);
+  } finally {
+    process.env.CONDUCTOR_BACKEND_URL = previousBackendUrl;
+    global.fetch = previousFetch;
+  }
+});
+
+test("discoverPreviewCandidateUrls prioritizes an explicit preview url hint", async () => {
+  const previousBackendUrl = process.env.CONDUCTOR_BACKEND_URL;
+  const previousFetch = global.fetch;
+
+  process.env.CONDUCTOR_BACKEND_URL = "http://127.0.0.1:4749";
+  global.fetch = (async (input: string | URL) => {
+    const url = String(input);
+    assert.match(url, /\/api\/sessions\/session-1\/output\?lines=400$/);
+    return new Response(JSON.stringify({ output: "" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  try {
+    const session = buildSession({});
+    const urls = await discoverPreviewCandidateUrls(session, { previewUrlHint: "http://localhost:3002" });
+
+    assert.deepEqual(urls, [
+      "http://localhost:3002/",
+      "https://deploy-preview.example.com/",
+    ]);
+  } finally {
+    process.env.CONDUCTOR_BACKEND_URL = previousBackendUrl;
+    global.fetch = previousFetch;
+  }
+});
 test("loadPreviewSessionContext captures backend lookup failures without throwing", async () => {
   const previousBackendUrl = process.env.CONDUCTOR_BACKEND_URL;
 

--- a/packages/web/src/lib/previewSession.ts
+++ b/packages/web/src/lib/previewSession.ts
@@ -25,6 +25,94 @@ function getBackendUrl(): string {
   return resolveRustBackendUrl() ?? "";
 }
 
+function normalizeConfiguredDevServerHost(value: string | null | undefined): string {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return "127.0.0.1";
+  }
+  return trimmed === "0.0.0.0" ? "127.0.0.1" : trimmed;
+}
+
+function normalizeConfiguredDevServerPath(value: string | null | undefined): string {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed === "/") {
+    return "";
+  }
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
+function readRecordString(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  return typeof value === "string" ? value : null;
+}
+
+function readRecordBoolean(record: Record<string, unknown>, key: string): boolean {
+  return record[key] === true;
+}
+
+function resolveProjectConfiguredPreviewUrl(record: Record<string, unknown>): string | null {
+  const explicitUrl = readRecordString(record, "devServerUrl")?.trim();
+  if (explicitUrl) {
+    return explicitUrl;
+  }
+
+  const port = readRecordString(record, "devServerPort")?.trim();
+  if (!port) {
+    return null;
+  }
+
+  const scheme = readRecordBoolean(record, "devServerHttps") ? "https" : "http";
+  const host = normalizeConfiguredDevServerHost(readRecordString(record, "devServerHost"));
+  const path = normalizeConfiguredDevServerPath(readRecordString(record, "devServerPath"));
+  return `${scheme}://${host}:${port}${path}`;
+}
+
+async function fetchProjectPreviewCandidateUrls(
+  session: DashboardSession,
+  options: PreviewFetchOptions = {},
+): Promise<string[]> {
+  const bridgeId = session.bridgeId?.trim() || decodeBridgeSessionId(session.id)?.bridgeId || null;
+  let response: Response;
+
+  try {
+    if (bridgeId) {
+      if (!options.request) {
+        return [];
+      }
+      response = await proxyToBridgeDevice(options.request, bridgeId, "/api/repositories", {
+        pathOverride: "/api/repositories",
+      });
+    } else {
+      const backendUrl = requireRustBackendUrl();
+      response = await fetch(new URL("/api/repositories", backendUrl), {
+        cache: "no-store",
+        headers: options.headers,
+      });
+    }
+  } catch {
+    return [];
+  }
+
+  if (!response.ok) {
+    return [];
+  }
+
+  const payload = await response.json().catch(() => null) as { repositories?: unknown } | null;
+  const repositories = Array.isArray(payload?.repositories) ? payload.repositories : [];
+  const repository = repositories.find((candidate) => (
+    candidate
+    && typeof candidate === "object"
+    && readRecordString(candidate as Record<string, unknown>, "id") === session.projectId
+  ));
+
+  if (!repository || typeof repository !== "object") {
+    return [];
+  }
+
+  const configuredPreviewUrl = resolveProjectConfiguredPreviewUrl(repository as Record<string, unknown>);
+  return configuredPreviewUrl ? [configuredPreviewUrl] : [];
+}
+
 export interface PreviewSessionContext {
   session: DashboardSession | null;
   candidateUrls: string[];
@@ -35,6 +123,7 @@ export interface PreviewSessionContext {
 type PreviewFetchOptions = {
   headers?: HeadersInit;
   request?: Request;
+  previewUrlHint?: string | null;
 };
 
 export interface BridgePreviewConfig {
@@ -298,6 +387,10 @@ export async function discoverPreviewCandidateUrls(
   const backendUrl = getBackendUrl();
   const candidates = new Map<string, number>();
 
+  if (options.previewUrlHint?.trim()) {
+    pushCandidate(candidates, options.previewUrlHint, -10, backendUrl, true);
+  }
+
   if (session.pr?.previewUrl?.trim()) {
     pushCandidate(candidates, session.pr.previewUrl, 50, backendUrl, true);
   }
@@ -306,17 +399,21 @@ export async function discoverPreviewCandidateUrls(
     pushCandidate(candidates, session.metadata.devServerUrl, 0, backendUrl, true);
   }
 
-  for (const [key, value] of Object.entries(session.metadata)) {
-    if (DIRECT_URL_METADATA_KEYS.has(key) && value.trim()) {
+  for (const [key, rawValue] of Object.entries(session.metadata)) {
+    if (typeof rawValue !== "string") {
+      continue;
+    }
+
+    if (DIRECT_URL_METADATA_KEYS.has(key) && rawValue.trim()) {
       pushCandidate(
         candidates,
-        value,
+        rawValue,
         DIRECT_URL_METADATA_PRIORITY[key] ?? 30,
         backendUrl,
         true,
       );
     }
-    for (const candidate of extractUrlsFromText(value)) {
+    for (const candidate of extractUrlsFromText(rawValue)) {
       pushCandidate(candidates, candidate, 60, backendUrl);
     }
   }
@@ -334,6 +431,13 @@ export async function discoverPreviewCandidateUrls(
 
   for (const candidate of extractUrlsFromText(await fetchSessionOutputForPreview(session.id, options))) {
     pushCandidate(candidates, candidate, 80, backendUrl);
+  }
+
+  const hasLoopbackCandidate = [...candidates.keys()].some((candidate) => isLoopbackUrl(candidate));
+  if (!hasLoopbackCandidate) {
+    for (const candidate of await fetchProjectPreviewCandidateUrls(session, options)) {
+      pushCandidate(candidates, candidate, 20, backendUrl, true);
+    }
   }
 
   const orderedCandidates = [...candidates.entries()]


### PR DESCRIPTION
## User-Facing Release Notes
- Bridge previews now honor the manual local preview URL you enter in the Preview tab, even when the session did not report it in metadata.
- Hosted preview can now fall back to the project's configured dev server URL when session metadata is missing the local preview address.

## Type of Change
- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Summary
- allow bridge preview to use an explicit local preview URL hint from the session UI
- fall back to project dev server config when a session does not report a loopback preview URL
- persist the preview URL input per session and cover the bridge hint path with tests

## Testing
- bun test packages/web/src/lib/previewSession.test.ts packages/web/src/app/api/sessions/[id]/preview/route.test.ts
- bun run --cwd packages/web typecheck
- bun run --cwd packages/web build
