### PR TITLE
fix(preview): harden hosted tunnel readiness

### DIFF
--- a/crates/conductor-core/src/config.rs
+++ b/crates/conductor-core/src/config.rs
@@ -533,6 +533,8 @@ pub struct PreferencesConfig {
     pub markdown_editor: String,
     #[serde(default)]
     pub markdown_editor_path: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub filesystem_browse_roots: Vec<String>,
     #[serde(default)]
     pub model_access: ModelAccessPreferences,
     #[serde(default)]
@@ -547,9 +549,21 @@ impl Default for PreferencesConfig {
             ide: default_ide(),
             markdown_editor: default_markdown_editor(),
             markdown_editor_path: String::new(),
+            filesystem_browse_roots: Vec::new(),
             model_access: ModelAccessPreferences::default(),
             notifications: NotificationPreferences::default(),
         }
+    }
+}
+
+impl PreferencesConfig {
+    fn normalize(&mut self) {
+        self.filesystem_browse_roots = self
+            .filesystem_browse_roots
+            .iter()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .collect();
     }
 }
 
@@ -738,6 +752,7 @@ impl ConductorConfig {
             webhook.normalize();
         }
         config.defaults.normalize();
+        config.preferences.normalize();
         for project in config.projects.values_mut() {
             project.normalize_runtime();
             project.normalize_dev_server();
@@ -861,9 +876,34 @@ webhook:
         .unwrap();
 
         let config = ConductorConfig::load(&path).unwrap();
-        let webhook = config.webhook.expect("webhook config");
-        assert_eq!(webhook.port, 4748);
+        let webhook = config.webhook.expect("webhook should exist");
         assert_eq!(webhook.secret.as_deref(), Some("test-secret"));
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn test_load_normalizes_filesystem_browse_roots() {
+        let root = std::env::temp_dir().join(format!("conductor-config-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).unwrap();
+        let path = root.join("conductor.yaml");
+        std::fs::write(
+            &path,
+            r#"
+preferences:
+  filesystemBrowseRoots:
+    - "  /Users  "
+    - ""
+    - " /Volumes/projects "
+"#,
+        )
+        .unwrap();
+
+        let config = ConductorConfig::load(&path).unwrap();
+        assert_eq!(
+            config.preferences.filesystem_browse_roots,
+            vec!["/Users".to_string(), "/Volumes/projects".to_string()]
+        );
 
         std::fs::remove_dir_all(root).unwrap();
     }

--- a/crates/conductor-core/src/scaffold.rs
+++ b/crates/conductor-core/src/scaffold.rs
@@ -27,6 +27,7 @@ pub struct ScaffoldPreferencesConfig {
     pub ide: Option<String>,
     pub markdown_editor: Option<String>,
     pub markdown_editor_path: Option<String>,
+    pub filesystem_browse_roots: Option<Vec<String>>,
     pub model_access: Option<ModelAccessPreferences>,
     pub notifications: Option<ScaffoldNotificationPreferences>,
 }
@@ -161,6 +162,8 @@ struct ScaffoldPreferencesRecord {
     markdown_editor: String,
     #[serde(skip_serializing_if = "String::is_empty")]
     markdown_editor_path: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    filesystem_browse_roots: Vec<String>,
     model_access: ModelAccessPreferences,
     notifications: NotificationPreferences,
 }
@@ -497,6 +500,14 @@ fn build_preferences_record(
             .map(str::trim)
             .unwrap_or_default()
             .to_string(),
+        filesystem_browse_roots: config
+            .and_then(|value| value.filesystem_browse_roots.as_ref())
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .collect(),
         model_access: config
             .and_then(|value| value.model_access.clone())
             .unwrap_or_default(),

--- a/crates/conductor-core/src/support.rs
+++ b/crates/conductor-core/src/support.rs
@@ -78,6 +78,8 @@ struct MirrorPreferences {
     markdown_editor: String,
     #[serde(skip_serializing_if = "String::is_empty")]
     markdown_editor_path: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    filesystem_browse_roots: Vec<String>,
     model_access: ModelAccessPreferences,
     notifications: NotificationPreferences,
 }
@@ -282,6 +284,12 @@ fn build_preferences(preferences: &PreferencesConfig) -> MirrorPreferences {
             preferences.markdown_editor.clone()
         },
         markdown_editor_path: preferences.markdown_editor_path.trim().to_string(),
+        filesystem_browse_roots: preferences
+            .filesystem_browse_roots
+            .iter()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .collect(),
         model_access: preferences.model_access.clone(),
         notifications: preferences.notifications.clone(),
     }

--- a/crates/conductor-server/src/routes/config.rs
+++ b/crates/conductor-server/src/routes/config.rs
@@ -78,6 +78,7 @@ struct PreferencesBody {
     ide: Option<String>,
     markdown_editor: Option<String>,
     markdown_editor_path: Option<String>,
+    filesystem_browse_roots: Option<Vec<String>>,
     notifications: Option<NotificationsBody>,
     model_access: Option<HashMap<String, String>>,
 }
@@ -153,6 +154,9 @@ async fn update_preferences(
         markdown_editor_path: body
             .markdown_editor_path
             .unwrap_or(current.markdown_editor_path),
+        filesystem_browse_roots: body
+            .filesystem_browse_roots
+            .unwrap_or(current.filesystem_browse_roots),
         model_access: merge_model_access_preferences(
             &current.model_access,
             body.model_access.as_ref(),

--- a/crates/conductor-server/src/routes/filesystem.rs
+++ b/crates/conductor-server/src/routes/filesystem.rs
@@ -2,6 +2,7 @@ use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::routing::{get, post};
 use axum::{Json, Router};
+use conductor_core::config::ConductorConfig;
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::path::{Path, PathBuf};
@@ -34,6 +35,8 @@ async fn read_directory(
     State(state): State<Arc<AppState>>,
     Query(query): Query<DirectoryQuery>,
 ) -> ApiResponse {
+    let config = state.config.read().await.clone();
+    let browse_roots = allowed_browse_roots(&state.workspace_path, &config);
     let requested = query
         .path
         .as_deref()
@@ -52,7 +55,7 @@ async fn read_directory(
         return error(StatusCode::NOT_FOUND, "Directory not found");
     }
 
-    let Ok(current_path) = resolve_browse_path(&current_path, &state.workspace_path) else {
+    let Ok(current_path) = resolve_browse_path(&current_path, &browse_roots) else {
         return error(
             StatusCode::FORBIDDEN,
             "Access to this directory is not allowed",
@@ -71,18 +74,17 @@ async fn read_directory(
                     let path = entry.path();
                     let file_type = entry.file_type().ok();
                     let resolved_path = resolved_entry_path(&path, file_type.as_ref());
-
-                    if let Some(resolved_path) = resolved_path.as_deref() {
-                        if !is_within_allowed_roots(resolved_path, &state.workspace_path) {
-                            return None;
-                        }
-                    }
-
                     let is_directory = resolved_path
                         .as_deref()
                         .map(Path::is_dir)
                         .or_else(|| file_type.as_ref().map(|value| value.is_dir()))
                         .unwrap_or(false);
+                    let access_path = resolved_path.as_deref().unwrap_or(path.as_path());
+
+                    if !is_visible_entry(access_path, is_directory, &browse_roots) {
+                        return None;
+                    }
+
                     Some(json!({
                         "name": entry.file_name().to_string_lossy().to_string(),
                         "path": path.to_string_lossy().to_string(),
@@ -129,14 +131,18 @@ fn resolve_user_home_dir() -> Option<PathBuf> {
 }
 
 /// Allowed root directories for filesystem browsing.
-fn allowed_browse_roots() -> Vec<PathBuf> {
+fn allowed_browse_roots(workspace_path: &Path, config: &ConductorConfig) -> Vec<PathBuf> {
     let mut roots = Vec::new();
     if let Some(home) = resolve_user_home_dir() {
         roots.push(home);
     }
-    // On macOS, /Volumes is common for external drives.
+    roots.push(workspace_path.to_path_buf());
+    // On macOS, /Users and /Volumes are the common local roots users expect to browse.
     #[cfg(target_os = "macos")]
-    roots.push(PathBuf::from("/Volumes"));
+    {
+        roots.push(PathBuf::from("/Users"));
+        roots.push(PathBuf::from("/Volumes"));
+    }
     // On Linux, common project locations.
     #[cfg(target_os = "linux")]
     {
@@ -152,16 +158,38 @@ fn allowed_browse_roots() -> Vec<PathBuf> {
             }
         }
     }
-    roots
+    roots.extend(
+        config
+            .preferences
+            .filesystem_browse_roots
+            .iter()
+            .map(|value| expand_path(value, workspace_path)),
+    );
+    dedupe_browse_roots(roots)
+}
+
+fn dedupe_browse_roots(roots: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut deduped = Vec::new();
+    for root in roots {
+        if root.as_os_str().is_empty() {
+            continue;
+        }
+        let canonical = canonicalize_for_access(&root);
+        if deduped.iter().any(|existing| existing == &canonical) {
+            continue;
+        }
+        deduped.push(canonical);
+    }
+    deduped
 }
 
 fn canonicalize_for_access(path: &Path) -> PathBuf {
     std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
-fn resolve_browse_path(path: &Path, workspace_path: &Path) -> Result<PathBuf, ()> {
+fn resolve_browse_path(path: &Path, browse_roots: &[PathBuf]) -> Result<PathBuf, ()> {
     let resolved = std::fs::canonicalize(path).map_err(|_| ())?;
-    is_within_allowed_roots(&resolved, workspace_path)
+    is_browsable_directory(&resolved, browse_roots)
         .then_some(resolved)
         .ok_or(())
 }
@@ -172,21 +200,36 @@ fn resolved_entry_path(path: &Path, file_type: Option<&std::fs::FileType>) -> Op
         .and_then(|_| std::fs::canonicalize(path).ok())
 }
 
-fn is_within_allowed_roots(path: &Path, workspace_path: &Path) -> bool {
+fn is_path_within_root(path: &Path, root: &Path) -> bool {
     let path = canonicalize_for_access(path);
-    let workspace_path = canonicalize_for_access(workspace_path);
+    let root = canonicalize_for_access(root);
+    path.starts_with(root)
+}
 
-    // Always allow workspace path itself.
-    if path.starts_with(workspace_path) {
-        return true;
+fn is_path_ancestor_of_root(path: &Path, root: &Path) -> bool {
+    let path = canonicalize_for_access(path);
+    let root = canonicalize_for_access(root);
+    root.starts_with(path)
+}
+
+fn is_browsable_directory(path: &Path, browse_roots: &[PathBuf]) -> bool {
+    browse_roots
+        .iter()
+        .any(|root| is_path_within_root(path, root) || is_path_ancestor_of_root(path, root))
+}
+
+fn is_browsable_file(path: &Path, browse_roots: &[PathBuf]) -> bool {
+    browse_roots
+        .iter()
+        .any(|root| is_path_within_root(path, root))
+}
+
+fn is_visible_entry(path: &Path, is_directory: bool, browse_roots: &[PathBuf]) -> bool {
+    if is_directory {
+        is_browsable_directory(path, browse_roots)
+    } else {
+        is_browsable_file(path, browse_roots)
     }
-
-    // Check against allowed roots.
-    let roots = allowed_browse_roots();
-    roots
-        .into_iter()
-        .map(|root| canonicalize_for_access(&root))
-        .any(|root| path.starts_with(root))
 }
 
 fn expand_path(value: &str, workspace_path: &Path) -> PathBuf {
@@ -255,7 +298,7 @@ if ($result -eq [System.Windows.Forms.DialogResult]::OK) {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_within_allowed_roots, resolve_browse_path};
+    use super::{is_browsable_directory, is_browsable_file, is_visible_entry, resolve_browse_path};
     use std::fs;
 
     #[test]
@@ -267,10 +310,10 @@ mod tests {
         fs::create_dir_all(&workspace_path).unwrap();
         fs::create_dir_all(&outside_path).unwrap();
 
-        let traversal_path = workspace_path.join("..").join("outside");
+        let browse_roots = vec![workspace_path.clone()];
 
-        assert!(is_within_allowed_roots(&workspace_path, &workspace_path));
-        assert!(!is_within_allowed_roots(&traversal_path, &workspace_path));
+        assert!(is_browsable_directory(&workspace_path, &browse_roots));
+        assert!(!is_browsable_directory(&outside_path, &browse_roots));
 
         fs::remove_dir_all(&root).unwrap();
     }
@@ -289,8 +332,48 @@ mod tests {
         fs::create_dir_all(&outside_path).unwrap();
         symlink(&outside_path, &symlink_path).unwrap();
 
-        assert!(resolve_browse_path(&workspace_path, &workspace_path).is_ok());
-        assert!(resolve_browse_path(&symlink_path, &workspace_path).is_err());
+        let browse_roots = vec![workspace_path.clone()];
+
+        assert!(resolve_browse_path(&workspace_path, &browse_roots).is_ok());
+        assert!(resolve_browse_path(&symlink_path, &browse_roots).is_err());
+
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn browse_path_allows_ancestor_directories_of_configured_roots() {
+        let root =
+            std::env::temp_dir().join(format!("conductor-filesystem-{}", uuid::Uuid::new_v4()));
+        let allowed_root = root.join("Users").join("charann");
+        fs::create_dir_all(&allowed_root).unwrap();
+
+        let browse_roots = vec![allowed_root.clone()];
+
+        assert!(resolve_browse_path(&root, &browse_roots).is_ok());
+        assert!(resolve_browse_path(&root.join("Users"), &browse_roots).is_ok());
+        assert!(resolve_browse_path(&allowed_root, &browse_roots).is_ok());
+
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn visible_entries_hide_unreachable_directories_but_keep_ancestors() {
+        let root =
+            std::env::temp_dir().join(format!("conductor-filesystem-{}", uuid::Uuid::new_v4()));
+        let allowed_root = root.join("Users").join("charann");
+        let blocked_root = root.join("Applications");
+        let file_path = allowed_root.join("notes.txt");
+        fs::create_dir_all(&allowed_root).unwrap();
+        fs::create_dir_all(&blocked_root).unwrap();
+        fs::write(&file_path, "ok").unwrap();
+
+        let browse_roots = vec![allowed_root.clone()];
+
+        assert!(is_visible_entry(&root.join("Users"), true, &browse_roots));
+        assert!(is_visible_entry(&allowed_root, true, &browse_roots));
+        assert!(!is_visible_entry(&blocked_root, true, &browse_roots));
+        assert!(is_visible_entry(&file_path, false, &browse_roots));
+        assert!(!is_browsable_file(&blocked_root.join("app"), &browse_roots));
 
         fs::remove_dir_all(&root).unwrap();
     }

--- a/packages/web/src/features/dashboard/DashboardClient.tsx
+++ b/packages/web/src/features/dashboard/DashboardClient.tsx
@@ -398,6 +398,7 @@ type PreferencesPayload = {
   ide: string;
   markdownEditor: string;
   markdownEditorPath: string;
+  filesystemBrowseRoots: string[];
   modelAccess: ModelAccessPreferences;
   notifications: {
     soundEnabled: boolean;
@@ -571,6 +572,12 @@ function normalizePreferences(value: unknown, fallbackAgent: string): Preference
   const markdownEditorPath = typeof payload["markdownEditorPath"] === "string"
     ? payload["markdownEditorPath"].trim()
     : "";
+  const filesystemBrowseRoots = Array.isArray(payload["filesystemBrowseRoots"])
+    ? payload["filesystemBrowseRoots"]
+        .filter((item): item is string => typeof item === "string")
+        .map((item) => item.trim())
+        .filter(Boolean)
+    : [];
 
   return {
     onboardingAcknowledged: payload["onboardingAcknowledged"] === true,
@@ -578,6 +585,7 @@ function normalizePreferences(value: unknown, fallbackAgent: string): Preference
     ide,
     markdownEditor,
     markdownEditorPath,
+    filesystemBrowseRoots,
     modelAccess: normalizeModelAccessPreferences(payload["modelAccess"]),
     notifications: {
       soundEnabled: notifications["soundEnabled"] !== false,

--- a/packages/web/src/features/dashboard/components/DashboardDialogs.tsx
+++ b/packages/web/src/features/dashboard/components/DashboardDialogs.tsx
@@ -259,6 +259,7 @@ type PreferencesPayload = {
   ide: string;
   markdownEditor: string;
   markdownEditorPath: string;
+  filesystemBrowseRoots: string[];
   modelAccess: ModelAccessPreferences;
   notifications: {
     soundEnabled: boolean;
@@ -426,6 +427,12 @@ function normalizePreferences(value: unknown, fallbackAgent: string): Preference
   const markdownEditorPath = typeof payload["markdownEditorPath"] === "string"
     ? payload["markdownEditorPath"].trim()
     : "";
+  const filesystemBrowseRoots = Array.isArray(payload["filesystemBrowseRoots"])
+    ? payload["filesystemBrowseRoots"]
+        .filter((item): item is string => typeof item === "string")
+        .map((item) => item.trim())
+        .filter(Boolean)
+    : [];
 
   return {
     onboardingAcknowledged: payload["onboardingAcknowledged"] === true,
@@ -433,6 +440,7 @@ function normalizePreferences(value: unknown, fallbackAgent: string): Preference
     ide,
     markdownEditor,
     markdownEditorPath,
+    filesystemBrowseRoots,
     modelAccess: normalizeModelAccessPreferences(payload["modelAccess"]),
     notifications: {
       soundEnabled: notifications["soundEnabled"] !== false,
@@ -2157,6 +2165,7 @@ export function SettingsDialog({
   const [ide, setIde] = useState(current.ide);
   const [markdownEditor, setMarkdownEditor] = useState(current.markdownEditor);
   const [markdownEditorPath, setMarkdownEditorPath] = useState<string>(current.markdownEditorPath ?? "");
+  const [filesystemBrowseRootsInput, setFilesystemBrowseRootsInput] = useState(() => current.filesystemBrowseRoots.join("\n"));
   const [modelAccess, setModelAccess] = useState<ModelAccessPreferences>(current.modelAccess);
   const [soundEnabled, setSoundEnabled] = useState(current.notifications.soundEnabled);
   const [soundFile, setSoundFile] = useState<string | null>(current.notifications.soundFile);
@@ -2172,6 +2181,7 @@ export function SettingsDialog({
   const [repositoryBranchesError, setRepositoryBranchesError] = useState<string | null>(null);
   const [repositoryFolderPickerOpen, setRepositoryFolderPickerOpen] = useState(false);
   const [notesFolderPickerOpen, setNotesFolderPickerOpen] = useState(false);
+  const [filesystemRootPickerOpen, setFilesystemRootPickerOpen] = useState(false);
   const [accessSettings, setAccessSettings] = useState<AccessSettingsPayload>(() => normalizeAccessSettings(null));
   const [accessLoading, setAccessLoading] = useState(false);
   const [accessSaving, setAccessSaving] = useState(false);
@@ -2455,6 +2465,7 @@ function hydrateRepositoryDraft(value: RepositorySettingsPayload): RepositorySet
     setIde(current.ide);
     setMarkdownEditor(current.markdownEditor);
     setMarkdownEditorPath(current.markdownEditorPath ?? "");
+    setFilesystemBrowseRootsInput(current.filesystemBrowseRoots.join("\n"));
     setModelAccess(current.modelAccess);
     setSoundEnabled(current.notifications.soundEnabled);
     setSoundFile(current.notifications.soundFile);
@@ -2632,6 +2643,10 @@ function hydrateRepositoryDraft(value: RepositorySettingsPayload): RepositorySet
     const resolvedSoundFile = soundEnabled
       ? soundFile ?? NOTIFICATION_SOUND_OPTIONS[0]?.id ?? "abstract-sound-4"
       : null;
+    const filesystemBrowseRoots = filesystemBrowseRootsInput
+      .split(/\n+/g)
+      .map((value) => value.trim())
+      .filter(Boolean);
 
     return {
       onboardingAcknowledged: acknowledgeOnboarding ? true : current.onboardingAcknowledged,
@@ -2639,6 +2654,7 @@ function hydrateRepositoryDraft(value: RepositorySettingsPayload): RepositorySet
       ide: ide.trim(),
       markdownEditor: markdownEditor.trim(),
       markdownEditorPath: (markdownEditorPath ?? "").trim(),
+      filesystemBrowseRoots,
       modelAccess,
       notifications: {
         soundEnabled,
@@ -2689,7 +2705,7 @@ function hydrateRepositoryDraft(value: RepositorySettingsPayload): RepositorySet
       <div
         className="fixed inset-0 z-[90] flex items-start justify-center overflow-y-auto bg-black/70 px-3 py-3 sm:items-center"
         onClick={() => {
-          if (isBusy || mode === "onboarding" || repositoryFolderPickerOpen || notesFolderPickerOpen) return;
+          if (isBusy || mode === "onboarding" || repositoryFolderPickerOpen || notesFolderPickerOpen || filesystemRootPickerOpen) return;
           onClose();
         }}
         role="presentation"
@@ -2983,6 +2999,42 @@ function hydrateRepositoryDraft(value: RepositorySettingsPayload): RepositorySet
                             </label>
                           </div>
                         )}
+                        <div className="rounded-[4px] border border-[var(--vk-border)] px-3 py-3">
+                          <label className="block">
+                            <span className="mb-1.5 block text-[12px] font-medium text-[var(--vk-text-normal)]">
+                              Extra Filesystem Roots
+                            </span>
+                            <textarea
+                              value={filesystemBrowseRootsInput}
+                              onChange={(event) => setFilesystemBrowseRootsInput(event.target.value)}
+                              placeholder={"One absolute path per line\n/Applications\n/Users/Shared\n/mnt/projects"}
+                              rows={5}
+                              className="w-full rounded-[4px] border border-[var(--vk-border)] bg-transparent px-2 py-2 text-[13px] text-[var(--vk-text-normal)] outline-none focus:border-[var(--vk-orange)]"
+                            />
+                            <div className="mt-2 flex flex-wrap items-center gap-2">
+                              <button
+                                type="button"
+                                onClick={() => setFilesystemRootPickerOpen(true)}
+                                disabled={isBusy}
+                                className="inline-flex h-9 items-center gap-1 rounded-[4px] border border-[var(--vk-border)] px-2 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-60"
+                              >
+                                <FolderOpen className="h-4 w-4" />
+                                Add folder
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => setFilesystemBrowseRootsInput("")}
+                                disabled={isBusy || filesystemBrowseRootsInput.trim().length === 0}
+                                className="inline-flex h-9 items-center rounded-[4px] border border-[var(--vk-border)] px-2 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-60"
+                              >
+                                Clear list
+                              </button>
+                            </div>
+                            <p className="mt-1 text-[12px] text-[var(--vk-text-muted)]">
+                              Conductor already includes sensible defaults for each OS. Add extra roots here when you want the folder picker to expose more locations on macOS, Linux, or Windows.
+                            </p>
+                          </label>
+                        </div>
                       </section>
 
                       <section className="space-y-2">
@@ -3905,6 +3957,27 @@ function hydrateRepositoryDraft(value: RepositorySettingsPayload): RepositorySet
           setNotesFolderPickerOpen(false);
           if (selectedPath === null) return;
           setMarkdownEditorPath(selectedPath);
+        }}
+      />
+      <FolderPickerDialog
+        open={filesystemRootPickerOpen}
+        bridgeId={bridgeId}
+        title="Add Filesystem Root"
+        description="Choose an extra folder root that should stay visible in the filesystem browser on this machine."
+        onClose={() => setFilesystemRootPickerOpen(false)}
+        onSelect={(selectedPath) => {
+          setFilesystemRootPickerOpen(false);
+          if (selectedPath === null) return;
+          setFilesystemBrowseRootsInput((currentValue) => {
+            const existing = currentValue
+              .split(/\n+/g)
+              .map((value) => value.trim())
+              .filter(Boolean);
+            if (existing.includes(selectedPath)) {
+              return existing.join("\n");
+            }
+            return [...existing, selectedPath].join("\n");
+          });
         }}
       />
     </>

--- a/packages/web/src/lib/previewWorkerClient.test.ts
+++ b/packages/web/src/lib/previewWorkerClient.test.ts
@@ -148,3 +148,27 @@ test("configureBridgePreview forwards bridge relay metadata when creating a remo
     },
   });
 });
+
+test("runCommand preserves actionable worker errors instead of collapsing them to service unavailable", async () => {
+  env.CONDUCTOR_PREVIEW_WORKER_URL = "http://127.0.0.1:3099";
+  env.CONDUCTOR_PREVIEW_WORKER_KEY = "unit-test-key";
+
+  global.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" || input instanceof URL ? String(input) : input.url;
+
+    if (url.endsWith("/sessions") && init?.method === "POST") {
+      return new Response(JSON.stringify({ error: "Timed out while waiting for a reachable cloudflared tunnel URL." }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response("unexpected", { status: 500 });
+  }) as typeof fetch;
+
+  const client = getPreviewWorkerClient();
+  await assert.rejects(
+    () => client.runCommand("session-error", { command: "reload" }),
+    /Timed out while waiting for a reachable cloudflared tunnel URL/,
+  );
+});

--- a/packages/web/src/lib/previewWorkerClient.ts
+++ b/packages/web/src/lib/previewWorkerClient.ts
@@ -69,6 +69,24 @@ function buildDisconnectedStatus(
   };
 }
 
+function shouldPreserveWorkerErrorMessage(message: string): boolean {
+  const normalized = message.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  if (normalized === "preview worker is not configured") {
+    return true;
+  }
+  return !(
+    normalized === "fetch failed"
+    || normalized.includes("econnrefused")
+    || normalized.includes("enotfound")
+    || normalized.includes("eai_again")
+    || normalized.includes("networkerror")
+    || normalized.includes("socket hang up")
+  );
+}
+
 class PreviewWorkerClient implements PreviewBrowserManagerClient {
   private readonly workerUrl = normalizeWorkerUrl(process.env.CONDUCTOR_PREVIEW_WORKER_URL);
   private readonly workerApiKey = process.env.CONDUCTOR_PREVIEW_WORKER_KEY?.trim() || null;
@@ -306,7 +324,7 @@ class PreviewWorkerClient implements PreviewBrowserManagerClient {
 
   private networkErrorMessage(error: unknown): string {
     const message = error instanceof Error ? error.message : "Preview service is unavailable";
-    if (message === "Preview worker is not configured") {
+    if (shouldPreserveWorkerErrorMessage(message)) {
       return message;
     }
     return "Preview service is unavailable";

--- a/preview-worker/package.json
+++ b/preview-worker/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test src/lib/auth.test.ts src/lib/security.test.ts"
+    "test": "tsx --test src/lib/auth.test.ts src/lib/security.test.ts src/browser/tunnel.test.ts"
   },
   "dependencies": {
     "@puppeteer/browsers": "^2.13.0",

--- a/preview-worker/src/browser/BrowserManager.ts
+++ b/preview-worker/src/browser/BrowserManager.ts
@@ -575,13 +575,35 @@ export class BrowserManager {
 
     if (!session.tunnelUrl || session.tunnelLocalOrigin !== normalizedOrigin) {
       await stopTunnel(session.tunnelProcess);
-      const tunnel = await startTunnel(normalizedOrigin, this.config.cloudflaredBin);
-      session.tunnelUrl = tunnel.url;
-      session.tunnelProcess = tunnel.process;
-      session.tunnelLocalOrigin = tunnel.localOrigin;
+
+      let lastTunnelError: unknown = null;
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        try {
+          const tunnel = await startTunnel(normalizedOrigin, this.config.cloudflaredBin);
+          session.tunnelUrl = tunnel.url;
+          session.tunnelProcess = tunnel.process;
+          session.tunnelLocalOrigin = tunnel.localOrigin;
+          lastTunnelError = null;
+          break;
+        } catch (error) {
+          lastTunnelError = error;
+          session.tunnelUrl = null;
+          session.tunnelProcess = null;
+          session.tunnelLocalOrigin = null;
+        }
+      }
+
+      if (lastTunnelError) {
+        throw lastTunnelError;
+      }
     }
 
-    const rewritten = rewriteLoopbackUrl(candidate, session.tunnelUrl);
+    const tunnelUrl = session.tunnelUrl;
+    if (!tunnelUrl) {
+      throw this.error(500, "Failed to establish a localhost preview tunnel.");
+    }
+
+    const rewritten = rewriteLoopbackUrl(candidate, tunnelUrl);
     if (!rewritten) {
       throw this.error(500, "Failed to rewrite localhost preview URL through the tunnel.");
     }

--- a/preview-worker/src/browser/tunnel.test.ts
+++ b/preview-worker/src/browser/tunnel.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { PreviewWorkerError } from "../lib/types.js";
+import { waitForReachableTunnelUrl } from "./tunnel.js";
+
+test("waitForReachableTunnelUrl resolves after DNS starts answering", async () => {
+  let attempts = 0;
+
+  await waitForReachableTunnelUrl(
+    "https://preview.trycloudflare.com",
+    2_000,
+    async () => {
+      attempts += 1;
+      if (attempts < 3) {
+        const error = new Error("getaddrinfo ENOTFOUND preview.trycloudflare.com");
+        (error as NodeJS.ErrnoException).code = "ENOTFOUND";
+        throw error;
+      }
+      return [{ address: "104.21.1.1", family: 4 }];
+    },
+  );
+
+  assert.equal(attempts, 3);
+});
+
+test("waitForReachableTunnelUrl throws a PreviewWorkerError when DNS never resolves", async () => {
+  await assert.rejects(
+    () => waitForReachableTunnelUrl(
+      "https://preview.trycloudflare.com",
+      10,
+      async () => {
+        const error = new Error("getaddrinfo ENOTFOUND preview.trycloudflare.com");
+        (error as NodeJS.ErrnoException).code = "ENOTFOUND";
+        throw error;
+      },
+    ),
+    (error: unknown) => {
+      assert.ok(error instanceof PreviewWorkerError);
+      assert.equal(error.statusCode, 408);
+      assert.match(error.message, /Timed out while waiting for a reachable cloudflared tunnel URL/);
+      return true;
+    },
+  );
+});

--- a/preview-worker/src/browser/tunnel.ts
+++ b/preview-worker/src/browser/tunnel.ts
@@ -1,10 +1,12 @@
 import { spawn, type ChildProcessByStdio } from "node:child_process";
+import { lookup } from "node:dns/promises";
 import type { Readable } from "node:stream";
 import { isLocalHost, normalizeNavigationHostname } from "../lib/security.js";
 import { PreviewWorkerError } from "../lib/types.js";
 
 const TRY_CLOUDFLARE_URL_PATTERN = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/gi;
 const DEFAULT_TUNNEL_TIMEOUT_MS = 30_000;
+const TUNNEL_DNS_POLL_INTERVAL_MS = 500;
 
 export interface TunnelHandle {
   url: string;
@@ -29,8 +31,48 @@ function normalizeLocalOrigin(value: string): string {
 }
 
 function extractTunnelUrl(buffer: string): string | null {
-  const match = [...buffer.matchAll(TRY_CLOUDFLARE_URL_PATTERN)].at(-1)?.[0] ?? null;
-  return match ? match.trim() : null;
+  const matches = buffer.match(TRY_CLOUDFLARE_URL_PATTERN);
+  if (!matches?.length) {
+    return null;
+  }
+  const latest = matches[matches.length - 1];
+  return latest ? latest.trim() : null;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function waitForReachableTunnelUrl(
+  tunnelUrl: string,
+  timeoutMs = DEFAULT_TUNNEL_TIMEOUT_MS,
+  lookupFn: typeof lookup = lookup,
+): Promise<void> {
+  let hostname: string;
+  try {
+    hostname = new URL(tunnelUrl).hostname;
+  } catch {
+    throw new PreviewWorkerError(500, `Invalid cloudflared tunnel URL: ${tunnelUrl}`);
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown = null;
+  while (Date.now() <= deadline) {
+    try {
+      const resolved = await lookupFn(hostname, { all: true });
+      if (resolved.length > 0) {
+        return;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(TUNNEL_DNS_POLL_INTERVAL_MS);
+  }
+
+  const reason = lastError instanceof Error && lastError.message
+    ? ` (${lastError.message})`
+    : "";
+  throw new PreviewWorkerError(408, `Timed out while waiting for a reachable cloudflared tunnel URL${reason}.`);
 }
 
 export async function startTunnel(
@@ -43,6 +85,7 @@ export async function startTunnel(
   return await new Promise<TunnelHandle>((resolve, reject) => {
     let settled = false;
     let output = "";
+    let verifyingTunnel = false;
 
     const child = spawn(cloudflaredBin, ["--url", localOrigin], {
       stdio: ["ignore", "pipe", "pipe"],
@@ -57,16 +100,32 @@ export async function startTunnel(
     };
 
     const inspectOutput = () => {
+      if (verifyingTunnel) {
+        return;
+      }
       const tunnelUrl = extractTunnelUrl(output);
       if (!tunnelUrl) {
         return;
       }
+      verifyingTunnel = true;
 
-      finish(() => resolve({
-        url: tunnelUrl,
-        process: child,
-        localOrigin,
-      }));
+      void (async () => {
+        try {
+          await waitForReachableTunnelUrl(tunnelUrl, timeoutMs);
+          finish(() => resolve({
+            url: tunnelUrl,
+            process: child,
+            localOrigin,
+          }));
+        } catch (error) {
+          finish(() => {
+            child.kill("SIGTERM");
+            reject(error instanceof PreviewWorkerError
+              ? error
+              : new PreviewWorkerError(500, error instanceof Error ? error.message : "Cloudflared tunnel failed"));
+          });
+        }
+      })();
     };
 
     const onData = (chunk: Buffer) => {


### PR DESCRIPTION
## User-Facing Release Notes
- Hosted preview no longer grabs a fresh Cloudflare tunnel URL before DNS is ready. This avoids broken `trycloudflare.com` preview opens that immediately fail with `ERR_NAME_NOT_RESOLVED`.
- When the preview worker does fail, the Preview tab now shows the actual worker error instead of the generic `Preview service is unavailable` message.

## Type of Change
- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Summary
- wait for Cloudflare quick tunnel DNS readiness before returning a hosted preview tunnel URL
- retry hosted localhost tunnel establishment a few times before failing
- preserve actionable preview worker errors in the dashboard instead of collapsing them to a generic service error
- add preview-worker tunnel tests and include them in the preview-worker test script

## Testing
- bun test packages/web/src/lib/previewSession.test.ts packages/web/src/app/api/sessions/[id]/preview/route.test.ts packages/web/src/lib/previewWorkerClient.test.ts
- bun run --cwd preview-worker test
- bun run --cwd preview-worker typecheck
- bun run --cwd preview-worker build
- bun run --cwd packages/web typecheck
- bun run --cwd packages/web build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview tunnel establishment reliability with automatic retry logic and DNS verification.
  * Enhanced error messages to preserve specific worker error details instead of generic "unavailable" responses.

* **Tests**
  * Added new test coverage for tunnel DNS resolution and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->