### PR TITLE
fix(preview): preserve bridge POST bodies and reclaim legacy sessions

### DIFF
--- a/packages/web/src/app/api/sessions/[id]/preview/route.test.ts
+++ b/packages/web/src/app/api/sessions/[id]/preview/route.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { NextRequest } from "next/server";
-import { GET } from "./route";
+import { GET, POST } from "./route";
 
 const originalBackendUrl = process.env.CONDUCTOR_BACKEND_URL;
 const originalBridgeRelayUrl = process.env.CONDUCTOR_BRIDGE_RELAY_URL;
@@ -396,6 +396,99 @@ test("GET uses an explicit previewUrlHint for bridge sessions that did not repor
     assert.deepEqual(payload.candidateUrls, ["http://localhost:3002/"]);
     assert.equal(payload.currentUrl, null);
     assert.equal(payload.lastError, null);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("POST clones the bridge request before preview lookup so body reuse does not poison status", async () => {
+  resetEnv();
+  process.env.CONDUCTOR_BACKEND_URL = "http://127.0.0.1:4749";
+  process.env.CONDUCTOR_BRIDGE_RELAY_URL = "https://relay.example.com";
+  process.env.RELAY_JWT_SECRET = "preview-test-secret";
+
+  const seenPaths: string[] = [];
+  const seenBodies: Array<unknown> = [];
+
+  global.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" || input instanceof URL
+      ? String(input)
+      : input.url;
+
+    assert.equal(url, "https://relay.example.com/api/devices/bridge-1/proxy");
+    assert.equal(init?.method, "POST");
+
+    const body = JSON.parse(String(init?.body)) as {
+      method: string;
+      path: string;
+      body?: unknown;
+    };
+    seenPaths.push(body.path);
+    seenBodies.push(body.body ?? null);
+
+    if (body.path === "/api/sessions/session-1") {
+      return new Response(JSON.stringify({
+        id: "session-1",
+        projectId: "demo",
+        status: "working",
+        activity: "active",
+        branch: "feature/demo",
+        issueId: null,
+        summary: null,
+        createdAt: new Date().toISOString(),
+        lastActivityAt: new Date().toISOString(),
+        pr: null,
+        metadata: {},
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (body.path === "/api/sessions/session-1/output?lines=400") {
+      return new Response(JSON.stringify({ output: "" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify({ error: "not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  try {
+    const response = await POST(
+      new NextRequest("http://127.0.0.1:3000/api/sessions/bridge%3Abridge-1%3Asession-1/preview?previewUrlHint=http%3A%2F%2Flocalhost%3A3002%2F", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ command: "connect", url: "http://localhost:3002/" }),
+      }),
+      { params: Promise.resolve({ id: "bridge:bridge-1:session-1" }) },
+    );
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(seenPaths, [
+      "/api/sessions/session-1",
+      "/api/sessions/session-1/output?lines=400",
+    ]);
+    assert.deepEqual(seenBodies, [
+      { command: "connect", url: "http://localhost:3002/" },
+      { command: "connect", url: "http://localhost:3002/" },
+    ]);
+
+    const payload = await response.json() as {
+      error: string;
+      status: {
+        candidateUrls: string[];
+        lastError: string | null;
+      };
+    };
+
+    assert.ok(!payload.error.includes("Body is unusable"));
+    assert.deepEqual(payload.status.candidateUrls, ["http://localhost:3002/"]);
+    assert.ok(payload.status.lastError === null || !payload.status.lastError.includes("Body is unusable"));
   } finally {
     global.fetch = originalFetch;
   }

--- a/packages/web/src/app/api/sessions/[id]/preview/route.test.ts
+++ b/packages/web/src/app/api/sessions/[id]/preview/route.test.ts
@@ -403,7 +403,7 @@ test("GET uses an explicit previewUrlHint for bridge sessions that did not repor
 
 test("POST clones the bridge request before preview lookup so body reuse does not poison status", async () => {
   resetEnv();
-  process.env.CONDUCTOR_BACKEND_URL = "http://127.0.0.1:4749";
+  process.env.CONDUCTOR_BACKEND_URL = "https://api.example.com";
   process.env.CONDUCTOR_BRIDGE_RELAY_URL = "https://relay.example.com";
   process.env.RELAY_JWT_SECRET = "preview-test-secret";
 

--- a/packages/web/src/app/api/sessions/[id]/preview/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/preview/route.ts
@@ -103,6 +103,7 @@ export async function POST(request: NextRequest, context: RouteParams): Promise<
   const forwardedHeaders = await buildForwardedAccessHeaders(request);
   const previewContext = await loadPreviewSessionContext(id, {
     request,
+    requestBody: body,
     headers: forwardedHeaders,
     previewUrlHint: resolveCommandPreviewUrlHint(body) ?? readPreviewUrlHint(request),
   });

--- a/packages/web/src/lib/previewSession.ts
+++ b/packages/web/src/lib/previewSession.ts
@@ -81,6 +81,7 @@ async function fetchProjectPreviewCandidateUrls(
       }
       response = await proxyToBridgeDevice(options.request, bridgeId, "/api/repositories", {
         pathOverride: "/api/repositories",
+        bodyOverride: options.requestBody,
       });
     } else {
       const backendUrl = requireRustBackendUrl();
@@ -123,6 +124,7 @@ export interface PreviewSessionContext {
 type PreviewFetchOptions = {
   headers?: HeadersInit;
   request?: Request;
+  requestBody?: unknown;
   previewUrlHint?: string | null;
 };
 
@@ -151,6 +153,7 @@ async function fetchPreviewResource(
 
     return proxyToBridgeDevice(options.request, bridgeSession.bridgeId, path, {
       pathOverride: path,
+      bodyOverride: options.requestBody,
     });
   }
 

--- a/preview-worker/src/browser/BrowserManager.ts
+++ b/preview-worker/src/browser/BrowserManager.ts
@@ -307,6 +307,17 @@ export class BrowserManager {
         existing.bridgePreview = options.bridgePreview ?? existing.bridgePreview;
         return existing;
       }
+
+      const legacySessions = this.sessionStore
+        .listByApiKey(apiKey)
+        .filter((session) => !session.clientSessionId)
+        .sort((left, right) => left.lastActivityAt - right.lastActivityAt);
+      for (const legacySession of legacySessions) {
+        await this.destroySessionInternal(legacySession);
+        if (this.sessionStore.countByApiKey(apiKey) < this.config.maxSessions) {
+          break;
+        }
+      }
     }
 
     if (this.sessionStore.countByApiKey(apiKey) >= this.config.maxSessions) {

--- a/preview-worker/src/sessions/SessionStore.test.ts
+++ b/preview-worker/src/sessions/SessionStore.test.ts
@@ -41,3 +41,19 @@ test("findByApiKeyAndClientSessionId returns the matching session only for the s
   assert.equal(store.findByApiKeyAndClientSessionId("key-b", "session-1")?.id, "preview-2");
   assert.equal(store.findByApiKeyAndClientSessionId("key-a", "missing"), undefined);
 });
+
+test("listByApiKey returns all sessions for the same API key, including legacy sessions without a clientSessionId", () => {
+  const store = new SessionStore(60_000);
+  const reused = buildSession("preview-1", "key-a", "session-1");
+  const legacy = buildSession("preview-legacy", "key-a", null);
+  const otherKey = buildSession("preview-2", "key-b", "session-1");
+  store.set(reused);
+  store.set(legacy);
+  store.set(otherKey);
+
+  assert.deepEqual(
+    store.listByApiKey("key-a").map((session) => session.id).sort(),
+    ["preview-1", "preview-legacy"],
+  );
+  assert.equal(store.countByApiKey("key-a"), 2);
+});

--- a/preview-worker/src/sessions/SessionStore.ts
+++ b/preview-worker/src/sessions/SessionStore.ts
@@ -16,17 +16,15 @@ export class SessionStore {
   }
 
   countByApiKey(apiKey: string): number {
-    let count = 0;
-    for (const session of this.sessions.values()) {
-      if (session.apiKey === apiKey) {
-        count += 1;
-      }
-    }
-    return count;
+    return this.listByApiKey(apiKey).length;
   }
 
   list(): PreviewSession[] {
     return [...this.sessions.values()];
+  }
+
+  listByApiKey(apiKey: string): PreviewSession[] {
+    return this.list().filter((session) => session.apiKey === apiKey);
   }
 
   findByApiKeyAndClientSessionId(apiKey: string, clientSessionId: string): PreviewSession | undefined {


### PR DESCRIPTION
## Summary

Fixes two production preview failures for bridge-backed sessions. Preview POST requests now preserve the parsed command body across paired-device lookups, and the preview worker clears legacy pre-reuse sessions before enforcing its per-key session cap.

## User-Facing Release Notes

- Fixed a bridge preview bug where Connect requests could fail because the server tried to reread an already-consumed request body.
- Fixed a preview worker issue where stale legacy sessions could block new preview connections with a session limit error.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Testing

- `bun test preview-worker/src/sessions/SessionStore.test.ts preview-worker/src/lib/types.test.ts packages/web/src/lib/previewWorkerClient.test.ts packages/web/src/app/api/sessions/[id]/preview/route.test.ts`
- Reproduced the failure live on `app.conductross.com` against the active carevm bridge session preview tab before patching.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for request body forwarding when proxying preview resources to bridge devices.

* **Bug Fixes**
  * Improved session management to automatically clean up legacy sessions before enforcing session limits, reducing connection rejections.

* **Tests**
  * Added test coverage for POST request handling and session listing by API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->