### PR TITLE
fix(preview): reuse worker sessions per conductor session

### DIFF
--- a/packages/web/src/lib/previewWorkerClient.test.ts
+++ b/packages/web/src/lib/previewWorkerClient.test.ts
@@ -72,6 +72,8 @@ test("runCommand creates a remote session and posts the command to the worker", 
     calls.push(`${init?.method ?? "GET"} ${url}`);
 
     if (url.endsWith("/sessions") && init?.method === "POST") {
+      const body = JSON.parse(String(init.body)) as { clientSessionId?: string };
+      assert.equal(body.clientSessionId, "session-c");
       return new Response(JSON.stringify({ sessionId: "remote-1" }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
@@ -139,6 +141,7 @@ test("configureBridgePreview forwards bridge relay metadata when creating a remo
 
   assert.ok(createBody);
   assert.deepEqual(createBody, {
+    clientSessionId: "session-bridge",
     bridgePreview: {
       bridgeId: "bridge-1",
       sessionId: "session-1",

--- a/packages/web/src/lib/previewWorkerClient.ts
+++ b/packages/web/src/lib/previewWorkerClient.ts
@@ -26,6 +26,7 @@ type RemoteBridgePreviewConfig = BridgePreviewConfig & {
 };
 
 type CreatePreviewWorkerSessionPayload = {
+  clientSessionId: string;
   bridgePreview?: RemoteBridgePreviewConfig | null;
 };
 
@@ -281,6 +282,7 @@ class PreviewWorkerClient implements PreviewBrowserManagerClient {
     }
 
     const payload: CreatePreviewWorkerSessionPayload = {
+      clientSessionId: sessionId,
       bridgePreview: this.bridgePreviewConfigs.get(sessionId) ?? null,
     };
 

--- a/preview-worker/package.json
+++ b/preview-worker/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test src/lib/auth.test.ts src/lib/security.test.ts src/browser/tunnel.test.ts"
+    "test": "tsx --test src/lib/auth.test.ts src/lib/security.test.ts src/lib/types.test.ts src/sessions/SessionStore.test.ts src/browser/tunnel.test.ts"
   },
   "dependencies": {
     "@puppeteer/browsers": "^2.13.0",

--- a/preview-worker/src/browser/BrowserManager.ts
+++ b/preview-worker/src/browser/BrowserManager.ts
@@ -299,6 +299,16 @@ export class BrowserManager {
   }
 
   async createSession(apiKey: string, options: CreatePreviewSessionRequest = {}): Promise<PreviewSession> {
+    const clientSessionId = options.clientSessionId?.trim() || null;
+    if (clientSessionId) {
+      const existing = this.sessionStore.findByApiKeyAndClientSessionId(apiKey, clientSessionId);
+      if (existing) {
+        existing.lastActivityAt = Date.now();
+        existing.bridgePreview = options.bridgePreview ?? existing.bridgePreview;
+        return existing;
+      }
+    }
+
     if (this.sessionStore.countByApiKey(apiKey) >= this.config.maxSessions) {
       throw this.error(429, "Preview session limit exceeded for this API key.");
     }
@@ -318,6 +328,7 @@ export class BrowserManager {
     const session: PreviewSession = {
       id: randomUUID(),
       apiKey,
+      clientSessionId,
       createdAt: Date.now(),
       lastActivityAt: Date.now(),
       browser,

--- a/preview-worker/src/lib/types.test.ts
+++ b/preview-worker/src/lib/types.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseCreatePreviewSessionRequest } from "./types.js";
+
+test("parseCreatePreviewSessionRequest preserves a trimmed clientSessionId", () => {
+  const parsed = parseCreatePreviewSessionRequest({
+    clientSessionId: "  bridge:session-123  ",
+    bridgePreview: null,
+  });
+
+  assert.deepEqual(parsed, {
+    clientSessionId: "bridge:session-123",
+    bridgePreview: null,
+  });
+});
+
+test("parseCreatePreviewSessionRequest rejects non-string clientSessionId values", () => {
+  const parsed = parseCreatePreviewSessionRequest({
+    clientSessionId: 42,
+    bridgePreview: null,
+  });
+
+  assert.equal(parsed, null);
+});

--- a/preview-worker/src/lib/types.ts
+++ b/preview-worker/src/lib/types.ts
@@ -95,6 +95,7 @@ export interface BridgePreviewSessionConfig {
 }
 
 export interface CreatePreviewSessionRequest {
+  clientSessionId?: string | null;
   bridgePreview?: BridgePreviewSessionConfig | null;
 }
 
@@ -123,6 +124,7 @@ export interface PreviewWorkerConfig {
 export interface PreviewSession {
   id: string;
   apiKey: string;
+  clientSessionId: string | null;
   createdAt: number;
   lastActivityAt: number;
   browser: Browser;
@@ -177,8 +179,15 @@ export function parseCreatePreviewSessionRequest(value: unknown): CreatePreviewS
   if (!isRecord(value)) {
     return null;
   }
+  const clientSessionId = value.clientSessionId;
+  if (clientSessionId !== undefined && clientSessionId !== null && typeof clientSessionId !== "string") {
+    return null;
+  }
+  const normalizedClientSessionId = typeof clientSessionId === "string" && clientSessionId.trim().length > 0
+    ? clientSessionId.trim()
+    : null;
   if (value.bridgePreview === undefined || value.bridgePreview === null) {
-    return { bridgePreview: null };
+    return { clientSessionId: normalizedClientSessionId, bridgePreview: null };
   }
   const bridgePreview = value.bridgePreview;
   if (!isRecord(bridgePreview)) {
@@ -195,6 +204,7 @@ export function parseCreatePreviewSessionRequest(value: unknown): CreatePreviewS
     return null;
   }
   return {
+    clientSessionId: normalizedClientSessionId,
     bridgePreview: {
       bridgeId: bridgePreview.bridgeId,
       sessionId: bridgePreview.sessionId,

--- a/preview-worker/src/sessions/SessionStore.test.ts
+++ b/preview-worker/src/sessions/SessionStore.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { SessionStore } from "./SessionStore.js";
+import type { PreviewSession } from "../lib/types.js";
+
+function buildSession(id: string, apiKey: string, clientSessionId: string | null): PreviewSession {
+  return {
+    id,
+    apiKey,
+    clientSessionId,
+    createdAt: Date.now(),
+    lastActivityAt: Date.now(),
+    browser: {} as PreviewSession["browser"],
+    page: {} as PreviewSession["page"],
+    tunnelUrl: null,
+    tunnelProcess: null,
+    tunnelLocalOrigin: null,
+    bridgePreview: null,
+    status: "active",
+    activeFrameId: null,
+    selectedElement: null,
+    consoleLogs: [],
+    networkLogs: [],
+    lastError: null,
+    frameIds: new WeakMap(),
+    frameSequence: 0,
+    requestStarts: new WeakMap(),
+    requestInterceptionEnabled: false,
+    lastRequestedUrl: null,
+  };
+}
+
+test("findByApiKeyAndClientSessionId returns the matching session only for the same API key", () => {
+  const store = new SessionStore(60_000);
+  const target = buildSession("preview-1", "key-a", "session-1");
+  const otherKey = buildSession("preview-2", "key-b", "session-1");
+  store.set(target);
+  store.set(otherKey);
+
+  assert.equal(store.findByApiKeyAndClientSessionId("key-a", "session-1")?.id, "preview-1");
+  assert.equal(store.findByApiKeyAndClientSessionId("key-b", "session-1")?.id, "preview-2");
+  assert.equal(store.findByApiKeyAndClientSessionId("key-a", "missing"), undefined);
+});

--- a/preview-worker/src/sessions/SessionStore.ts
+++ b/preview-worker/src/sessions/SessionStore.ts
@@ -29,6 +29,15 @@ export class SessionStore {
     return [...this.sessions.values()];
   }
 
+  findByApiKeyAndClientSessionId(apiKey: string, clientSessionId: string): PreviewSession | undefined {
+    for (const session of this.sessions.values()) {
+      if (session.apiKey === apiKey && session.clientSessionId === clientSessionId) {
+        return session;
+      }
+    }
+    return undefined;
+  }
+
   get(sessionId: string): PreviewSession | undefined {
     return this.sessions.get(sessionId);
   }


### PR DESCRIPTION
## User-Facing Release Notes
- Preview now reuses the existing hosted preview-worker session for the same Conductor session, which avoids false "Preview session limit exceeded for this API key" failures after reconnects or server restarts.

## Type of Change
- [ ] Breaking Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Plugin Addition / Modification
- [ ] Documentation Update
- [ ] Refactor / Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session reuse functionality allowing users to reconnect to existing preview sessions using client session identifiers, improving session continuity and reducing unnecessary session creation.

* **Tests**
  * Added tests for session retrieval, session reuse logic, and client session ID validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->