### PR TITLE
fix(preview): harden hosted tunnel readiness

### DIFF
--- a/preview-worker/src/browser/BrowserManager.ts
+++ b/preview-worker/src/browser/BrowserManager.ts
@@ -592,7 +592,12 @@ export class BrowserManager {
   }
 
   private shouldResetTunnel(targetUrl: string, error: unknown): boolean {
-    if (!targetUrl.includes(".trycloudflare.com")) {
+    try {
+      const hostname = new URL(targetUrl).hostname.toLowerCase();
+      if (!hostname.endsWith(".trycloudflare.com")) {
+        return false;
+      }
+    } catch {
       return false;
     }
 

--- a/preview-worker/src/browser/BrowserManager.ts
+++ b/preview-worker/src/browser/BrowserManager.ts
@@ -43,6 +43,16 @@ const VIEWPORT = { width: 1440, height: 960 };
 const LOG_LIMIT = 150;
 const DOM_NODE_LIMIT = 250;
 const CLEANUP_INTERVAL_MS = 30_000;
+const RETRYABLE_TUNNEL_ERROR_MARKERS = [
+  "ERR_NAME_NOT_RESOLVED",
+  "ERR_CONNECTION_REFUSED",
+  "ERR_CONNECTION_RESET",
+  "ERR_CONNECTION_CLOSED",
+  "ERR_QUIC_PROTOCOL_ERROR",
+  "ERR_HTTP2_PROTOCOL_ERROR",
+  "ERR_SSL_PROTOCOL_ERROR",
+  "ERR_TUNNEL_CONNECTION_FAILED",
+] as const;
 const CHROME_ARGS = [
   "--disable-dev-shm-usage",
   "--disable-background-networking",
@@ -491,9 +501,10 @@ export class BrowserManager {
       }
 
       const previousUrl = session.page.url();
+      let targetUrl = candidate;
 
       try {
-        const targetUrl = navigationMode === "bridge"
+        targetUrl = navigationMode === "bridge"
           ? candidate
           : await this.resolveNavigationTarget(session, candidate);
         await this.syncRequestInterception(session, navigationMode === "bridge");
@@ -505,9 +516,10 @@ export class BrowserManager {
         session.lastRequestedUrl = candidate;
         return;
       } catch (error) {
-        const targetUrl = navigationMode === "bridge"
-          ? candidate
-          : (session.lastRequestedUrl ?? candidate);
+        if (navigationMode !== "bridge" && this.shouldResetTunnel(targetUrl, error)) {
+          await this.resetTunnel(session);
+        }
+
         if (await this.navigationProducedUsablePage(session.page, targetUrl, previousUrl, error)) {
           await this.syncRequestInterception(session, navigationMode === "bridge");
           session.selectedElement = null;
@@ -579,6 +591,22 @@ export class BrowserManager {
     await Promise.all(expiredSessions.map((session) => this.destroySessionInternal(session)));
   }
 
+  private shouldResetTunnel(targetUrl: string, error: unknown): boolean {
+    if (!targetUrl.includes(".trycloudflare.com")) {
+      return false;
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    return RETRYABLE_TUNNEL_ERROR_MARKERS.some((marker) => message.includes(marker));
+  }
+
+  private async resetTunnel(session: PreviewSession): Promise<void> {
+    await stopTunnel(session.tunnelProcess);
+    session.tunnelUrl = null;
+    session.tunnelProcess = null;
+    session.tunnelLocalOrigin = null;
+  }
+
   private async resolveNavigationTarget(
     session: PreviewSession,
     candidate: string,
@@ -596,7 +624,7 @@ export class BrowserManager {
     const normalizedOrigin = localOrigin.toString();
 
     if (!session.tunnelUrl || session.tunnelLocalOrigin !== normalizedOrigin) {
-      await stopTunnel(session.tunnelProcess);
+      await this.resetTunnel(session);
 
       let lastTunnelError: unknown = null;
       for (let attempt = 0; attempt < 3; attempt += 1) {

--- a/preview-worker/src/browser/tunnel.test.ts
+++ b/preview-worker/src/browser/tunnel.test.ts
@@ -3,41 +3,49 @@ import test from "node:test";
 import { PreviewWorkerError } from "../lib/types.js";
 import { waitForReachableTunnelUrl } from "./tunnel.js";
 
-test("waitForReachableTunnelUrl resolves after DNS starts answering", async () => {
-  let attempts = 0;
+test("waitForReachableTunnelUrl resolves after DNS and the tunnel probe both succeed", async () => {
+  let dnsAttempts = 0;
+  let probeAttempts = 0;
 
   await waitForReachableTunnelUrl(
     "https://preview.trycloudflare.com",
     2_000,
     async () => {
-      attempts += 1;
-      if (attempts < 3) {
-        const error = new Error("getaddrinfo ENOTFOUND preview.trycloudflare.com");
+      dnsAttempts += 1;
+      return [{ address: "104.21.1.1", family: 4 }];
+    },
+    async () => {
+      probeAttempts += 1;
+      if (probeAttempts < 3) {
+        const error = new Error("fetch failed");
         (error as NodeJS.ErrnoException).code = "ENOTFOUND";
         throw error;
       }
-      return [{ address: "104.21.1.1", family: 4 }];
     },
   );
 
-  assert.equal(attempts, 3);
+  assert.equal(dnsAttempts, 3);
+  assert.equal(probeAttempts, 3);
 });
 
-test("waitForReachableTunnelUrl throws a PreviewWorkerError when DNS never resolves", async () => {
+test("waitForReachableTunnelUrl throws a PreviewWorkerError when the tunnel probe never succeeds", async () => {
+  let probeAttempts = 0;
+
   await assert.rejects(
     () => waitForReachableTunnelUrl(
       "https://preview.trycloudflare.com",
       10,
+      async () => [{ address: "104.21.1.1", family: 4 }],
       async () => {
-        const error = new Error("getaddrinfo ENOTFOUND preview.trycloudflare.com");
-        (error as NodeJS.ErrnoException).code = "ENOTFOUND";
-        throw error;
+        probeAttempts += 1;
+        throw new Error("fetch failed");
       },
     ),
     (error: unknown) => {
       assert.ok(error instanceof PreviewWorkerError);
       assert.equal(error.statusCode, 408);
       assert.match(error.message, /Timed out while waiting for a reachable cloudflared tunnel URL/);
+      assert.ok(probeAttempts >= 1);
       return true;
     },
   );

--- a/preview-worker/src/browser/tunnel.ts
+++ b/preview-worker/src/browser/tunnel.ts
@@ -4,6 +4,9 @@ import type { Readable } from "node:stream";
 import { isLocalHost, normalizeNavigationHostname } from "../lib/security.js";
 import { PreviewWorkerError } from "../lib/types.js";
 
+type TunnelLookup = (hostname: string, options: { all: true }) => Promise<Array<{ address: string; family: number }>>;
+type TunnelProbe = (url: string) => Promise<void>;
+
 const TRY_CLOUDFLARE_URL_PATTERN = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/gi;
 const DEFAULT_TUNNEL_TIMEOUT_MS = 30_000;
 const TUNNEL_DNS_POLL_INTERVAL_MS = 500;
@@ -43,10 +46,25 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+async function probeTunnelUrl(tunnelUrl: string): Promise<void> {
+  const response = await fetch(tunnelUrl, {
+    method: "HEAD",
+    redirect: "manual",
+    signal: AbortSignal.timeout(5_000),
+  });
+
+  void response.body?.cancel().catch(() => {});
+}
+
+const lookupTunnelAddresses: TunnelLookup = async (hostname, options) => {
+  return await lookup(hostname, options) as Array<{ address: string; family: number }>;
+};
+
 export async function waitForReachableTunnelUrl(
   tunnelUrl: string,
   timeoutMs = DEFAULT_TUNNEL_TIMEOUT_MS,
-  lookupFn: typeof lookup = lookup,
+  lookupFn: TunnelLookup = lookupTunnelAddresses,
+  probeFn: TunnelProbe = probeTunnelUrl,
 ): Promise<void> {
   let hostname: string;
   try {
@@ -61,6 +79,7 @@ export async function waitForReachableTunnelUrl(
     try {
       const resolved = await lookupFn(hostname, { all: true });
       if (resolved.length > 0) {
+        await probeFn(tunnelUrl);
         return;
       }
     } catch (error) {


### PR DESCRIPTION
## Summary

Harden hosted Preview connects for localhost dev servers by waiting for the Cloudflare quick tunnel to answer HTTP requests, not just DNS lookups, and by dropping stale tunnel state after retryable trycloudflare navigation failures.

## User-Facing Release Notes

- Fixed hosted Preview connects that could fail with `Preview session limit exceeded for this API key.` followed by `net::ERR_NAME_NOT_RESOLVED` on a fresh `trycloudflare.com` tunnel.
- Fixed Preview retries so stale quick-tunnel sessions do not get reused after retryable tunnel failures.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Testing

- `bun run --cwd preview-worker test`
- `bun run --cwd preview-worker typecheck`
- `bun run --cwd preview-worker build`
- `bun test packages/web/src/lib/previewWorkerClient.test.ts packages/web/src/app/api/sessions/[id]/preview/route.test.ts`
- `bun run --cwd packages/web test`
- `bun run --cwd packages/web typecheck`
- `bun run --cwd packages/web build`
- Reproduced the live prod failure on `app.conductross.com` for the active carevm bridge session before patching. The Preview connect POST returned `net::ERR_NAME_NOT_RESOLVED at https://...trycloudflare.com/`.
