### PR TITLE
feat: Obsidian-like notes workspace with wikilinks, backlinks, tags, graph view

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -45,6 +45,7 @@ jobs:
           --ignore RUSTSEC-2023-0071
           --ignore RUSTSEC-2024-0384
           --ignore RUSTSEC-2026-0008
+          --ignore RUSTSEC-2026-0097
 
   secret-scan:
     name: Secret Scanning

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2257,9 +2257,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,11 @@
       "version": "0.1.0",
       "dependencies": {
         "@clerk/nextjs": "^6.39.0",
+        "@codemirror/commands": "^6.10.3",
+        "@codemirror/lang-markdown": "^6.5.0",
+        "@codemirror/language-data": "^6.5.2",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.41.0",
         "@conductor-oss/core": "workspace:*",
         "@pierre/diffs": "^1.0.11",
         "@primer/octicons-react": "^19.15.0",
@@ -73,6 +78,7 @@
         "@vercel/analytics": "^2.0.1",
         "@xterm/addon-fit": "^0.11.0",
         "clsx": "^2.1.1",
+        "d3-force": "^3.0.0",
         "diff": "^8.0.3",
         "geist": "^1.7.0",
         "jose": "^6.1.3",
@@ -91,6 +97,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.2.1",
+        "@types/d3-force": "^3.0.10",
         "@types/node": "^25.3.3",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -169,6 +176,64 @@
     "@clerk/shared": ["@clerk/shared@3.47.2", "", { "dependencies": { "csstype": "3.1.3", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0", "swr": "2.3.4" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-dwUT27DKq3Gr9vn9lAfc/LSe79P1rKIib8/mTWA7ZEzY7XX2Yq5UnDMCMznYrI8oVLdJrCT4ypFXRgnH306Oew=="],
 
     "@clerk/types": ["@clerk/types@4.101.20", "", { "dependencies": { "@clerk/shared": "^3.47.2" } }, "sha512-MHvr1tGL5lwxD6zdzzixkHICbbZz/S1LChONKR52Qeu0yRGChZomPknsgqBMG9J3yNeyhaj0SWa5phQgQUk0lg=="],
+
+    "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.1", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A=="],
+
+    "@codemirror/commands": ["@codemirror/commands@6.10.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.6.0", "@codemirror/view": "^6.27.0", "@lezer/common": "^1.1.0" } }, "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q=="],
+
+    "@codemirror/lang-angular": ["@codemirror/lang-angular@0.1.4", "", { "dependencies": { "@codemirror/lang-html": "^6.0.0", "@codemirror/lang-javascript": "^6.1.2", "@codemirror/language": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.3" } }, "sha512-oap+gsltb/fzdlTQWD6BFF4bSLKcDnlxDsLdePiJpCVNKWXSTAbiiQeYI3UmES+BLAdkmIC1WjyztC1pi/bX4g=="],
+
+    "@codemirror/lang-cpp": ["@codemirror/lang-cpp@6.0.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@lezer/cpp": "^1.0.0" } }, "sha512-URM26M3vunFFn9/sm6rzqrBzDgfWuDixp85uTY49wKudToc2jTHUrKIGGKs+QWND+YLofNNZpxcNGRynFJfvgA=="],
+
+    "@codemirror/lang-css": ["@codemirror/lang-css@6.3.1", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.0.2", "@lezer/css": "^1.1.7" } }, "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg=="],
+
+    "@codemirror/lang-go": ["@codemirror/lang-go@6.0.1", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.6.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.0.0", "@lezer/go": "^1.0.0" } }, "sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg=="],
+
+    "@codemirror/lang-html": ["@codemirror/lang-html@6.4.11", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/lang-css": "^6.0.0", "@codemirror/lang-javascript": "^6.0.0", "@codemirror/language": "^6.4.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/css": "^1.1.0", "@lezer/html": "^1.3.12" } }, "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw=="],
+
+    "@codemirror/lang-java": ["@codemirror/lang-java@6.0.2", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@lezer/java": "^1.0.0" } }, "sha512-m5Nt1mQ/cznJY7tMfQTJchmrjdjQ71IDs+55d1GAa8DGaB8JXWsVCkVT284C3RTASaY43YknrK2X3hPO/J3MOQ=="],
+
+    "@codemirror/lang-javascript": ["@codemirror/lang-javascript@6.2.5", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.6.0", "@codemirror/lint": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/javascript": "^1.0.0" } }, "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A=="],
+
+    "@codemirror/lang-jinja": ["@codemirror/lang-jinja@6.0.0", "", { "dependencies": { "@codemirror/lang-html": "^6.0.0", "@codemirror/language": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.2.0", "@lezer/lr": "^1.4.0" } }, "sha512-47MFmRcR8UAxd8DReVgj7WJN1WSAMT7OJnewwugZM4XiHWkOjgJQqvEM1NpMj9ALMPyxmlziEI1opH9IaEvmaw=="],
+
+    "@codemirror/lang-json": ["@codemirror/lang-json@6.0.2", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@lezer/json": "^1.0.0" } }, "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ=="],
+
+    "@codemirror/lang-less": ["@codemirror/lang-less@6.0.2", "", { "dependencies": { "@codemirror/lang-css": "^6.2.0", "@codemirror/language": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-EYdQTG22V+KUUk8Qq582g7FMnCZeEHsyuOJisHRft/mQ+ZSZ2w51NupvDUHiqtsOy7It5cHLPGfHQLpMh9bqpQ=="],
+
+    "@codemirror/lang-liquid": ["@codemirror/lang-liquid@6.3.2", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/lang-html": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.0.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.1" } }, "sha512-6PDVU3ZnfeYyz1at1E/ttorErZvZFXXt1OPhtfe1EZJ2V2iDFa0CwPqPgG5F7NXN0yONGoBogKmFAafKTqlwIw=="],
+
+    "@codemirror/lang-markdown": ["@codemirror/lang-markdown@6.5.0", "", { "dependencies": { "@codemirror/autocomplete": "^6.7.1", "@codemirror/lang-html": "^6.0.0", "@codemirror/language": "^6.3.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.2.1", "@lezer/markdown": "^1.0.0" } }, "sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw=="],
+
+    "@codemirror/lang-php": ["@codemirror/lang-php@6.0.2", "", { "dependencies": { "@codemirror/lang-html": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.0.0", "@lezer/php": "^1.0.0" } }, "sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA=="],
+
+    "@codemirror/lang-python": ["@codemirror/lang-python@6.2.1", "", { "dependencies": { "@codemirror/autocomplete": "^6.3.2", "@codemirror/language": "^6.8.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.2.1", "@lezer/python": "^1.1.4" } }, "sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw=="],
+
+    "@codemirror/lang-rust": ["@codemirror/lang-rust@6.0.2", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@lezer/rust": "^1.0.0" } }, "sha512-EZaGjCUegtiU7kSMvOfEZpaCReowEf3yNidYu7+vfuGTm9ow4mthAparY5hisJqOHmJowVH3Upu+eJlUji6qqA=="],
+
+    "@codemirror/lang-sass": ["@codemirror/lang-sass@6.0.2", "", { "dependencies": { "@codemirror/lang-css": "^6.2.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.0.2", "@lezer/sass": "^1.0.0" } }, "sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q=="],
+
+    "@codemirror/lang-sql": ["@codemirror/lang-sql@6.10.0", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w=="],
+
+    "@codemirror/lang-vue": ["@codemirror/lang-vue@0.1.3", "", { "dependencies": { "@codemirror/lang-html": "^6.0.0", "@codemirror/lang-javascript": "^6.1.2", "@codemirror/language": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.1" } }, "sha512-QSKdtYTDRhEHCfo5zOShzxCmqKJvgGrZwDQSdbvCRJ5pRLWBS7pD/8e/tH44aVQT6FKm0t6RVNoSUWHOI5vNug=="],
+
+    "@codemirror/lang-wast": ["@codemirror/lang-wast@6.0.2", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-Imi2KTpVGm7TKuUkqyJ5NRmeFWF7aMpNiwHnLQe0x9kmrxElndyH0K6H/gXtWwY6UshMRAhpENsgfpSwsgmC6Q=="],
+
+    "@codemirror/lang-xml": ["@codemirror/lang-xml@6.1.0", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.4.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.0.0", "@lezer/xml": "^1.0.0" } }, "sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg=="],
+
+    "@codemirror/lang-yaml": ["@codemirror/lang-yaml@6.1.3", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.2.0", "@lezer/lr": "^1.0.0", "@lezer/yaml": "^1.0.0" } }, "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ=="],
+
+    "@codemirror/language": ["@codemirror/language@6.12.3", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.23.0", "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0", "style-mod": "^4.0.0" } }, "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA=="],
+
+    "@codemirror/language-data": ["@codemirror/language-data@6.5.2", "", { "dependencies": { "@codemirror/lang-angular": "^0.1.0", "@codemirror/lang-cpp": "^6.0.0", "@codemirror/lang-css": "^6.0.0", "@codemirror/lang-go": "^6.0.0", "@codemirror/lang-html": "^6.0.0", "@codemirror/lang-java": "^6.0.0", "@codemirror/lang-javascript": "^6.0.0", "@codemirror/lang-jinja": "^6.0.0", "@codemirror/lang-json": "^6.0.0", "@codemirror/lang-less": "^6.0.0", "@codemirror/lang-liquid": "^6.0.0", "@codemirror/lang-markdown": "^6.0.0", "@codemirror/lang-php": "^6.0.0", "@codemirror/lang-python": "^6.0.0", "@codemirror/lang-rust": "^6.0.0", "@codemirror/lang-sass": "^6.0.0", "@codemirror/lang-sql": "^6.0.0", "@codemirror/lang-vue": "^0.1.1", "@codemirror/lang-wast": "^6.0.0", "@codemirror/lang-xml": "^6.0.0", "@codemirror/lang-yaml": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/legacy-modes": "^6.4.0" } }, "sha512-CPkWBKrNS8stYbEU5kwBwTf3JB1kghlbh4FSAwzGW2TEscdeHHH4FGysREW86Mqnj3Qn09s0/6Ea/TutmoTobg=="],
+
+    "@codemirror/legacy-modes": ["@codemirror/legacy-modes@6.5.2", "", { "dependencies": { "@codemirror/language": "^6.0.0" } }, "sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q=="],
+
+    "@codemirror/lint": ["@codemirror/lint@6.9.5", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.35.0", "crelt": "^1.0.5" } }, "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA=="],
+
+    "@codemirror/state": ["@codemirror/state@6.6.0", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ=="],
+
+    "@codemirror/view": ["@codemirror/view@6.41.0", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-6H/qadXsVuDY219Yljhohglve8xf4B8xJkVOEWfA5uiYKiTFppjqsvsfR5iPA0RbvRBoOyTZpbLIxe9+0UR8xA=="],
 
     "@conductor-oss/core": ["@conductor-oss/core@workspace:packages/core"],
 
@@ -314,9 +379,45 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
+
+    "@lezer/cpp": ["@lezer/cpp@1.1.5", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-DIhSXmYtJKLehrjzDFN+2cPt547ySQ41nA8yqcDf/GxMc+YM736xqltFkvADL2M0VebU5I+3+4ks2Vv+Kyq3Aw=="],
+
+    "@lezer/css": ["@lezer/css@1.3.3", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.0" } }, "sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg=="],
+
+    "@lezer/go": ["@lezer/go@1.0.1", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.0" } }, "sha512-xToRsYxwsgJNHTgNdStpcvmbVuKxTapV0dM0wey1geMMRc9aggoVyKgzYp41D2/vVOx+Ii4hmE206kvxIXBVXQ=="],
+
+    "@lezer/highlight": ["@lezer/highlight@1.2.3", "", { "dependencies": { "@lezer/common": "^1.3.0" } }, "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g=="],
+
+    "@lezer/html": ["@lezer/html@1.3.13", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg=="],
+
+    "@lezer/java": ["@lezer/java@1.1.3", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw=="],
+
+    "@lezer/javascript": ["@lezer/javascript@1.5.4", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.1.3", "@lezer/lr": "^1.3.0" } }, "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA=="],
+
+    "@lezer/json": ["@lezer/json@1.0.3", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ=="],
+
+    "@lezer/lr": ["@lezer/lr@1.4.8", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA=="],
+
+    "@lezer/markdown": ["@lezer/markdown@1.6.3", "", { "dependencies": { "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0" } }, "sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw=="],
+
+    "@lezer/php": ["@lezer/php@1.0.5", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.1.0" } }, "sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA=="],
+
+    "@lezer/python": ["@lezer/python@1.1.18", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-31FiUrU7z9+d/ElGQLJFXl+dKOdx0jALlP3KEOsGTex8mvj+SoE1FgItcHWK/axkxCHGUSpqIHt6JAWfWu9Rhg=="],
+
+    "@lezer/rust": ["@lezer/rust@1.0.2", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-Lz5sIPBdF2FUXcWeCu1//ojFAZqzTQNRga0aYv6dYXqJqPfMdCAI0NzajWUd4Xijj1IKJLtjoXRPMvTKWBcqKg=="],
+
+    "@lezer/sass": ["@lezer/sass@1.1.0", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-3mMGdCTUZ/84ArHOuXWQr37pnf7f+Nw9ycPUeKX+wu19b7pSMcZGLbaXwvD2APMBDOGxPmpK/O6S1v1EvLoqgQ=="],
+
+    "@lezer/xml": ["@lezer/xml@1.0.6", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww=="],
+
+    "@lezer/yaml": ["@lezer/yaml@1.0.4", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.4.0" } }, "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw=="],
+
     "@manypkg/find-root": ["@manypkg/find-root@1.1.0", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@types/node": "^12.7.1", "find-up": "^4.1.0", "fs-extra": "^8.1.0" } }, "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA=="],
 
     "@manypkg/get-packages": ["@manypkg/get-packages@1.1.3", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@changesets/types": "^4.0.1", "@manypkg/find-root": "^1.1.0", "fs-extra": "^8.1.0", "globby": "^11.0.0", "read-yaml-file": "^1.1.0" } }, "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A=="],
+
+    "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
 
     "@next/env": ["@next/env@16.2.1", "", {}, "sha512-n8P/HCkIWW+gVal2Z8XqXJ6aB3J0tuM29OcHpCsobWlChH/SITBs1DFBk/HajgrwDkqqBXPbuUuzgDvUekREPg=="],
 
@@ -470,6 +571,8 @@
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -594,9 +697,19 @@
 
     "cosmiconfig": ["cosmiconfig@9.0.1", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ=="],
 
+    "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
 
     "data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
 
@@ -1132,6 +1245,8 @@
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
+    "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
+
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
@@ -1199,6 +1314,8 @@
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
+    "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
     "webdriver-bidi-protocol": ["webdriver-bidi-protocol@0.4.1", "", {}, "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw=="],
 

--- a/crates/conductor-server/src/routes/project_notes.rs
+++ b/crates/conductor-server/src/routes/project_notes.rs
@@ -2,9 +2,11 @@ use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::routing::{get, post};
 use axum::{Json, Router};
+use chrono::Datelike;
+use regex::Regex;
 use serde::Deserialize;
 use serde_json::{json, Value};
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
@@ -18,6 +20,7 @@ use crate::state::{resolve_board_file, AppState};
 const MAX_NOTE_FILE_BYTES: usize = 1024 * 1024;
 const MAX_NOTE_COUNT: usize = 2500;
 const MAX_NOTE_DEPTH: usize = 10;
+const TAG_SCAN_BYTES: usize = 64 * 1024;
 
 type ApiResponse = (StatusCode, Json<Value>);
 
@@ -29,6 +32,9 @@ pub fn router() -> Router<Arc<AppState>> {
             get(get_project_note_file).put(save_project_note_file),
         )
         .route("/api/project-notes/open", post(open_project_note))
+        .route("/api/project-notes/backlinks", get(get_backlinks))
+        .route("/api/project-notes/daily", post(create_daily_note))
+        .route("/api/project-notes/graph", get(get_notes_graph))
 }
 
 fn ok(value: Value) -> ApiResponse {
@@ -167,12 +173,22 @@ async fn list_project_notes(
     });
     files.dedup_by(|left, right| left["path"] == right["path"]);
 
+    // Build tags and forwardLinks maps by scanning file contents
+    let (tags, forward_links) = {
+        let files_snapshot = files.clone();
+        tokio::task::spawn_blocking(move || build_tags_and_forward_links(&files_snapshot))
+            .await
+            .unwrap_or_default()
+    };
+
     ok(json!({
         "editor": context.editor,
         "notesRoot": context.notes_root.as_ref().map(|path| path.to_string_lossy().to_string()),
         "syncManagedByEditor": context.editor.trim().eq_ignore_ascii_case("obsidian") && context.notes_root.is_some(),
         "writable": true,
         "files": files,
+        "tags": tags,
+        "forwardLinks": forward_links,
     }))
 }
 
@@ -825,6 +841,455 @@ async fn run_open_command(program: &str, args: Vec<String>) -> anyhow::Result<()
     } else {
         anyhow::bail!("Required opener is not installed: {program}")
     }
+}
+
+// ---------------------------------------------------------------------------
+// Tag & wikilink extraction helpers
+// ---------------------------------------------------------------------------
+
+/// Extract tags and wikilinks from the first 64KB of each file in the index.
+/// Returns `(tags_map, forward_links_map)` as serde_json::Value objects.
+fn build_tags_and_forward_links(files: &[Value]) -> (Value, Value) {
+    let tag_re = Regex::new(r"(?m)(?:^|[\s(])#([a-zA-Z][\w-]*)").expect("tag regex");
+    let wikilink_re = Regex::new(r"\[\[([^\]]+)\]\]").expect("wikilink regex");
+    let header_re = Regex::new(r"^#\s").expect("header regex");
+
+    let mut tags: HashMap<String, Vec<String>> = HashMap::new();
+    let mut forward_links: HashMap<String, Vec<String>> = HashMap::new();
+
+    for file in files {
+        let path_str = match file["path"].as_str() {
+            Some(p) => p.to_string(),
+            None => continue,
+        };
+        let path = PathBuf::from(&path_str);
+
+        let content = match fs::read(&path) {
+            Ok(bytes) => {
+                let limit = bytes.len().min(TAG_SCAN_BYTES);
+                String::from_utf8_lossy(&bytes[..limit]).to_string()
+            }
+            Err(_) => continue,
+        };
+
+        // Extract wikilinks
+        let mut file_links: Vec<String> = Vec::new();
+        for cap in wikilink_re.captures_iter(&content) {
+            if let Some(m) = cap.get(1) {
+                file_links.push(m.as_str().trim().to_string());
+            }
+        }
+        if !file_links.is_empty() {
+            forward_links.insert(path_str.clone(), file_links);
+        }
+
+        // Extract tags, but only from non-header lines
+        let mut file_tags: HashSet<String> = HashSet::new();
+        for line in content.lines() {
+            // Skip markdown headers (lines starting with "# ")
+            if header_re.is_match(line) {
+                continue;
+            }
+            for cap in tag_re.captures_iter(line) {
+                if let Some(m) = cap.get(1) {
+                    file_tags.insert(m.as_str().to_string());
+                }
+            }
+        }
+        for tag in file_tags {
+            tags.entry(tag).or_default().push(path_str.clone());
+        }
+    }
+
+    let tags_json = serde_json::to_value(&tags).unwrap_or(json!({}));
+    let links_json = serde_json::to_value(&forward_links).unwrap_or(json!({}));
+    (tags_json, links_json)
+}
+
+/// Read the first `limit` bytes of a file as a string. Returns None on error.
+fn read_file_head(path: &Path, limit: usize) -> Option<String> {
+    let bytes = fs::read(path).ok()?;
+    let end = bytes.len().min(limit);
+    Some(String::from_utf8_lossy(&bytes[..end]).to_string())
+}
+
+/// Extract wikilink targets from markdown content.
+fn extract_wikilinks(content: &str) -> Vec<String> {
+    let re = Regex::new(r"\[\[([^\]]+)\]\]").expect("wikilink regex");
+    re.captures_iter(content)
+        .filter_map(|cap| cap.get(1).map(|m| m.as_str().trim().to_string()))
+        .collect()
+}
+
+/// Extract tags from markdown content (excluding headers).
+fn extract_tags(content: &str) -> Vec<String> {
+    let tag_re = Regex::new(r"(?:^|[\s(])#([a-zA-Z][\w-]*)").expect("tag regex");
+    let header_re = Regex::new(r"^#\s").expect("header regex");
+    let mut tags = HashSet::new();
+    for line in content.lines() {
+        if header_re.is_match(line) {
+            continue;
+        }
+        for cap in tag_re.captures_iter(line) {
+            if let Some(m) = cap.get(1) {
+                tags.insert(m.as_str().to_string());
+            }
+        }
+    }
+    tags.into_iter().collect()
+}
+
+/// Get the note name without extension from a file path.
+fn note_name_from_path(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
+/// Build a file index mapping lowercase note name → absolute path.
+fn build_note_name_index(files: &[Value]) -> HashMap<String, PathBuf> {
+    let mut index: HashMap<String, PathBuf> = HashMap::new();
+    for file in files {
+        if let Some(p) = file["path"].as_str() {
+            let path = PathBuf::from(p);
+            let name = note_name_from_path(&path);
+            if !name.is_empty() {
+                index.entry(name.to_ascii_lowercase()).or_insert(path);
+            }
+        }
+    }
+    index
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/project-notes/backlinks
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BacklinksQuery {
+    project_id: String,
+    path: String,
+}
+
+async fn get_backlinks(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<BacklinksQuery>,
+) -> ApiResponse {
+    let context = match resolve_project_notes_context(&state, &query.project_id).await {
+        Ok(context) => context,
+        Err(response) => return response,
+    };
+
+    if !context.writable {
+        return error(
+            StatusCode::BAD_REQUEST,
+            "The selected markdown editor does not support local notes.",
+        );
+    }
+
+    let current_path = match resolve_requested_note_path(&context, &query.path, false) {
+        Ok(path) => path,
+        Err(response) => return response,
+    };
+
+    let note_name = note_name_from_path(&current_path);
+    if note_name.is_empty() {
+        return error(
+            StatusCode::BAD_REQUEST,
+            "Cannot determine note name from path",
+        );
+    }
+
+    // Read forward links from current file
+    let current_content = read_file_head(&current_path, MAX_NOTE_FILE_BYTES);
+    let forward_links: Vec<String> = current_content
+        .as_deref()
+        .map(extract_wikilinks)
+        .unwrap_or_default();
+
+    // Collect all note files and scan for backlinks
+    let backlinks = {
+        let note_name_clone = note_name.clone();
+        let current_path_str = current_path.to_string_lossy().to_string();
+        let mut files = Vec::new();
+        if let Some(notes_root) = context.notes_root.as_deref() {
+            collect_note_files(
+                notes_root,
+                Some(notes_root),
+                context.source_label,
+                &mut files,
+                MAX_NOTE_COUNT,
+                MAX_NOTE_DEPTH,
+            );
+        }
+        let files_clone = files.clone();
+        tokio::task::spawn_blocking(move || {
+            scan_backlinks(&files_clone, &note_name_clone, &current_path_str)
+        })
+        .await
+        .unwrap_or_default()
+    };
+
+    ok(json!({
+        "backlinks": backlinks,
+        "forwardLinks": forward_links,
+    }))
+}
+
+/// Scan files for backlinks to the given note name. Returns backlink entries
+/// with ~100 chars of context around each match.
+fn scan_backlinks(files: &[Value], note_name: &str, current_path: &str) -> Vec<Value> {
+    let wikilink_re = Regex::new(r"\[\[([^\]]+)\]\]").expect("wikilink regex");
+    let note_name_lower = note_name.to_ascii_lowercase();
+    let mut results: Vec<Value> = Vec::new();
+
+    for file in files {
+        let path_str = match file["path"].as_str() {
+            Some(p) => p,
+            None => continue,
+        };
+        // Skip self-referencing
+        if path_str == current_path {
+            continue;
+        }
+
+        let display_path = file["displayPath"].as_str().unwrap_or_default().to_string();
+        let name = file["name"].as_str().unwrap_or_default().to_string();
+
+        let content = match read_file_head(&PathBuf::from(path_str), MAX_NOTE_FILE_BYTES) {
+            Some(c) => c,
+            None => continue,
+        };
+
+        for cap in wikilink_re.captures_iter(&content) {
+            let target = cap.get(1).map(|m| m.as_str().trim()).unwrap_or("");
+            if target.to_ascii_lowercase() != note_name_lower {
+                continue;
+            }
+
+            let full_match = cap.get(0).unwrap();
+            let match_start = full_match.start();
+            let match_end = full_match.end();
+
+            // Get ~100 chars of context around the match
+            let ctx_start = match_start.saturating_sub(50);
+            let ctx_end = (match_end + 50).min(content.len());
+            let context = content[ctx_start..ctx_end].replace('\n', " ");
+
+            results.push(json!({
+                "path": path_str,
+                "displayPath": display_path,
+                "name": name,
+                "context": context,
+            }));
+            // Only one backlink entry per file
+            break;
+        }
+    }
+
+    results
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/project-notes/daily
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateDailyNoteBody {
+    project_id: String,
+}
+
+async fn create_daily_note(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<CreateDailyNoteBody>,
+) -> ApiResponse {
+    let context = match resolve_project_notes_context(&state, &body.project_id).await {
+        Ok(context) => context,
+        Err(response) => return response,
+    };
+
+    if !context.writable {
+        return error(
+            StatusCode::BAD_REQUEST,
+            "The selected markdown editor does not support local notes.",
+        );
+    }
+
+    let now = chrono::Utc::now();
+    let date_str = format!("{}-{:02}-{:02}", now.year(), now.month(), now.day());
+    let relative_path = format!("daily/{}.md", date_str);
+    let seed_content = format!("# {}\n\n", date_str);
+
+    let full_path = match resolve_requested_note_path(&context, &relative_path, true) {
+        Ok(path) => path,
+        Err(response) => return response,
+    };
+
+    let created = if full_path.exists() {
+        false
+    } else {
+        let parent = match full_path.parent() {
+            Some(p) => p,
+            None => {
+                return error(
+                    StatusCode::BAD_REQUEST,
+                    "Daily note path must be inside a writable notes folder.",
+                )
+            }
+        };
+        if let Err(err) = fs::create_dir_all(parent) {
+            return error(StatusCode::INTERNAL_SERVER_ERROR, err.to_string());
+        }
+        if let Err(err) = atomic_write_text_file(&full_path, &seed_content) {
+            return error(StatusCode::INTERNAL_SERVER_ERROR, err.to_string());
+        }
+        true
+    };
+
+    ok(json!({
+        "path": full_path.to_string_lossy().to_string(),
+        "displayPath": display_path_for_note(&context, &full_path),
+        "created": created,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/project-notes/graph
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GraphQuery {
+    project_id: String,
+}
+
+async fn get_notes_graph(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<GraphQuery>,
+) -> ApiResponse {
+    let context = match resolve_project_notes_context(&state, &query.project_id).await {
+        Ok(context) => context,
+        Err(response) => return response,
+    };
+
+    if !context.writable {
+        return ok(json!({ "nodes": [], "edges": [] }));
+    }
+
+    let mut files = Vec::new();
+    if let Some(notes_root) = context.notes_root.as_deref() {
+        collect_note_files(
+            notes_root,
+            Some(notes_root),
+            context.source_label,
+            &mut files,
+            MAX_NOTE_COUNT,
+            MAX_NOTE_DEPTH,
+        );
+    }
+
+    let graph_data = {
+        let files_snapshot = files;
+        tokio::task::spawn_blocking(move || build_graph_data(&files_snapshot))
+            .await
+            .unwrap_or_else(|_| (json!([]), json!([])))
+    };
+
+    ok(json!({
+        "nodes": graph_data.0,
+        "edges": graph_data.1,
+    }))
+}
+
+/// Build graph nodes and edges from the file index.
+fn build_graph_data(files: &[Value]) -> (Value, Value) {
+    let note_name_index = build_note_name_index(files);
+    let wikilink_re = Regex::new(r"\[\[([^\]]+)\]\]").expect("wikilink regex");
+
+    let mut nodes: Vec<Value> = Vec::new();
+    let mut edges: Vec<Value> = Vec::new();
+
+    for file in files {
+        let path_str = match file["path"].as_str() {
+            Some(p) => p.to_string(),
+            None => continue,
+        };
+        let path = PathBuf::from(&path_str);
+        let name = file["name"].as_str().unwrap_or_default().to_string();
+
+        // Read content for tags and wikilinks
+        let content = read_file_head(&path, TAG_SCAN_BYTES);
+        let tags: Vec<String> = content.as_deref().map(extract_tags).unwrap_or_default();
+
+        nodes.push(json!({
+            "id": path_str,
+            "name": name,
+            "tags": tags,
+        }));
+
+        // Extract wikilinks and resolve to actual paths
+        if let Some(ref content) = content {
+            for cap in wikilink_re.captures_iter(content) {
+                let target = match cap.get(1) {
+                    Some(m) => m.as_str().trim().to_string(),
+                    None => continue,
+                };
+
+                // Try to resolve: first by exact path match in files, then by name match
+                let resolved = resolve_wikilink_target(&target, files, &note_name_index);
+                if let Some(resolved_path) = resolved {
+                    edges.push(json!({
+                        "source": path_str,
+                        "target": resolved_path,
+                    }));
+                }
+            }
+        }
+    }
+
+    (json!(nodes), json!(edges))
+}
+
+/// Resolve a wikilink target to an actual file path. Tries:
+/// 1. Direct match against file paths (if the target looks like a relative path)
+/// 2. Case-insensitive match by note name (stem without extension)
+fn resolve_wikilink_target(
+    target: &str,
+    files: &[Value],
+    name_index: &HashMap<String, PathBuf>,
+) -> Option<String> {
+    let target_lower = target.to_ascii_lowercase();
+
+    // Try direct path suffix match against known files
+    for file in files {
+        if let Some(p) = file["path"].as_str() {
+            let p_lower = p.to_ascii_lowercase();
+            // Check if target matches the end of a path (with or without .md extension)
+            if p_lower.ends_with(&format!("/{}", target_lower))
+                || p_lower.ends_with(&format!("/{}.md", target_lower))
+                || p_lower == target_lower
+                || p_lower == format!("{}.md", target_lower)
+            {
+                return Some(p.to_string());
+            }
+        }
+    }
+
+    // Try name-based lookup (stem only)
+    let stem = if target_lower.ends_with(".md") {
+        target_lower.trim_end_matches(".md").to_string()
+    } else {
+        target_lower.clone()
+    };
+
+    if let Some(resolved) = name_index.get(&stem) {
+        return Some(resolved.to_string_lossy().to_string());
+    }
+
+    None
 }
 
 #[cfg(test)]

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -14,6 +14,11 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^6.39.0",
+    "@codemirror/commands": "^6.10.3",
+    "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/language-data": "^6.5.2",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/view": "^6.41.0",
     "@conductor-oss/core": "workspace:*",
     "@pierre/diffs": "^1.0.11",
     "@primer/octicons-react": "^19.15.0",
@@ -28,6 +33,7 @@
     "@vercel/analytics": "^2.0.1",
     "@xterm/addon-fit": "^0.11.0",
     "clsx": "^2.1.1",
+    "d3-force": "^3.0.0",
     "diff": "^8.0.3",
     "geist": "^1.7.0",
     "jose": "^6.1.3",
@@ -46,6 +52,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.1",
+    "@types/d3-force": "^3.0.10",
     "@types/node": "^25.3.3",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/packages/web/src/components/notes/NotesBacklinks.tsx
+++ b/packages/web/src/components/notes/NotesBacklinks.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { ChevronDown, ChevronRight, FileText } from "lucide-react";
+import type { BacklinkInfo } from "./types";
+import { withBridgeQuery } from "@/lib/bridgeQuery";
+
+interface NotesBacklinksProps {
+  projectId: string;
+  bridgeId?: string | null;
+  notePath: string | null;
+  onNavigate: (path: string) => void;
+}
+
+export function NotesBacklinks({ projectId, bridgeId, notePath, onNavigate }: NotesBacklinksProps) {
+  const [backlinks, setBacklinks] = useState<BacklinkInfo[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState(true);
+
+  const fetchBacklinks = useCallback(async () => {
+    if (!notePath) {
+      setBacklinks([]);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const params = new URLSearchParams({
+        projectId,
+        path: notePath,
+      });
+      const response = await fetch(
+        withBridgeQuery(`/api/project-notes/backlinks?${params.toString()}`, bridgeId),
+        { cache: "no-store" },
+      );
+      const payload = (await response.json().catch(() => null)) as
+        | { backlinks?: BacklinkInfo[] }
+        | { error?: string }
+        | null;
+
+      if (!response.ok) {
+        throw new Error(
+          payload && "error" in payload
+            ? payload.error ?? "Failed to load backlinks"
+            : `Failed to load backlinks (${response.status})`,
+        );
+      }
+
+      const blPayload = payload as { backlinks?: BacklinkInfo[] } | null;
+      setBacklinks(blPayload?.backlinks ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load backlinks");
+      setBacklinks([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [bridgeId, notePath, projectId]);
+
+  useEffect(() => {
+    void fetchBacklinks();
+  }, [fetchBacklinks]);
+
+  if (!notePath) return null;
+
+  if (backlinks.length === 0 && !loading) return null;
+
+  return (
+    <div className="border-t border-[var(--vk-border)] bg-[var(--vk-bg-panel)]/20">
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="flex w-full items-center gap-2 px-4 py-2 text-left text-[12px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)]"
+      >
+        {expanded ? (
+          <ChevronDown className="h-3.5 w-3.5 shrink-0" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5 shrink-0" />
+        )}
+        <span className="font-medium">
+          Linked References
+        </span>
+        <span className="rounded-full bg-[var(--vk-bg-main)] px-2 py-0.5 text-[11px]">
+          {backlinks.length}
+        </span>
+        {loading && (
+          <span className="text-[11px] text-[var(--vk-text-muted)]">loading…</span>
+        )}
+      </button>
+
+      {expanded && (
+        <div className="max-h-[240px] overflow-auto px-4 pb-3">
+          {error && (
+            <p className="py-2 text-[12px] text-[var(--vk-red)]">{error}</p>
+          )}
+          {backlinks.map((bl) => (
+            <button
+              key={bl.path}
+              type="button"
+              onClick={() => onNavigate(bl.path)}
+              className="flex w-full items-start gap-2 rounded-[4px] px-2 py-2 text-left hover:bg-[var(--vk-bg-hover)]"
+            >
+              <FileText className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--vk-text-muted)]" />
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-[12px] text-[var(--vk-text-normal)]">
+                  {bl.name || bl.displayPath}
+                </p>
+                {bl.context && (
+                  <p className="mt-0.5 line-clamp-2 text-[11px] leading-4 text-[var(--vk-text-muted)]">
+                    {bl.context}
+                  </p>
+                )}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/notes/NotesEditor.tsx
+++ b/packages/web/src/components/notes/NotesEditor.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+import { EditorState, Compartment } from "@codemirror/state";
+import { EditorView, keymap, lineNumbers, highlightActiveLineGutter, highlightSpecialChars, drawSelection, highlightActiveLine, placeholder as cmPlaceholder } from "@codemirror/view";
+import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
+import { languages } from "@codemirror/language-data";
+import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import { bracketMatching } from "@codemirror/language";
+import { wikilinkPlugin } from "./wikilinkPlugin";
+
+interface NotesEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  readOnly?: boolean;
+  placeholder?: string;
+  onWikilinkClick?: (target: string) => void;
+  onSave?: () => void;
+  onQuickSwitch?: () => void;
+}
+
+const baseTheme = EditorView.theme({
+  "&": {
+    height: "100%",
+    fontSize: "13px",
+  },
+  ".cm-content": {
+    fontFamily: "var(--font-geist-mono), ui-monospace, SFMono-Regular, monospace",
+    padding: "16px 0",
+    caretColor: "var(--vk-accent)",
+    lineHeight: "1.6",
+  },
+  ".cm-cursor": {
+    borderLeftColor: "var(--vk-accent)",
+  },
+  "&.cm-focused .cm-selectionBackground, .cm-selectionBackground": {
+    backgroundColor: "rgba(139, 92, 246, 0.25) !important",
+  },
+  ".cm-gutters": {
+    backgroundColor: "transparent",
+    color: "var(--vk-text-muted)",
+    border: "none",
+    paddingRight: "8px",
+  },
+  ".cm-activeLineGutter": {
+    backgroundColor: "transparent",
+    color: "var(--vk-text-normal)",
+  },
+  ".cm-activeLine": {
+    backgroundColor: "rgba(255,255,255,0.03)",
+  },
+  ".cm-line": {
+    padding: "0 16px",
+  },
+  ".cm-placeholder": {
+    color: "var(--vk-text-muted)",
+    fontStyle: "italic",
+    padding: "0 16px",
+  },
+});
+
+export function NotesEditor({
+  value,
+  onChange,
+  readOnly = false,
+  placeholder = "Select a note to start editing",
+  onWikilinkClick,
+  onSave,
+  onQuickSwitch,
+}: NotesEditorProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView | null>(null);
+  const onChangeRef = useRef(onChange);
+  const onSaveRef = useRef(onSave);
+  const onQuickSwitchRef = useRef(onQuickSwitch);
+  const onWikilinkClickRef = useRef(onWikilinkClick);
+  const readOnlyCompartment = useRef(new Compartment());
+
+  // Keep refs up to date
+  onChangeRef.current = onChange;
+  onSaveRef.current = onSave;
+  onQuickSwitchRef.current = onQuickSwitch;
+  onWikilinkClickRef.current = onWikilinkClick;
+
+  const handleSave = useCallback(() => {
+    onSaveRef.current?.();
+    return true;
+  }, []);
+
+  const handleQuickSwitch = useCallback(() => {
+    onQuickSwitchRef.current?.();
+    return true;
+  }, []);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const isMac = typeof navigator !== "undefined" && /Mac|iPod|iPhone|iPad/.test(navigator.userAgent);
+    const modKey = isMac ? "Meta" : "Control";
+
+    const state = EditorState.create({
+      doc: value,
+      extensions: [
+        baseTheme,
+        lineNumbers(),
+        highlightActiveLineGutter(),
+        highlightSpecialChars(),
+        history(),
+        drawSelection(),
+        EditorState.allowMultipleSelections.of(true),
+        readOnlyCompartment.current.of(EditorState.readOnly.of(readOnly)),
+        bracketMatching(),
+        highlightActiveLine(),
+        markdown({ base: markdownLanguage, codeLanguages: languages }),
+        wikilinkPlugin,
+        EditorView.updateListener.of((update) => {
+          if (update.docChanged) {
+            onChangeRef.current(update.state.doc.toString());
+          }
+        }),
+        EditorView.domEventHandlers({
+          click(event, view) {
+            const pos = view.posAtCoords(event);
+            if (pos == null) return false;
+
+            const line = view.state.doc.lineAt(pos);
+            const lineText = line.text;
+            const lineOffset = pos - line.from;
+
+            // Check for wikilink click
+            const wikilinkRegex = /\[\[([^\]]+)\]\]/g;
+            let match: RegExpExecArray | null;
+            while ((match = wikilinkRegex.exec(lineText)) !== null) {
+              const start = match.index;
+              const end = start + match[0].length;
+              if (lineOffset >= start && lineOffset <= end) {
+                onWikilinkClickRef.current?.(match[1].trim());
+                return true;
+              }
+            }
+            return false;
+          },
+        }),
+        keymap.of([
+          ...defaultKeymap,
+          ...historyKeymap,
+          {
+            key: `${modKey}-s`,
+            run: () => handleSave(),
+            preventDefault: true,
+          },
+          {
+            key: `${modKey}-k`,
+            run: () => handleQuickSwitch(),
+            preventDefault: true,
+          },
+        ]),
+        EditorView.lineWrapping,
+        placeholder ? cmPlaceholder(placeholder) : [],
+      ],
+    });
+
+    const view = new EditorView({
+      state,
+      parent: containerRef.current,
+    });
+
+    viewRef.current = view;
+
+    return () => {
+      view.destroy();
+      viewRef.current = null;
+    };
+    // We intentionally only run this once per mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Sync external value changes
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+
+    const currentValue = view.state.doc.toString();
+    if (currentValue !== value) {
+      view.dispatch({
+        changes: { from: 0, to: currentValue.length, insert: value },
+      });
+    }
+  }, [value]);
+
+  // Sync readOnly
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    view.dispatch({
+      effects: readOnlyCompartment.current.reconfigure(EditorState.readOnly.of(readOnly)),
+    });
+  }, [readOnly]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-full min-h-0 w-full bg-[var(--vk-bg-main)] text-[var(--vk-text-normal)]"
+    />
+  );
+}

--- a/packages/web/src/components/notes/NotesGraph.tsx
+++ b/packages/web/src/components/notes/NotesGraph.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import { forceSimulation, forceLink, forceManyBody, forceCenter, forceCollide } from "d3-force";
+import type { GraphNode, GraphEdge } from "./types";
+import { withBridgeQuery } from "@/lib/bridgeQuery";
+
+interface NotesGraphProps {
+  projectId: string;
+  bridgeId?: string | null;
+  onNavigate: (path: string) => void;
+}
+
+interface SimNode extends GraphNode {
+  x: number;
+  y: number;
+  fx?: number | null;
+  fy?: number | null;
+}
+
+interface SimEdge {
+  source: SimNode | string;
+  target: SimNode | string;
+}
+
+const NODE_RADIUS = 6;
+const COLORS = [
+  "#8b5cf6", // purple
+  "#06b6d4", // cyan
+  "#f59e0b", // amber
+  "#10b981", // green
+  "#ef4444", // red
+  "#ec4899", // pink
+  "#3b82f6", // blue
+  "#f97316", // orange
+];
+
+function getNodeColor(path: string): string {
+  const depth = path.split("/").length - 1;
+  return COLORS[depth % COLORS.length];
+}
+
+export function NotesGraph({ projectId, bridgeId, onNavigate }: NotesGraphProps) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [nodes, setNodes] = useState<SimNode[]>([]);
+  const [edges, setEdges] = useState<SimEdge[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hoveredNode, setHoveredNode] = useState<string | null>(null);
+  const [transform, setTransform] = useState({ x: 0, y: 0, k: 1 });
+  const isPanning = useRef(false);
+  const lastMouse = useRef({ x: 0, y: 0 });
+
+  const fetchGraph = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const params = new URLSearchParams({ projectId });
+      const response = await fetch(
+        withBridgeQuery(`/api/project-notes/graph?${params.toString()}`, bridgeId),
+        { cache: "no-store" },
+      );
+      const payload = (await response.json().catch(() => null)) as
+        | { nodes: GraphNode[]; edges: GraphEdge[] }
+        | { error?: string }
+        | null;
+
+      if (!response.ok) {
+        throw new Error(
+          payload && "error" in payload
+            ? payload.error ?? "Failed to load graph"
+            : `Failed to load graph (${response.status})`,
+        );
+      }
+
+      const graphData = payload as { nodes: GraphNode[]; edges: GraphEdge[] };
+
+      // Initialize node positions
+      const simNodes: SimNode[] = graphData.nodes.map((n, i) => ({
+        ...n,
+        x: Math.cos((i / graphData.nodes.length) * 2 * Math.PI) * 200,
+        y: Math.sin((i / graphData.nodes.length) * 2 * Math.PI) * 200,
+      }));
+
+      const simEdges: SimEdge[] = graphData.edges.map((e) => ({
+        source: e.source,
+        target: e.target,
+      }));
+
+      setNodes(simNodes);
+      setEdges(simEdges);
+
+      // Run simulation
+      const simulation = forceSimulation<SimNode>(simNodes)
+        .force(
+          "link",
+          forceLink<SimNode, SimEdge>(simEdges)
+            .id((d) => d.id)
+            .distance(80),
+        )
+        .force("charge", forceManyBody().strength(-120))
+        .force("center", forceCenter(0, 0))
+        .force("collide", forceCollide(NODE_RADIUS * 2.5))
+        .stop();
+
+      // Run synchronously for 300 ticks
+      for (let i = 0; i < 300; i++) {
+        simulation.tick();
+      }
+
+      setNodes([...simNodes]);
+      setEdges([...simEdges]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load graph");
+    } finally {
+      setLoading(false);
+    }
+  }, [bridgeId, projectId]);
+
+  useEffect(() => {
+    void fetchGraph();
+  }, [fetchGraph]);
+
+  // Pan handlers
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent<SVGSVGElement>) => {
+      if (e.button === 0) {
+        isPanning.current = true;
+        lastMouse.current = { x: e.clientX, y: e.clientY };
+      }
+    },
+    [],
+  );
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<SVGSVGElement>) => {
+      if (isPanning.current) {
+        const dx = e.clientX - lastMouse.current.x;
+        const dy = e.clientY - lastMouse.current.y;
+        lastMouse.current = { x: e.clientX, y: e.clientY };
+        setTransform((prev) => ({
+          x: prev.x + dx,
+          y: prev.y + dy,
+          k: prev.k,
+        }));
+      }
+    },
+    [],
+  );
+
+  const handleMouseUp = useCallback(() => {
+    isPanning.current = false;
+  }, []);
+
+  const handleWheel = useCallback((e: React.WheelEvent<SVGSVGElement>) => {
+    e.preventDefault();
+    const delta = e.deltaY > 0 ? 0.9 : 1.1;
+    setTransform((prev) => ({
+      x: prev.x,
+      y: prev.y,
+      k: Math.max(0.2, Math.min(4, prev.k * delta)),
+    }));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center gap-2 text-[13px] text-[var(--vk-text-muted)]">
+        Loading graph…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-full items-center justify-center text-[13px] text-[var(--vk-red)]">
+        {error}
+      </div>
+    );
+  }
+
+  if (nodes.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-[13px] text-[var(--vk-text-muted)]">
+        No notes to graph
+      </div>
+    );
+  }
+
+  const svgWidth = 800;
+  const svgHeight = 600;
+  const centerX = svgWidth / 2 + transform.x;
+  const centerY = svgHeight / 2 + transform.y;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-[var(--vk-bg-main)]">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-[var(--vk-border)] px-4 py-2">
+        <span className="text-[12px] text-[var(--vk-text-muted)]">
+          {nodes.length} notes · {edges.length} links
+        </span>
+        <button
+          type="button"
+          onClick={() => void fetchGraph()}
+          className="text-[12px] text-[var(--vk-text-muted)] hover:text-[var(--vk-text-normal)]"
+        >
+          Refresh
+        </button>
+      </div>
+
+      {/* SVG */}
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <svg
+          ref={svgRef}
+          width="100%"
+          height="100%"
+          viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+          onMouseDown={handleMouseDown}
+          onMouseMove={handleMouseMove}
+          onMouseUp={handleMouseUp}
+          onMouseLeave={handleMouseUp}
+          onWheel={handleWheel}
+          style={{ cursor: isPanning.current ? "grabbing" : "grab" }}
+        >
+          <g transform={`translate(${centerX}, ${centerY}) scale(${transform.k})`}>
+            {/* Edges */}
+            {edges.map((edge, idx) => {
+              const source = typeof edge.source === "object" ? edge.source : null;
+              const target = typeof edge.target === "object" ? edge.target : null;
+              if (!source || !target) return null;
+              return (
+                <line
+                  key={`edge-${idx}`}
+                  x1={source.x}
+                  y1={source.y}
+                  x2={target.x}
+                  y2={target.y}
+                  stroke="var(--vk-border)"
+                  strokeWidth={1}
+                  opacity={0.6}
+                />
+              );
+            })}
+
+            {/* Nodes */}
+            {nodes.map((node) => {
+              const color = getNodeColor(node.id);
+              const isHovered = hoveredNode === node.id;
+              return (
+                <g
+                  key={node.id}
+                  transform={`translate(${node.x}, ${node.y})`}
+                  onClick={() => onNavigate(node.id)}
+                  onMouseEnter={() => setHoveredNode(node.id)}
+                  onMouseLeave={() => setHoveredNode(null)}
+                  style={{ cursor: "pointer" }}
+                >
+                  <circle
+                    r={isHovered ? NODE_RADIUS * 1.5 : NODE_RADIUS}
+                    fill={color}
+                    stroke={isHovered ? "var(--vk-text-strong)" : "transparent"}
+                    strokeWidth={isHovered ? 2 : 0}
+                    opacity={0.85}
+                  />
+                  {(isHovered || transform.k > 1.2) && (
+                    <text
+                      x={NODE_RADIUS + 4}
+                      y={4}
+                      fontSize={10}
+                      fill="var(--vk-text-normal)"
+                      style={{ pointerEvents: "none" }}
+                    >
+                      {node.name}
+                    </text>
+                  )}
+                </g>
+              );
+            })}
+          </g>
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/notes/NotesPreview.tsx
+++ b/packages/web/src/components/notes/NotesPreview.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useMemo, type ReactNode, type ComponentPropsWithoutRef } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import type { NoteFile } from "./types";
+import { resolveWikilinkTarget } from "./utils";
+
+interface NotesPreviewProps {
+  content: string;
+  onWikilinkClick?: (target: string) => void;
+  noteFiles?: NoteFile[];
+}
+
+function preprocessWikilinks(
+  markdown: string,
+  onWikilinkClick?: (target: string) => void,
+  noteFiles?: NoteFile[],
+): ReactNode[] {
+  const parts: ReactNode[] = [];
+  const regex = /(\[\[([^\]]+)\]\])|(#([a-zA-Z][\w/-]*))/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  let key = 0;
+
+  while ((match = regex.exec(markdown)) !== null) {
+    // Add text before this match
+    if (match.index > lastIndex) {
+      parts.push(markdown.slice(lastIndex, match.index));
+    }
+
+    if (match[1]) {
+      // Wikilink [[target]]
+      const target = match[2].trim();
+      const resolved = noteFiles ? resolveWikilinkTarget(target, noteFiles) : null;
+      const isUnresolved = !resolved;
+      parts.push(
+        <span
+          key={`wl-${key++}`}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onWikilinkClick?.(target);
+          }}
+          style={{
+            backgroundColor: isUnresolved ? "rgba(255, 143, 122, 0.12)" : "rgba(139, 92, 246, 0.15)",
+            borderRadius: "3px",
+            padding: "1px 5px",
+            cursor: "pointer",
+            color: isUnresolved ? "var(--vk-red, #ff8f7a)" : "#cdb4ff",
+            fontSize: "0.9em",
+          }}
+        >
+          {target}
+        </span>,
+      );
+    } else if (match[3]) {
+      // Tag #tag
+      // Check if it's a heading (# at start of line followed by space)
+      const tagStr = match[3];
+      const preChar = match.index > 0 ? markdown[match.index - 1] : "\n";
+      const isHeading = (match.index === 0 || preChar === "\n") && markdown[match.index + tagStr.length] === " ";
+
+      if (isHeading) {
+        parts.push(tagStr);
+      } else {
+        const tagName = match[4];
+        parts.push(
+          <span
+            key={`tag-${key++}`}
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              // Could trigger tag filtering
+            }}
+            style={{
+              backgroundColor: "rgba(248, 147, 30, 0.12)",
+              borderRadius: "3px",
+              padding: "1px 5px",
+              cursor: "pointer",
+              color: "#f6c56f",
+              fontSize: "0.85em",
+            }}
+          >
+            #{tagName}
+          </span>,
+        );
+      }
+    }
+
+    lastIndex = match.index + match[0].length;
+  }
+
+  // Add remaining text
+  if (lastIndex < markdown.length) {
+    parts.push(markdown.slice(lastIndex));
+  }
+
+  return parts.length > 0 ? parts : [markdown];
+}
+
+export function NotesPreview({ content, onWikilinkClick, noteFiles }: NotesPreviewProps) {
+  const processedContent = useMemo(() => {
+    if (!content.trim()) return "";
+    return content;
+  }, [content]);
+
+  if (!content.trim()) {
+    return (
+      <div className="flex h-full min-h-[240px] items-center justify-center text-center text-[13px] text-[var(--vk-text-muted)]">
+        Markdown preview will appear here once the note has content.
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-auto bg-[var(--vk-bg-panel)]/25 px-4 py-4">
+      <article className="prose prose-invert max-w-none text-[14px] leading-7 text-[var(--vk-text-normal)] prose-headings:text-[var(--vk-text-strong)] prose-strong:text-[var(--vk-text-strong)] prose-code:text-[var(--vk-accent)] prose-pre:bg-[var(--vk-bg-main)] prose-blockquote:border-l-[var(--vk-accent)] prose-blockquote:text-[var(--vk-text-muted)]">
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          components={{
+            // Process text nodes to render wikilinks and tags
+            p: ({ children, ...props }: ComponentPropsWithoutRef<"p">) => {
+              return <p {...props}>{processChildren(children, onWikilinkClick, noteFiles)}</p>;
+            },
+            li: ({ children, ...props }: ComponentPropsWithoutRef<"li">) => {
+              return <li {...props}>{processChildren(children, onWikilinkClick, noteFiles)}</li>;
+            },
+          }}
+        >
+          {processedContent}
+        </ReactMarkdown>
+      </article>
+    </div>
+  );
+}
+
+function processChildren(
+  children: ReactNode,
+  onWikilinkClick?: (target: string) => void,
+  noteFiles?: NoteFile[],
+): ReactNode {
+  if (typeof children === "string") {
+    const nodes = preprocessWikilinks(children, onWikilinkClick, noteFiles);
+    return nodes.length === 1 ? nodes[0] : <>{nodes}</>;
+  }
+  if (Array.isArray(children)) {
+    return children.map((child, idx) => {
+      if (typeof child === "string") {
+        const nodes = preprocessWikilinks(child, onWikilinkClick, noteFiles);
+        return nodes.length === 1 ? (
+          <span key={idx}>{nodes[0]}</span>
+        ) : (
+          <span key={idx}>{nodes}</span>
+        );
+      }
+      return child;
+    });
+  }
+  return children;
+}

--- a/packages/web/src/components/notes/NotesSidebar.tsx
+++ b/packages/web/src/components/notes/NotesSidebar.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import {
+  ChevronDown,
+  ChevronRight,
+  FileText,
+  Folder,
+  FolderOpen,
+  Search,
+} from "lucide-react";
+import type { NoteFile, NotesTreeNode, TagMap } from "./types";
+import { buildNotesTree, filterNotesTree, collectFolderPaths } from "./utils";
+
+interface NotesSidebarProps {
+  noteFiles: NoteFile[];
+  selectedPath: string | null;
+  expandedFolders: string[];
+  onToggleFolder: (path: string) => void;
+  onSelectFile: (path: string) => void;
+  search: string;
+  onSearchChange: (value: string) => void;
+  editorLabel?: string;
+  tags?: TagMap;
+  onTagClick?: (tag: string) => void;
+}
+
+function NotesTree({
+  nodes,
+  expandedFolders,
+  selectedPath,
+  onToggleFolder,
+  onSelectFile,
+  depth = 0,
+}: {
+  nodes: NotesTreeNode[];
+  expandedFolders: Set<string>;
+  selectedPath: string | null;
+  onToggleFolder: (path: string) => void;
+  onSelectFile: (path: string) => void;
+  depth?: number;
+}) {
+  return (
+    <>
+      {nodes.map((node) => {
+        const paddingLeft = 10 + depth * 14;
+        if (node.isDirectory) {
+          const expanded = expandedFolders.has(node.path);
+          return (
+            <div key={`${node.path}-${node.name}`}>
+              <button
+                type="button"
+                onClick={() => onToggleFolder(node.path)}
+                className="flex w-full items-center gap-1.5 py-1.5 text-left text-[12px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)]"
+                style={{ paddingLeft }}
+              >
+                {expanded ? (
+                  <ChevronDown className="h-3.5 w-3.5 shrink-0" />
+                ) : (
+                  <ChevronRight className="h-3.5 w-3.5 shrink-0" />
+                )}
+                {expanded ? (
+                  <FolderOpen className="h-3.5 w-3.5 shrink-0 text-[var(--vk-accent)]" />
+                ) : (
+                  <Folder className="h-3.5 w-3.5 shrink-0 text-[var(--vk-accent)]" />
+                )}
+                <span className="truncate">{node.name}</span>
+              </button>
+              {expanded ? (
+                <NotesTree
+                  nodes={node.children}
+                  expandedFolders={expandedFolders}
+                  selectedPath={selectedPath}
+                  onToggleFolder={onToggleFolder}
+                  onSelectFile={onSelectFile}
+                  depth={depth + 1}
+                />
+              ) : null}
+            </div>
+          );
+        }
+
+        const selected = selectedPath === node.path;
+        return (
+          <button
+            key={node.path}
+            type="button"
+            onClick={() => onSelectFile(node.path)}
+            className={`flex w-full items-center gap-1.5 py-1.5 pr-2 text-left text-[12px] ${
+              selected
+                ? "bg-[var(--vk-bg-active)] text-[var(--vk-text-strong)]"
+                : "text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)]"
+            }`}
+            style={{ paddingLeft: paddingLeft + 18 }}
+          >
+            <FileText className="h-3.5 w-3.5 shrink-0 text-[var(--vk-text-muted)]" />
+            <span className="truncate">{node.name}</span>
+          </button>
+        );
+      })}
+    </>
+  );
+}
+
+export function NotesSidebar({
+  noteFiles,
+  selectedPath,
+  expandedFolders,
+  onToggleFolder,
+  onSelectFile,
+  search,
+  onSearchChange,
+  editorLabel,
+  tags,
+  onTagClick,
+}: NotesSidebarProps) {
+  const [tagsExpanded, setTagsExpanded] = useState(true);
+
+  const filteredTree = useMemo(() => {
+    const matchingFiles =
+      search.trim().length === 0
+        ? noteFiles
+        : noteFiles.filter((file) => {
+            const haystack = `${file.displayPath} ${file.name} ${file.source ?? ""}`.toLowerCase();
+            return haystack.includes(search.trim().toLowerCase());
+          });
+    return filterNotesTree(buildNotesTree(matchingFiles), search);
+  }, [noteFiles, search]);
+
+  const tagEntries = useMemo(() => {
+    if (!tags) return [];
+    return Object.entries(tags).sort((a, b) => b[1].length - a[1].length);
+  }, [tags]);
+
+  const folderPathsSet = useMemo(
+    () => new Set(expandedFolders),
+    [expandedFolders],
+  );
+
+  return (
+    <aside className="flex min-h-0 flex-col border-r border-[var(--vk-border)] bg-[var(--vk-bg-panel)]/35">
+      {/* Search + header */}
+      <div className="flex items-center justify-between border-b border-[var(--vk-border)] px-3 py-2 text-[12px] text-[var(--vk-text-muted)]">
+        <span>
+          {noteFiles.length} note{noteFiles.length === 1 ? "" : "s"}
+        </span>
+        <span>
+          {search.trim().length > 0 ? "Filtered" : editorLabel || "notes"}
+        </span>
+      </div>
+
+      {/* Search bar */}
+      <div className="border-b border-[var(--vk-border)] px-3 py-2">
+        <div className="flex items-center gap-2 rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-2.5 py-1.5">
+          <Search className="h-3.5 w-3.5 shrink-0 text-[var(--vk-text-muted)]" />
+          <input
+            value={search}
+            onChange={(event) => onSearchChange(event.target.value)}
+            placeholder="Search notes…"
+            className="min-w-0 flex-1 bg-transparent text-[12px] text-[var(--vk-text-normal)] outline-none placeholder:text-[var(--vk-text-muted)]"
+          />
+        </div>
+      </div>
+
+      {/* File tree */}
+      <div className="min-h-0 flex-1 overflow-auto py-2">
+        <NotesTree
+          nodes={filteredTree}
+          expandedFolders={folderPathsSet}
+          selectedPath={selectedPath}
+          onToggleFolder={onToggleFolder}
+          onSelectFile={onSelectFile}
+        />
+      </div>
+
+      {/* Tags pane */}
+      {tagEntries.length > 0 && (
+        <div className="border-t border-[var(--vk-border)]">
+          <button
+            type="button"
+            onClick={() => setTagsExpanded(!tagsExpanded)}
+            className="flex w-full items-center gap-1.5 px-3 py-2 text-left text-[11px] uppercase tracking-[0.08em] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)]"
+          >
+            {tagsExpanded ? (
+              <ChevronDown className="h-3 w-3 shrink-0" />
+            ) : (
+              <ChevronRight className="h-3 w-3 shrink-0" />
+            )}
+            Tags ({tagEntries.length})
+          </button>
+          {tagsExpanded && (
+            <div className="max-h-[160px] overflow-auto px-3 pb-2">
+              <div className="flex flex-wrap gap-1.5">
+                {tagEntries.map(([tag, files]) => (
+                  <button
+                    key={tag}
+                    type="button"
+                    onClick={() => onTagClick?.(tag)}
+                    className="inline-flex items-center gap-1 rounded-full border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-2 py-0.5 text-[11px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)]"
+                  >
+                    <span className="text-[#f6c56f]">#{tag}</span>
+                    <span className="text-[10px] opacity-60">{files.length}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/packages/web/src/components/notes/NotesToolbar.tsx
+++ b/packages/web/src/components/notes/NotesToolbar.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import {
+  ExternalLink,
+  Loader2,
+  Network,
+  RefreshCcw,
+  Save,
+  TriangleAlert,
+  CalendarDays,
+} from "lucide-react";
+import type { ViewMode } from "./types";
+
+interface NotesToolbarProps {
+  viewMode: ViewMode;
+  onViewModeChange: (mode: ViewMode) => void;
+  onSave: () => void;
+  onRefresh: () => void;
+  onOpenExternally: () => void;
+  onDailyNote: () => void;
+  onToggleGraph: () => void;
+  graphOpen: boolean;
+  saving: boolean;
+  dirty: boolean;
+  indexLoading: boolean;
+  opening: boolean;
+  selectedFile: { path: string; name: string } | null;
+  fileTruncated: boolean;
+  editorName?: string;
+  canSave?: boolean;
+}
+
+export function NotesToolbar({
+  viewMode,
+  onViewModeChange,
+  onSave,
+  onRefresh,
+  onOpenExternally,
+  onDailyNote,
+  onToggleGraph,
+  graphOpen,
+  saving,
+  dirty,
+  indexLoading,
+  opening,
+  selectedFile,
+  fileTruncated,
+  editorName = "editor",
+  canSave = true,
+}: NotesToolbarProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {/* View mode switcher */}
+      <div className="inline-flex rounded-[6px] border border-[var(--vk-border)] p-0.5 text-[12px]">
+        {(["split", "edit", "preview"] as ViewMode[]).map((mode) => (
+          <button
+            key={mode}
+            type="button"
+            onClick={() => onViewModeChange(mode)}
+            className={`rounded-[4px] px-3 py-1.5 ${
+              viewMode === mode
+                ? "bg-[var(--vk-bg-active)] text-[var(--vk-text-strong)]"
+                : "text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)]"
+            }`}
+          >
+            {mode === "split" ? "Split" : mode === "edit" ? "Edit" : "Preview"}
+          </button>
+        ))}
+      </div>
+
+      {/* Refresh */}
+      <button
+        type="button"
+        onClick={onRefresh}
+        disabled={indexLoading}
+        className="inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-60"
+      >
+        {indexLoading ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <RefreshCcw className="h-3.5 w-3.5" />
+        )}
+        Refresh
+      </button>
+
+      {/* Save */}
+      {canSave && (
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={!selectedFile || !dirty || saving || fileTruncated}
+          className="inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-60"
+        >
+          {saving ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Save className="h-3.5 w-3.5" />
+          )}
+          Save
+        </button>
+      )}
+
+      {/* Open in editor */}
+      <button
+        type="button"
+        onClick={onOpenExternally}
+        disabled={!selectedFile || opening}
+        className="inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-60"
+      >
+        {opening ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <ExternalLink className="h-3.5 w-3.5" />
+        )}
+        Open in {editorName}
+      </button>
+
+      {/* Today / Daily note */}
+      <button
+        type="button"
+        onClick={onDailyNote}
+        className="inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)]"
+      >
+        <CalendarDays className="h-3.5 w-3.5" />
+        Today
+      </button>
+
+      {/* Graph view toggle */}
+      <button
+        type="button"
+        onClick={onToggleGraph}
+        className={`inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border px-3 text-[12px] hover:bg-[var(--vk-bg-hover)] ${
+          graphOpen
+            ? "border-[var(--vk-accent)] bg-[rgba(139,92,246,0.12)] text-[var(--vk-accent)]"
+            : "border-[var(--vk-border)] text-[var(--vk-text-normal)]"
+        }`}
+      >
+        <Network className="h-3.5 w-3.5" />
+        Graph
+      </button>
+
+      {/* Unsaved changes indicator */}
+      {dirty && (
+        <span className="inline-flex items-center gap-1.5 text-[12px] text-[#f6c56f]">
+          <TriangleAlert className="h-3.5 w-3.5" />
+          Unsaved
+        </span>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/notes/ProjectNotesWorkspace.tsx
+++ b/packages/web/src/components/notes/ProjectNotesWorkspace.tsx
@@ -1,30 +1,43 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import {
   BookText,
-  Check,
-  ChevronDown,
-  ChevronRight,
-  ExternalLink,
-  FilePlus2,
-  FileText,
-  Folder,
-  FolderOpen,
   Loader2,
-  RefreshCcw,
-  Save,
-  Search,
-  Send,
-  Sparkles,
-  TriangleAlert,
 } from "lucide-react";
 
 import type { DashboardSession } from "@/lib/types";
 import { withBridgeQuery } from "@/lib/bridgeQuery";
 import { isProjectDispatcherSession } from "@/lib/sessionKinds";
+
+import type {
+  ViewMode,
+  NoteFile,
+  NotesIndexPayload,
+  NoteFilePayload,
+  SaveNotePayload,
+  TagMap,
+} from "./types";
+import {
+  buildNotesTree,
+  filterNotesTree,
+  collectFolderPaths,
+  normalizeNewNotePath,
+  buildNewNoteSeedContent,
+  resolveWikilinkTarget,
+  fuzzyMatch,
+} from "./utils";
+import { NotesSidebar } from "./NotesSidebar";
+import { NotesToolbar } from "./NotesToolbar";
+import { NotesEditor } from "./NotesEditor";
+import { NotesPreview } from "./NotesPreview";
+import { NotesBacklinks } from "./NotesBacklinks";
+import { QuickSwitcher } from "./QuickSwitcher";
+import { NotesGraph } from "./NotesGraph";
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
 
 interface ProjectNotesWorkspaceProps {
   projectId: string;
@@ -33,260 +46,9 @@ interface ProjectNotesWorkspaceProps {
   selectedSessionId?: string | null;
 }
 
-type ViewMode = "split" | "edit" | "preview";
-
-type NoteFile = {
-  path: string;
-  displayPath: string;
-  name: string;
-  source: string | null;
-  sizeBytes: number | null;
-  modifiedAt: string | null;
-  kind: string;
-};
-
-type NotesIndexPayload = {
-  editor: string;
-  notesRoot: string | null;
-  syncManagedByEditor: boolean;
-  writable: boolean;
-  files: NoteFile[];
-};
-
-type NoteFilePayload = {
-  path: string;
-  displayPath: string;
-  content: string;
-  size: number;
-  truncated: boolean;
-  modifiedAt: string | null;
-  writable: boolean;
-};
-
-type SaveNotePayload = {
-  ok: boolean;
-  path: string;
-  displayPath: string;
-  modifiedAt: string | null;
-  savedBytes: number;
-  created: boolean;
-};
-
-type NotesTreeNode = {
-  name: string;
-  path: string;
-  isDirectory: boolean;
-  file?: NoteFile;
-  children: NotesTreeNode[];
-};
-
-function buildNotesTree(files: NoteFile[]): NotesTreeNode[] {
-  const root: NotesTreeNode = {
-    name: "",
-    path: "",
-    isDirectory: true,
-    children: [],
-  };
-
-  for (const file of files) {
-    const normalizedDisplayPath = file.displayPath.replace(/^\/+/, "");
-    const parts = normalizedDisplayPath.split("/").filter(Boolean);
-    if (parts.length === 0) {
-      continue;
-    }
-
-    let current = root;
-    let currentPath = "";
-    for (let index = 0; index < parts.length; index += 1) {
-      const part = parts[index];
-      currentPath = currentPath ? `${currentPath}/${part}` : part;
-      const isLast = index === parts.length - 1;
-      let child = current.children.find((candidate) => candidate.name === part && candidate.isDirectory !== isLast);
-      if (!child) {
-        child = {
-          name: part,
-          path: isLast ? file.path : currentPath,
-          isDirectory: !isLast,
-          file: isLast ? file : undefined,
-          children: [],
-        };
-        current.children.push(child);
-      }
-      current = child;
-    }
-  }
-
-  const sortTree = (nodes: NotesTreeNode[]) => {
-    nodes.sort((left, right) => {
-      if (left.isDirectory !== right.isDirectory) {
-        return left.isDirectory ? -1 : 1;
-      }
-      return left.name.localeCompare(right.name, undefined, { sensitivity: "base" });
-    });
-    for (const node of nodes) {
-      if (node.children.length > 0) {
-        sortTree(node.children);
-      }
-    }
-  };
-
-  sortTree(root.children);
-  return root.children;
-}
-
-function filterNotesTree(nodes: NotesTreeNode[], query: string): NotesTreeNode[] {
-  const normalizedQuery = query.trim().toLowerCase();
-  if (!normalizedQuery) {
-    return nodes;
-  }
-
-  const filterNode = (node: NotesTreeNode): NotesTreeNode | null => {
-    const haystack = `${node.name} ${node.file?.displayPath ?? ""}`.toLowerCase();
-    const childMatches = node.children
-      .map((child) => filterNode(child))
-      .filter((child): child is NotesTreeNode => Boolean(child));
-    if (haystack.includes(normalizedQuery) || childMatches.length > 0) {
-      return {
-        ...node,
-        children: childMatches,
-      };
-    }
-    return null;
-  };
-
-  return nodes
-    .map((node) => filterNode(node))
-    .filter((node): node is NotesTreeNode => Boolean(node));
-}
-
-function collectFolderPaths(nodes: NotesTreeNode[]): string[] {
-  const paths: string[] = [];
-  const visit = (node: NotesTreeNode) => {
-    if (node.isDirectory) {
-      paths.push(node.path);
-      node.children.forEach(visit);
-    }
-  };
-  nodes.forEach(visit);
-  return paths;
-}
-
-function formatTimestamp(value: string | null | undefined): string {
-  if (!value) {
-    return "";
-  }
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return "";
-  }
-  return date.toLocaleString();
-}
-
-function formatBytes(value: number | null | undefined): string {
-  if (!value || value <= 0) {
-    return "";
-  }
-  if (value < 1024) return `${value} B`;
-  if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KB`;
-  return `${(value / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-function normalizeNewNotePath(value: string): string {
-  const normalized = value.trim().replace(/\\/g, "/").replace(/^\/+/, "");
-  if (!normalized) {
-    return "";
-  }
-  if (/\.(md|markdown|mdx|txt)$/i.test(normalized)) {
-    return normalized;
-  }
-  return `${normalized}.md`;
-}
-
-function buildNewNoteSeedContent(notePath: string): string {
-  const fileName = notePath.split("/").pop() ?? "Note";
-  const heading = fileName.replace(/\.(md|markdown|mdx|txt)$/i, "").replace(/[-_]+/g, " ").trim();
-  if (!heading) {
-    return "";
-  }
-  return `# ${heading.charAt(0).toUpperCase()}${heading.slice(1)}\n\n`;
-}
-
-function NotesTree({
-  nodes,
-  expandedFolders,
-  selectedPath,
-  onToggleFolder,
-  onSelectFile,
-  depth = 0,
-}: {
-  nodes: NotesTreeNode[];
-  expandedFolders: Set<string>;
-  selectedPath: string | null;
-  onToggleFolder: (path: string) => void;
-  onSelectFile: (path: string) => void;
-  depth?: number;
-}) {
-  return (
-    <>
-      {nodes.map((node) => {
-        const paddingLeft = 10 + depth * 14;
-        if (node.isDirectory) {
-          const expanded = expandedFolders.has(node.path);
-          return (
-            <div key={`${node.path}-${node.name}`}>
-              <button
-                type="button"
-                onClick={() => onToggleFolder(node.path)}
-                className="flex w-full items-center gap-1.5 py-1.5 text-left text-[12px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)]"
-                style={{ paddingLeft }}
-              >
-                {expanded ? (
-                  <ChevronDown className="h-3.5 w-3.5 shrink-0" />
-                ) : (
-                  <ChevronRight className="h-3.5 w-3.5 shrink-0" />
-                )}
-                {expanded ? (
-                  <FolderOpen className="h-3.5 w-3.5 shrink-0 text-[var(--vk-accent)]" />
-                ) : (
-                  <Folder className="h-3.5 w-3.5 shrink-0 text-[var(--vk-accent)]" />
-                )}
-                <span className="truncate">{node.name}</span>
-              </button>
-              {expanded ? (
-                <NotesTree
-                  nodes={node.children}
-                  expandedFolders={expandedFolders}
-                  selectedPath={selectedPath}
-                  onToggleFolder={onToggleFolder}
-                  onSelectFile={onSelectFile}
-                  depth={depth + 1}
-                />
-              ) : null}
-            </div>
-          );
-        }
-
-        const selected = selectedPath === node.path;
-        return (
-          <button
-            key={node.path}
-            type="button"
-            onClick={() => onSelectFile(node.path)}
-            className={`flex w-full items-center gap-1.5 py-1.5 pr-2 text-left text-[12px] ${
-              selected
-                ? "bg-[var(--vk-bg-active)] text-[var(--vk-text-strong)]"
-                : "text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)]"
-            }`}
-            style={{ paddingLeft: paddingLeft + 18 }}
-          >
-            <FileText className="h-3.5 w-3.5 shrink-0 text-[var(--vk-text-muted)]" />
-            <span className="truncate">{node.name}</span>
-          </button>
-        );
-      })}
-    </>
-  );
-}
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
 
 export function ProjectNotesWorkspace({
   projectId,
@@ -294,20 +56,32 @@ export function ProjectNotesWorkspace({
   sessions,
   selectedSessionId = null,
 }: ProjectNotesWorkspaceProps) {
+  // -- Index state ---------------------------------------------------------
   const [indexPayload, setIndexPayload] = useState<NotesIndexPayload | null>(null);
   const [indexLoading, setIndexLoading] = useState(true);
   const [indexError, setIndexError] = useState<string | null>(null);
   const [refreshNonce, setRefreshNonce] = useState(0);
+
+  // -- Selection state -----------------------------------------------------
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [expandedFolders, setExpandedFolders] = useState<string[]>([]);
   const [search, setSearch] = useState("");
+
+  // -- View state ----------------------------------------------------------
   const [viewMode, setViewMode] = useState<ViewMode>("split");
+  const [graphOpen, setGraphOpen] = useState(false);
+  const [quickSwitcherOpen, setQuickSwitcherOpen] = useState(false);
+  const [activeTag, setActiveTag] = useState<string | null>(null);
+
+  // -- File content state --------------------------------------------------
   const [draftContent, setDraftContent] = useState("");
   const [savedContent, setSavedContent] = useState("");
   const [fileModifiedAt, setFileModifiedAt] = useState<string | null>(null);
   const [fileTruncated, setFileTruncated] = useState(false);
   const [fileLoading, setFileLoading] = useState(false);
   const [fileError, setFileError] = useState<string | null>(null);
+
+  // -- Action state --------------------------------------------------------
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
@@ -321,25 +95,48 @@ export function ProjectNotesWorkspace({
   const [sendingDispatcher, setSendingDispatcher] = useState(false);
   const [sendingSession, setSendingSession] = useState(false);
   const [targetSessionId, setTargetSessionId] = useState<string>(selectedSessionId ?? "");
-  const latestLoadId = useRef(0);
 
+  // -- Refs ----------------------------------------------------------------
+  const latestLoadId = useRef(0);
+  const recentPaths = useRef<string[]>([]);
+
+  // -- Derived -------------------------------------------------------------
   const noteFiles = indexPayload?.files ?? [];
+  const tags: TagMap = indexPayload?.tags ?? {};
   const selectedFile = useMemo(
-    () => noteFiles.find((file) => file.path === selectedPath) ?? null,
+    () => noteFiles.find((f) => f.path === selectedPath) ?? null,
     [noteFiles, selectedPath],
   );
   const dirty = draftContent !== savedContent;
   const readOnlyNote = fileTruncated || indexPayload?.writable === false;
   const supportedLocalNotes = indexPayload?.writable !== false;
+
   const sessionTargets = useMemo(
-    () => sessions.filter((session) => !isProjectDispatcherSession(session)),
+    () => sessions.filter((s) => !isProjectDispatcherSession(s)),
     [sessions],
   );
 
-  useEffect(() => {
-    if (!selectedSessionId) {
-      return;
+  const filteredTree = useMemo(() => {
+    let files = noteFiles;
+    // Filter by active tag
+    if (activeTag && tags[activeTag]) {
+      const taggedPaths = new Set(tags[activeTag]);
+      files = files.filter((f) => taggedPaths.has(f.path));
     }
+    // Filter by search
+    if (search.trim().length > 0) {
+      const q = search.trim().toLowerCase();
+      files = files.filter((f) => {
+        const haystack = `${f.displayPath} ${f.name} ${f.source ?? ""}`.toLowerCase();
+        return haystack.includes(q);
+      });
+    }
+    return filterNotesTree(buildNotesTree(files), search);
+  }, [noteFiles, search, activeTag, tags]);
+
+  // -- Sync selectedSessionId → targetSessionId ----------------------------
+  useEffect(() => {
+    if (!selectedSessionId) return;
     setTargetSessionId(selectedSessionId);
   }, [selectedSessionId]);
 
@@ -348,21 +145,25 @@ export function ProjectNotesWorkspace({
       setTargetSessionId("");
       return;
     }
-    if (!targetSessionId || !sessionTargets.some((session) => session.id === targetSessionId)) {
-      setTargetSessionId(selectedSessionId && sessionTargets.some((session) => session.id === selectedSessionId)
-        ? selectedSessionId
-        : sessionTargets[0]?.id ?? "");
+    if (!targetSessionId || !sessionTargets.some((s) => s.id === targetSessionId)) {
+      setTargetSessionId(
+        selectedSessionId && sessionTargets.some((s) => s.id === selectedSessionId)
+          ? selectedSessionId
+          : sessionTargets[0]?.id ?? "",
+      );
     }
   }, [selectedSessionId, sessionTargets, targetSessionId]);
 
+  // -- Index loading -------------------------------------------------------
   const refreshIndex = useCallback(() => {
-    setRefreshNonce((current) => current + 1);
+    setRefreshNonce((c) => c + 1);
   }, []);
 
   useEffect(() => {
     let cancelled = false;
     setIndexLoading(true);
     setIndexError(null);
+
     const loadIndex = async () => {
       try {
         const response = await fetch(
@@ -374,54 +175,45 @@ export function ProjectNotesWorkspace({
           | { error?: string }
           | null;
         if (!response.ok) {
-          throw new Error(payload && "error" in payload ? payload.error ?? "Failed to load notes" : `Failed to load notes (${response.status})`);
+          throw new Error(
+            payload && "error" in payload
+              ? payload.error ?? "Failed to load notes"
+              : `Failed to load notes (${response.status})`,
+          );
         }
         if (cancelled) return;
         setIndexPayload((payload as NotesIndexPayload) ?? null);
-      } catch (error) {
+      } catch (err) {
         if (cancelled) return;
         setIndexPayload(null);
-        setIndexError(error instanceof Error ? error.message : "Failed to load notes workspace");
+        setIndexError(err instanceof Error ? err.message : "Failed to load notes workspace");
       } finally {
-        if (!cancelled) {
-          setIndexLoading(false);
-        }
+        if (!cancelled) setIndexLoading(false);
       }
     };
 
     void loadIndex();
-    return () => {
-      cancelled = true;
-    };
+    return () => { cancelled = true; };
   }, [bridgeId, projectId, refreshNonce]);
 
+  // -- Auto-select first file if selection is invalid ----------------------
   useEffect(() => {
     if (noteFiles.length === 0) {
       setSelectedPath(null);
       return;
     }
-    if (!selectedPath || !noteFiles.some((file) => file.path === selectedPath)) {
+    if (!selectedPath || !noteFiles.some((f) => f.path === selectedPath)) {
       setSelectedPath(noteFiles[0]?.path ?? null);
     }
   }, [noteFiles, selectedPath]);
 
-  const filteredTree = useMemo(() => {
-    const matchingFiles = search.trim().length === 0
-      ? noteFiles
-      : noteFiles.filter((file) => {
-          const haystack = `${file.displayPath} ${file.name} ${file.source ?? ""}`.toLowerCase();
-          return haystack.includes(search.trim().toLowerCase());
-        });
-    return filterNotesTree(buildNotesTree(matchingFiles), search);
-  }, [noteFiles, search]);
-
+  // -- Expand all folders when searching -----------------------------------
   useEffect(() => {
-    if (search.trim().length === 0) {
-      return;
-    }
+    if (search.trim().length === 0) return;
     setExpandedFolders(collectFolderPaths(filteredTree));
   }, [filteredTree, search]);
 
+  // -- Load selected file --------------------------------------------------
   useEffect(() => {
     if (!selectedPath) {
       setDraftContent("");
@@ -442,19 +234,21 @@ export function ProjectNotesWorkspace({
 
     const loadFile = async () => {
       try {
-        const params = new URLSearchParams({
-          projectId,
-          path: selectedPath,
-        });
-        const response = await fetch(withBridgeQuery(`/api/project-notes/file?${params.toString()}`, bridgeId), {
-          cache: "no-store",
-        });
+        const params = new URLSearchParams({ projectId, path: selectedPath });
+        const response = await fetch(
+          withBridgeQuery(`/api/project-notes/file?${params.toString()}`, bridgeId),
+          { cache: "no-store" },
+        );
         const payload = (await response.json().catch(() => null)) as
           | NoteFilePayload
           | { error?: string }
           | null;
         if (!response.ok) {
-          throw new Error(payload && "error" in payload ? payload.error ?? "Failed to load note" : `Failed to load note (${response.status})`);
+          throw new Error(
+            payload && "error" in payload
+              ? payload.error ?? "Failed to load note"
+              : `Failed to load note (${response.status})`,
+          );
         }
         if (cancelled || latestLoadId.current !== loadId) return;
         const note = payload as NoteFilePayload;
@@ -462,30 +256,25 @@ export function ProjectNotesWorkspace({
         setSavedContent(note.content ?? "");
         setFileModifiedAt(note.modifiedAt ?? null);
         setFileTruncated(note.truncated === true);
-      } catch (error) {
+      } catch (err) {
         if (cancelled || latestLoadId.current !== loadId) return;
         setDraftContent("");
         setSavedContent("");
         setFileModifiedAt(null);
         setFileTruncated(false);
-        setFileError(error instanceof Error ? error.message : "Failed to load note");
+        setFileError(err instanceof Error ? err.message : "Failed to load note");
       } finally {
-        if (!cancelled && latestLoadId.current === loadId) {
-          setFileLoading(false);
-        }
+        if (!cancelled && latestLoadId.current === loadId) setFileLoading(false);
       }
     };
 
     void loadFile();
-    return () => {
-      cancelled = true;
-    };
+    return () => { cancelled = true; };
   }, [bridgeId, projectId, refreshNonce, selectedPath]);
 
+  // -- Save ----------------------------------------------------------------
   const saveCurrentNote = useCallback(async () => {
-    if (!selectedFile) {
-      return null;
-    }
+    if (!selectedFile) return null;
     if (fileTruncated) {
       setSaveError("This note was truncated for safety. Open it externally to edit the full file.");
       return null;
@@ -509,31 +298,32 @@ export function ProjectNotesWorkspace({
         | { error?: string }
         | null;
       if (!response.ok) {
-        throw new Error(payload && "error" in payload ? payload.error ?? "Failed to save note" : `Failed to save note (${response.status})`);
+        throw new Error(
+          payload && "error" in payload
+            ? payload.error ?? "Failed to save note"
+            : `Failed to save note (${response.status})`,
+        );
       }
-      const savePayload = payload as SaveNotePayload;
+      const saved = payload as SaveNotePayload;
       setSavedContent(draftContent);
-      setFileModifiedAt(savePayload.modifiedAt ?? null);
-      setSaveSuccess(savePayload.created ? "Note created." : "Note saved.");
+      setFileModifiedAt(saved.modifiedAt ?? null);
+      setSaveSuccess(saved.created ? "Note created." : "Note saved.");
       refreshIndex();
-      return savePayload;
-    } catch (error) {
-      setSaveError(error instanceof Error ? error.message : "Failed to save note");
+      return saved;
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Failed to save note");
       return null;
     } finally {
       setSaving(false);
     }
   }, [bridgeId, draftContent, fileModifiedAt, fileTruncated, projectId, refreshIndex, selectedFile]);
 
+  // -- Open externally -----------------------------------------------------
   const handleOpenExternally = useCallback(async () => {
-    if (!selectedFile) {
-      return;
-    }
+    if (!selectedFile) return;
     if (dirty) {
       const saved = await saveCurrentNote();
-      if (!saved) {
-        return;
-      }
+      if (!saved) return;
     }
     setOpening(true);
     setOpenError(null);
@@ -541,27 +331,23 @@ export function ProjectNotesWorkspace({
       const response = await fetch(withBridgeQuery("/api/project-notes/open", bridgeId), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          projectId,
-          path: selectedFile.path,
-        }),
+        body: JSON.stringify({ projectId, path: selectedFile.path }),
       });
       const payload = (await response.json().catch(() => null)) as { error?: string } | null;
       if (!response.ok) {
         throw new Error(payload?.error ?? `Failed to open note (${response.status})`);
       }
-    } catch (error) {
-      setOpenError(error instanceof Error ? error.message : "Failed to open note");
+    } catch (err) {
+      setOpenError(err instanceof Error ? err.message : "Failed to open note");
     } finally {
       setOpening(false);
     }
   }, [bridgeId, dirty, projectId, saveCurrentNote, selectedFile]);
 
+  // -- Create note ---------------------------------------------------------
   const handleCreateNote = useCallback(async () => {
     const normalizedPath = normalizeNewNotePath(newNotePath);
-    if (!normalizedPath || creatingNote) {
-      return;
-    }
+    if (!normalizedPath || creatingNote) return;
     setCreatingNote(true);
     setSaveError(null);
     setSaveSuccess(null);
@@ -580,29 +366,57 @@ export function ProjectNotesWorkspace({
         | { error?: string }
         | null;
       if (!response.ok) {
-        throw new Error(payload && "error" in payload ? payload.error ?? "Failed to create note" : `Failed to create note (${response.status})`);
+        throw new Error(
+          payload && "error" in payload
+            ? payload.error ?? "Failed to create note"
+            : `Failed to create note (${response.status})`,
+        );
       }
       const created = payload as SaveNotePayload;
       setNewNotePath("");
       setSelectedPath(created.path);
       setSaveSuccess("Note created.");
       refreshIndex();
-    } catch (error) {
-      setSaveError(error instanceof Error ? error.message : "Failed to create note");
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Failed to create note");
     } finally {
       setCreatingNote(false);
     }
   }, [bridgeId, creatingNote, newNotePath, projectId, refreshIndex]);
 
-  const sendToDispatcher = useCallback(async () => {
-    if ((!selectedFile && composerMessage.trim().length === 0) || sendingDispatcher) {
-      return;
+  // -- Daily note ----------------------------------------------------------
+  const handleDailyNote = useCallback(async () => {
+    try {
+      const response = await fetch(withBridgeQuery("/api/project-notes/daily", bridgeId), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ projectId }),
+      });
+      const payload = (await response.json().catch(() => null)) as
+        | { path: string; displayPath: string; created: boolean; error?: string }
+        | null;
+      if (!response.ok || (payload && "error" in payload)) {
+        throw new Error(payload?.error ?? `Failed to create daily note (${response.status})`);
+      }
+      if (payload?.path) {
+        setSelectedPath(payload.path);
+        // Expand daily folder
+        setExpandedFolders((prev) =>
+          prev.includes("daily") ? prev : [...prev, "daily"],
+        );
+        refreshIndex();
+      }
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Failed to create daily note");
     }
+  }, [bridgeId, projectId, refreshIndex]);
+
+  // -- Send to dispatcher --------------------------------------------------
+  const sendToDispatcher = useCallback(async () => {
+    if ((!selectedFile && composerMessage.trim().length === 0) || sendingDispatcher) return;
     if (dirty) {
       const saved = await saveCurrentNote();
-      if (!saved) {
-        return;
-      }
+      if (!saved) return;
     }
     setSendingDispatcher(true);
     setSendError(null);
@@ -625,22 +439,19 @@ export function ProjectNotesWorkspace({
       }
       setSendSuccess(selectedFile ? "Sent note to dispatcher." : "Sent message to dispatcher.");
       setComposerMessage("");
-    } catch (error) {
-      setSendError(error instanceof Error ? error.message : "Failed to send note to dispatcher");
+    } catch (err) {
+      setSendError(err instanceof Error ? err.message : "Failed to send note to dispatcher");
     } finally {
       setSendingDispatcher(false);
     }
   }, [bridgeId, composerMessage, dirty, projectId, saveCurrentNote, selectedFile, sendingDispatcher]);
 
+  // -- Send to session -----------------------------------------------------
   const sendToSession = useCallback(async () => {
-    if ((!selectedFile && composerMessage.trim().length === 0) || !targetSessionId || sendingSession) {
-      return;
-    }
+    if ((!selectedFile && composerMessage.trim().length === 0) || !targetSessionId || sendingSession) return;
     if (dirty) {
       const saved = await saveCurrentNote();
-      if (!saved) {
-        return;
-      }
+      if (!saved) return;
     }
     setSendingSession(true);
     setSendError(null);
@@ -661,132 +472,130 @@ export function ProjectNotesWorkspace({
       if (!response.ok) {
         throw new Error(payload?.error ?? `Failed to send note to session (${response.status})`);
       }
-      const selectedSession = sessionTargets.find((session) => session.id === targetSessionId);
-      setSendSuccess(selectedSession
-        ? `Sent note to ${selectedSession.branch || selectedSession.id.slice(0, 8)}.`
-        : "Sent note to session.");
+      const targetSession = sessionTargets.find((s) => s.id === targetSessionId);
+      setSendSuccess(
+        targetSession
+          ? `Sent note to ${targetSession.branch || targetSession.id.slice(0, 8)}.`
+          : "Sent note to session.",
+      );
       setComposerMessage("");
-    } catch (error) {
-      setSendError(error instanceof Error ? error.message : "Failed to send note to session");
+    } catch (err) {
+      setSendError(err instanceof Error ? err.message : "Failed to send note to session");
     } finally {
       setSendingSession(false);
     }
   }, [bridgeId, composerMessage, dirty, saveCurrentNote, selectedFile, sendingSession, sessionTargets, targetSessionId]);
 
+  // -- Folder toggle -------------------------------------------------------
   const toggleFolder = useCallback((path: string) => {
     setExpandedFolders((current) =>
-      current.includes(path)
-        ? current.filter((entry) => entry !== path)
-        : [...current, path],
+      current.includes(path) ? current.filter((e) => e !== path) : [...current, path],
     );
   }, []);
 
+  // -- File select ---------------------------------------------------------
   const selectFile = useCallback((path: string) => {
-    if (path === selectedPath) {
-      return;
-    }
+    if (path === selectedPath) return;
     if (dirty && typeof window !== "undefined") {
       const discard = window.confirm("Discard unsaved note changes and switch notes?");
-      if (!discard) {
-        return;
-      }
+      if (!discard) return;
     }
     setSelectedPath(path);
+    // Track recent files
+    recentPaths.current = [path, ...recentPaths.current.filter((p) => p !== path)].slice(0, 20);
   }, [dirty, selectedPath]);
 
+  // -- Wikilink navigation -------------------------------------------------
+  const handleWikilinkClick = useCallback((target: string) => {
+    const resolved = resolveWikilinkTarget(target, noteFiles);
+    if (resolved) {
+      selectFile(resolved);
+    } else {
+      // Create the note
+      const normalizedPath = target.includes("/")
+        ? `${target}.md`
+        : `${target}.md`;
+      setNewNotePath(normalizedPath);
+    }
+  }, [noteFiles, selectFile]);
+
+  // -- Tag click -----------------------------------------------------------
+  const handleTagClick = useCallback((tag: string) => {
+    setActiveTag((prev) => (prev === tag ? null : tag));
+  }, []);
+
+  // -- Keyboard shortcuts --------------------------------------------------
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        setQuickSwitcherOpen(true);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  // -- Quick switcher select -----------------------------------------------
+  const handleQuickSwitchSelect = useCallback((path: string) => {
+    setQuickSwitcherOpen(false);
+    selectFile(path);
+  }, [selectFile]);
+
+  // -- Error/success aggregation -------------------------------------------
+  const anyError = saveError || openError || sendError || indexError || fileError;
+  const anySuccess = saveSuccess || sendSuccess;
+
+  // -- Label ---------------------------------------------------------------
   const rootLabel = indexPayload?.notesRoot
     ? indexPayload.notesRoot
     : indexPayload?.editor?.trim().toLowerCase() === "notion"
       ? "Notion"
       : "Project markdown files";
 
+  // -- Render --------------------------------------------------------------
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-[var(--vk-bg-main)]">
-      <div className="border-b border-[var(--vk-border)] bg-[var(--vk-bg-panel)]/70 px-3 py-3 sm:px-4">
-        <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
+      {/* Toolbar */}
+      <NotesToolbar
+        viewMode={viewMode}
+        onViewModeChange={setViewMode}
+        onSave={() => void saveCurrentNote()}
+        onRefresh={refreshIndex}
+        onOpenExternally={() => void handleOpenExternally()}
+        onDailyNote={() => void handleDailyNote()}
+        onToggleGraph={() => setGraphOpen((v) => !v)}
+        graphOpen={graphOpen}
+        saving={saving}
+        dirty={dirty}
+        indexLoading={indexLoading}
+        opening={opening}
+        selectedFile={selectedFile}
+        fileTruncated={fileTruncated}
+        editorName={indexPayload?.editor}
+        canSave={supportedLocalNotes}
+      />
+
+      {/* Header info bar */}
+      <div className="border-b border-[var(--vk-border)] bg-[var(--vk-bg-panel)]/70 px-3 py-2 sm:px-4">
+        <div className="flex flex-wrap items-center justify-between gap-2">
           <div className="min-w-0">
-            <div className="flex flex-wrap items-center gap-2">
-              <p className="text-[11px] uppercase tracking-[0.12em] text-[var(--vk-text-muted)]">
-                Notes Workspace
-              </p>
-              {indexPayload?.syncManagedByEditor ? (
-                <span className="inline-flex items-center gap-1 rounded-full border border-[rgba(255,255,255,0.08)] bg-[rgba(139,92,246,0.12)] px-2 py-0.5 text-[11px] text-[#cdb4ff]">
-                  <Sparkles className="h-3 w-3" />
-                  Synced by Obsidian
-                </span>
-              ) : null}
-            </div>
-            <p className="mt-1 truncate text-[14px] text-[var(--vk-text-strong)]">
+            <p className="truncate text-[14px] text-[var(--vk-text-strong)]">
               {projectId} · {indexPayload?.editor || "markdown"}
             </p>
-            <p className="mt-1 truncate text-[12px] text-[var(--vk-text-muted)]">
+            <p className="truncate text-[12px] text-[var(--vk-text-muted)]">
               {rootLabel}
+              {activeTag ? ` · Filtered by #${activeTag}` : ""}
             </p>
           </div>
 
-          <div className="flex flex-wrap items-center gap-2">
-            <div className="inline-flex rounded-[6px] border border-[var(--vk-border)] p-0.5 text-[12px]">
-              {(["split", "edit", "preview"] as ViewMode[]).map((mode) => (
-                <button
-                  key={mode}
-                  type="button"
-                  onClick={() => setViewMode(mode)}
-                  className={`rounded-[4px] px-3 py-1.5 ${
-                    viewMode === mode
-                      ? "bg-[var(--vk-bg-active)] text-[var(--vk-text-strong)]"
-                      : "text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)]"
-                  }`}
-                >
-                  {mode === "split" ? "Split" : mode === "edit" ? "Edit" : "Preview"}
-                </button>
-              ))}
-            </div>
-            <button
-              type="button"
-              onClick={refreshIndex}
-              disabled={indexLoading}
-              className="inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-60"
-            >
-              {indexLoading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCcw className="h-3.5 w-3.5" />}
-              Refresh
-            </button>
-            <button
-              type="button"
-              onClick={() => void saveCurrentNote()}
-              disabled={!selectedFile || !dirty || saving || fileTruncated}
-              className="inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-60"
-            >
-              {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
-              Save
-            </button>
-            <button
-              type="button"
-              onClick={() => void handleOpenExternally()}
-              disabled={!selectedFile || opening}
-              className="inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-60"
-            >
-              {opening ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <ExternalLink className="h-3.5 w-3.5" />}
-              Open in {indexPayload?.editor || "editor"}
-            </button>
-          </div>
-        </div>
-
-        <div className="mt-3 flex flex-col gap-2 xl:flex-row xl:items-center xl:justify-between">
-          <div className="flex min-w-0 flex-1 items-center gap-2 rounded-[8px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-3 py-2">
-            <Search className="h-3.5 w-3.5 shrink-0 text-[var(--vk-text-muted)]" />
-            <input
-              value={search}
-              onChange={(event) => setSearch(event.target.value)}
-              placeholder="Search notes"
-              className="min-w-0 flex-1 bg-transparent text-[13px] text-[var(--vk-text-normal)] outline-none placeholder:text-[var(--vk-text-muted)]"
-            />
-          </div>
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
             <input
               value={newNotePath}
-              onChange={(event) => setNewNotePath(event.target.value)}
-              placeholder="New note path, example: architecture/overview.md"
-              className="min-h-[34px] min-w-0 rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-3 text-[12px] text-[var(--vk-text-normal)] outline-none placeholder:text-[var(--vk-text-muted)] sm:min-w-[280px]"
+              onChange={(e) => setNewNotePath(e.target.value)}
+              placeholder="New note path, e.g. architecture/overview.md"
+              className="min-h-[34px] min-w-0 rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-3 text-[12px] text-[var(--vk-text-normal)] outline-none placeholder:text-[var(--vk-text-muted)] sm:min-w-[260px]"
+              onKeyDown={(e) => { if (e.key === "Enter") void handleCreateNote(); }}
             />
             <button
               type="button"
@@ -794,36 +603,36 @@ export function ProjectNotesWorkspace({
               disabled={creatingNote || newNotePath.trim().length === 0 || !supportedLocalNotes}
               className="inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-60"
             >
-              {creatingNote ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <FilePlus2 className="h-3.5 w-3.5" />}
+              {creatingNote ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <BookText className="h-3.5 w-3.5" />}
               New note
             </button>
           </div>
         </div>
 
-        {saveError || openError || sendError || indexError || fileError ? (
-          <div className="mt-3 rounded-[8px] border border-[rgba(255,143,122,0.28)] bg-[rgba(255,143,122,0.08)] px-3 py-2 text-[12px] text-[var(--vk-red)]">
-            {saveError || openError || sendError || indexError || fileError}
+        {/* Error/success banners */}
+        {anyError ? (
+          <div className="mt-2 rounded-[8px] border border-[rgba(255,143,122,0.28)] bg-[rgba(255,143,122,0.08)] px-3 py-2 text-[12px] text-[var(--vk-red)]">
+            {anyError}
           </div>
         ) : null}
-        {saveSuccess || sendSuccess ? (
-          <div className="mt-3 rounded-[8px] border border-[rgba(24,197,143,0.28)] bg-[rgba(24,197,143,0.08)] px-3 py-2 text-[12px] text-[var(--vk-green)]">
-            {saveSuccess || sendSuccess}
+        {anySuccess ? (
+          <div className="mt-2 rounded-[8px] border border-[rgba(24,197,143,0.28)] bg-[rgba(24,197,143,0.08)] px-3 py-2 text-[12px] text-[var(--vk-green)]">
+            {anySuccess}
           </div>
         ) : null}
         {dirty ? (
-          <div className="mt-3 flex items-center gap-1.5 text-[12px] text-[#f6c56f]">
-            <TriangleAlert className="h-3.5 w-3.5" />
-            Unsaved changes
+          <div className="mt-2 flex items-center gap-1.5 text-[12px] text-[#f6c56f]">
+            ● Unsaved changes
           </div>
         ) : null}
         {fileTruncated ? (
-          <div className="mt-2 flex items-center gap-1.5 text-[12px] text-[#f6c56f]">
-            <TriangleAlert className="h-3.5 w-3.5" />
-            This note is too large to edit safely in Conductor. The preview is read-only.
+          <div className="mt-1 flex items-center gap-1.5 text-[12px] text-[#f6c56f]">
+            This note is too large to edit safely. The preview is read-only.
           </div>
         ) : null}
       </div>
 
+      {/* Main content area */}
       {!supportedLocalNotes ? (
         <div className="flex min-h-0 flex-1 items-center justify-center px-4">
           <div className="w-full max-w-xl rounded-[12px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] px-6 py-8 text-center shadow-[0_20px_48px_rgba(0,0,0,0.18)]">
@@ -853,29 +662,37 @@ export function ProjectNotesWorkspace({
               No markdown notes found yet
             </h2>
             <p className="mt-2 text-[14px] leading-6 text-[var(--vk-text-muted)]">
-              Point Conductor at your notes root in Preferences, or create a new note here. If this is an Obsidian vault and Obsidian Sync is enabled there, saved changes will sync through Obsidian automatically.
+              Point Conductor at your notes root in Preferences, or create a new note above.
             </p>
           </div>
         </div>
+      ) : graphOpen ? (
+        /* Graph View */
+        <NotesGraph
+          projectId={projectId}
+          bridgeId={bridgeId}
+          onNavigate={selectFile}
+        />
       ) : (
+        /* Normal view: sidebar + editor/preview */
         <div className="min-h-0 flex-1 overflow-hidden xl:grid xl:grid-cols-[280px_minmax(0,1fr)]">
-          <aside className="flex min-h-0 flex-col border-r border-[var(--vk-border)] bg-[var(--vk-bg-panel)]/35">
-            <div className="flex items-center justify-between border-b border-[var(--vk-border)] px-3 py-2 text-[12px] text-[var(--vk-text-muted)]">
-              <span>{noteFiles.length} note{noteFiles.length === 1 ? "" : "s"}</span>
-              <span>{search.trim().length > 0 ? "Filtered" : (indexPayload?.editor || "notes")}</span>
-            </div>
-            <div className="min-h-0 flex-1 overflow-auto py-2">
-              <NotesTree
-                nodes={filteredTree}
-                expandedFolders={new Set(expandedFolders)}
-                selectedPath={selectedPath}
-                onToggleFolder={toggleFolder}
-                onSelectFile={selectFile}
-              />
-            </div>
-          </aside>
+          {/* Sidebar */}
+          <NotesSidebar
+            noteFiles={noteFiles}
+            selectedPath={selectedPath}
+            expandedFolders={expandedFolders}
+            onToggleFolder={toggleFolder}
+            onSelectFile={selectFile}
+            search={search}
+            onSearchChange={setSearch}
+            editorLabel={indexPayload?.editor}
+            tags={tags}
+            onTagClick={handleTagClick}
+          />
 
+          {/* Main panel */}
           <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+            {/* File info + send-to bar */}
             <div className="border-b border-[var(--vk-border)] bg-[var(--vk-bg-panel)]/45 px-3 py-2">
               <div className="flex flex-col gap-2 xl:flex-row xl:items-start xl:justify-between">
                 <div className="min-w-0">
@@ -885,32 +702,33 @@ export function ProjectNotesWorkspace({
                   {selectedFile ? (
                     <p className="mt-1 text-[12px] text-[var(--vk-text-muted)]">
                       {selectedFile.source || "notes"}
-                      {selectedFile.modifiedAt ? ` · ${formatTimestamp(selectedFile.modifiedAt)}` : ""}
-                      {selectedFile.sizeBytes ? ` · ${formatBytes(selectedFile.sizeBytes)}` : ""}
+                      {selectedFile.modifiedAt ? ` · ${new Date(selectedFile.modifiedAt).toLocaleString()}` : ""}
+                      {selectedFile.sizeBytes ? ` · ${(selectedFile.sizeBytes / 1024).toFixed(1)} KB` : ""}
                     </p>
                   ) : null}
                 </div>
 
+                {/* Send-to controls */}
                 <div className="grid gap-2 xl:min-w-[420px]">
                   <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                     <input
                       value={composerMessage}
-                      onChange={(event) => setComposerMessage(event.target.value)}
+                      onChange={(e) => setComposerMessage(e.target.value)}
                       placeholder="Optional message to send with this note"
                       className="min-h-[34px] min-w-0 flex-1 rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-3 text-[12px] text-[var(--vk-text-normal)] outline-none placeholder:text-[var(--vk-text-muted)]"
                     />
                     <select
                       value={targetSessionId}
-                      onChange={(event) => setTargetSessionId(event.target.value)}
+                      onChange={(e) => setTargetSessionId(e.target.value)}
                       className="min-h-[34px] rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-3 text-[12px] text-[var(--vk-text-normal)] outline-none"
                       disabled={sessionTargets.length === 0}
                     >
                       {sessionTargets.length === 0 ? (
                         <option value="">No active sessions</option>
                       ) : null}
-                      {sessionTargets.map((session) => (
-                        <option key={session.id} value={session.id}>
-                          {(session.branch || session.id.slice(0, 8)).trim()} · {session.status}
+                      {sessionTargets.map((s) => (
+                        <option key={s.id} value={s.id}>
+                          {(s.branch || s.id.slice(0, 8)).trim()} · {s.status}
                         </option>
                       ))}
                     </select>
@@ -922,7 +740,7 @@ export function ProjectNotesWorkspace({
                       disabled={sendingDispatcher || (!selectedFile && composerMessage.trim().length === 0)}
                       className="inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-60"
                     >
-                      {sendingDispatcher ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Sparkles className="h-3.5 w-3.5" />}
+                      {sendingDispatcher ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "✦"}
                       Send to dispatcher
                     </button>
                     <button
@@ -931,19 +749,15 @@ export function ProjectNotesWorkspace({
                       disabled={sendingSession || !targetSessionId || (!selectedFile && composerMessage.trim().length === 0)}
                       className="inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-60"
                     >
-                      {sendingSession ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Send className="h-3.5 w-3.5" />}
+                      {sendingSession ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "→"}
                       Send to session
                     </button>
-                    {selectedFile ? (
-                      <span className="rounded-full border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-2.5 py-1 text-[11px] text-[var(--vk-text-muted)]">
-                        Attachment · {selectedFile.name}
-                      </span>
-                    ) : null}
                   </div>
                 </div>
               </div>
             </div>
 
+            {/* Editor / Preview area */}
             <div className={`grid min-h-0 flex-1 ${viewMode === "split" ? "xl:grid-cols-2" : "grid-cols-1"}`}>
               {viewMode !== "preview" ? (
                 <div className={`min-h-0 overflow-hidden ${viewMode === "split" ? "border-b border-[var(--vk-border)] xl:border-b-0 xl:border-r" : ""}`}>
@@ -953,12 +767,14 @@ export function ProjectNotesWorkspace({
                       Loading note…
                     </div>
                   ) : (
-                    <textarea
+                    <NotesEditor
                       value={draftContent}
-                      onChange={(event) => setDraftContent(event.target.value)}
+                      onChange={setDraftContent}
                       readOnly={readOnlyNote}
                       placeholder="Select a note to start editing"
-                      className="h-full min-h-0 w-full resize-none bg-[var(--vk-bg-main)] px-4 py-4 font-mono text-[13px] leading-6 text-[var(--vk-text-normal)] outline-none placeholder:text-[var(--vk-text-muted)]"
+                      onWikilinkClick={handleWikilinkClick}
+                      onSave={() => void saveCurrentNote()}
+                      onQuickSwitch={() => setQuickSwitcherOpen(true)}
                     />
                   )}
                 </div>
@@ -966,23 +782,34 @@ export function ProjectNotesWorkspace({
 
               {viewMode !== "edit" ? (
                 <div className="min-h-0 overflow-auto bg-[var(--vk-bg-panel)]/25 px-4 py-4">
-                  {draftContent.trim().length === 0 ? (
-                    <div className="flex h-full min-h-[240px] items-center justify-center text-center text-[13px] text-[var(--vk-text-muted)]">
-                      Markdown preview will appear here once the note has content.
-                    </div>
-                  ) : (
-                    <article className="prose prose-invert max-w-none text-[14px] leading-7 text-[var(--vk-text-normal)] prose-headings:text-[var(--vk-text-strong)] prose-strong:text-[var(--vk-text-strong)] prose-code:text-[var(--vk-accent)] prose-pre:bg-[var(--vk-bg-main)] prose-blockquote:border-l-[var(--vk-accent)] prose-blockquote:text-[var(--vk-text-muted)]">
-                      <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                        {draftContent}
-                      </ReactMarkdown>
-                    </article>
-                  )}
+                  <NotesPreview
+                    content={draftContent}
+                    onWikilinkClick={handleWikilinkClick}
+                    noteFiles={noteFiles}
+                  />
                 </div>
               ) : null}
             </div>
+
+            {/* Backlinks panel */}
+            <NotesBacklinks
+              projectId={projectId}
+              bridgeId={bridgeId}
+              notePath={selectedPath}
+              onNavigate={selectFile}
+            />
           </div>
         </div>
       )}
+
+      {/* Quick Switcher overlay */}
+      <QuickSwitcher
+        open={quickSwitcherOpen}
+        onOpenChange={setQuickSwitcherOpen}
+        files={noteFiles.map((f) => ({ path: f.path, name: f.name, displayPath: f.displayPath }))}
+        onSelect={handleQuickSwitchSelect}
+        recentPaths={recentPaths.current}
+      />
     </div>
   );
 }

--- a/packages/web/src/components/notes/QuickSwitcher.tsx
+++ b/packages/web/src/components/notes/QuickSwitcher.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { Search, FileText } from "lucide-react";
+import { fuzzyMatch } from "./utils";
+
+interface QuickSwitcherProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  files: { path: string; name: string; displayPath: string }[];
+  onSelect: (path: string) => void;
+  recentPaths?: string[];
+}
+
+export function QuickSwitcher({
+  open,
+  onOpenChange,
+  files,
+  onSelect,
+  recentPaths = [],
+}: QuickSwitcherProps) {
+  const [query, setQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Reset on open
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      setSelectedIndex(0);
+      // Focus input after a tick
+      requestAnimationFrame(() => {
+        inputRef.current?.focus();
+      });
+    }
+  }, [open]);
+
+  const results = useMemo(() => {
+    if (query.trim().length === 0) {
+      // Show recent files when no query
+      const recent = recentPaths
+        .map((path) => files.find((f) => f.path === path))
+        .filter((f): f is NonNullable<typeof f> => f != null);
+      if (recent.length > 0) return recent;
+      // Otherwise show all
+      return files;
+    }
+
+    const names = files.map((f) => f.displayPath);
+    const matched = fuzzyMatch(query.trim(), names);
+    return matched
+      .map((m) => files.find((f) => f.displayPath === m.item))
+      .filter((f): f is NonNullable<typeof f> => f != null)
+      .slice(0, 20);
+  }, [query, files, recentPaths]);
+
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query]);
+
+  const handleSelect = useCallback(
+    (path: string) => {
+      onSelect(path);
+      onOpenChange(false);
+    },
+    [onSelect, onOpenChange],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelectedIndex((idx) => Math.min(idx + 1, results.length - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelectedIndex((idx) => Math.max(idx - 1, 0));
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        if (results[selectedIndex]) {
+          handleSelect(results[selectedIndex].path);
+        }
+      }
+    },
+    [results, selectedIndex, handleSelect],
+  );
+
+  // Scroll selected item into view
+  useEffect(() => {
+    const el = listRef.current?.querySelector(`[data-index="${selectedIndex}"]`);
+    el?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
+        <Dialog.Content className="fixed left-1/2 top-[20%] z-50 w-full max-w-lg -translate-x-1/2 rounded-[12px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_20px_48px_rgba(0,0,0,0.3)]">
+          {/* Search input */}
+          <div className="flex items-center gap-3 border-b border-[var(--vk-border)] px-4 py-3">
+            <Search className="h-4 w-4 shrink-0 text-[var(--vk-text-muted)]" />
+            <input
+              ref={inputRef}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Search notes by name…"
+              className="min-w-0 flex-1 bg-transparent text-[14px] text-[var(--vk-text-normal)] outline-none placeholder:text-[var(--vk-text-muted)]"
+            />
+            <kbd className="rounded-[4px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-1.5 py-0.5 text-[11px] text-[var(--vk-text-muted)]">
+              Esc
+            </kbd>
+          </div>
+
+          {/* Results */}
+          <div ref={listRef} className="max-h-[320px] overflow-auto py-1">
+            {results.length === 0 ? (
+              <div className="px-4 py-6 text-center text-[13px] text-[var(--vk-text-muted)]">
+                No notes found
+              </div>
+            ) : (
+              results.map((file, idx) => (
+                <button
+                  key={file.path}
+                  type="button"
+                  data-index={idx}
+                  onClick={() => handleSelect(file.path)}
+                  onMouseEnter={() => setSelectedIndex(idx)}
+                  className={`flex w-full items-center gap-2.5 px-4 py-2 text-left text-[13px] ${
+                    idx === selectedIndex
+                      ? "bg-[var(--vk-bg-active)] text-[var(--vk-text-strong)]"
+                      : "text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)]"
+                  }`}
+                >
+                  <FileText className="h-3.5 w-3.5 shrink-0 text-[var(--vk-text-muted)]" />
+                  <span className="truncate">{file.displayPath}</span>
+                </button>
+              ))
+            )}
+          </div>
+
+          {/* Footer */}
+          <div className="flex items-center gap-4 border-t border-[var(--vk-border)] px-4 py-2 text-[11px] text-[var(--vk-text-muted)]">
+            <span>↑↓ Navigate</span>
+            <span>↵ Open</span>
+            <span>Esc Close</span>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/packages/web/src/components/notes/types.ts
+++ b/packages/web/src/components/notes/types.ts
@@ -1,0 +1,67 @@
+export type ViewMode = "split" | "edit" | "preview";
+
+export type NoteFile = {
+  path: string;
+  displayPath: string;
+  name: string;
+  source: string | null;
+  sizeBytes: number | null;
+  modifiedAt: string | null;
+  kind: string;
+};
+
+export type NotesIndexPayload = {
+  editor: string;
+  notesRoot: string | null;
+  syncManagedByEditor: boolean;
+  writable: boolean;
+  files: NoteFile[];
+  tags?: TagMap;
+};
+
+export type NoteFilePayload = {
+  path: string;
+  displayPath: string;
+  content: string;
+  size: number;
+  truncated: boolean;
+  modifiedAt: string | null;
+  writable: boolean;
+};
+
+export type SaveNotePayload = {
+  ok: boolean;
+  path: string;
+  displayPath: string;
+  modifiedAt: string | null;
+  savedBytes: number;
+  created: boolean;
+};
+
+export type NotesTreeNode = {
+  name: string;
+  path: string;
+  isDirectory: boolean;
+  file?: NoteFile;
+  children: NotesTreeNode[];
+};
+
+export type BacklinkInfo = {
+  path: string;
+  displayPath: string;
+  name: string;
+  context: string;
+};
+
+export type GraphNode = {
+  id: string;
+  name: string;
+  tags?: string[];
+};
+
+export type GraphEdge = {
+  source: string;
+  target: string;
+};
+
+export type TagMap = Record<string, string[]>;

--- a/packages/web/src/components/notes/utils.ts
+++ b/packages/web/src/components/notes/utils.ts
@@ -1,0 +1,232 @@
+import type { NoteFile, NotesTreeNode } from "./types";
+
+export function buildNotesTree(files: NoteFile[]): NotesTreeNode[] {
+  const root: NotesTreeNode = {
+    name: "",
+    path: "",
+    isDirectory: true,
+    children: [],
+  };
+
+  for (const file of files) {
+    const normalizedDisplayPath = file.displayPath.replace(/^\/+/, "");
+    const parts = normalizedDisplayPath.split("/").filter(Boolean);
+    if (parts.length === 0) {
+      continue;
+    }
+
+    let current = root;
+    let currentPath = "";
+    for (let index = 0; index < parts.length; index += 1) {
+      const part = parts[index];
+      currentPath = currentPath ? `${currentPath}/${part}` : part;
+      const isLast = index === parts.length - 1;
+      let child = current.children.find((candidate) => candidate.name === part && candidate.isDirectory !== isLast);
+      if (!child) {
+        child = {
+          name: part,
+          path: isLast ? file.path : currentPath,
+          isDirectory: !isLast,
+          file: isLast ? file : undefined,
+          children: [],
+        };
+        current.children.push(child);
+      }
+      current = child;
+    }
+  }
+
+  const sortTree = (nodes: NotesTreeNode[]) => {
+    nodes.sort((left, right) => {
+      if (left.isDirectory !== right.isDirectory) {
+        return left.isDirectory ? -1 : 1;
+      }
+      return left.name.localeCompare(right.name, undefined, { sensitivity: "base" });
+    });
+    for (const node of nodes) {
+      if (node.children.length > 0) {
+        sortTree(node.children);
+      }
+    }
+  };
+
+  sortTree(root.children);
+  return root.children;
+}
+
+export function filterNotesTree(nodes: NotesTreeNode[], query: string): NotesTreeNode[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return nodes;
+  }
+
+  const filterNode = (node: NotesTreeNode): NotesTreeNode | null => {
+    const haystack = `${node.name} ${node.file?.displayPath ?? ""}`.toLowerCase();
+    const childMatches = node.children
+      .map((child) => filterNode(child))
+      .filter((child): child is NotesTreeNode => Boolean(child));
+    if (haystack.includes(normalizedQuery) || childMatches.length > 0) {
+      return {
+        ...node,
+        children: childMatches,
+      };
+    }
+    return null;
+  };
+
+  return nodes
+    .map((node) => filterNode(node))
+    .filter((node): node is NotesTreeNode => Boolean(node));
+}
+
+export function collectFolderPaths(nodes: NotesTreeNode[]): string[] {
+  const paths: string[] = [];
+  const visit = (node: NotesTreeNode) => {
+    if (node.isDirectory) {
+      paths.push(node.path);
+      node.children.forEach(visit);
+    }
+  };
+  nodes.forEach(visit);
+  return paths;
+}
+
+export function formatTimestamp(value: string | null | undefined): string {
+  if (!value) {
+    return "";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+  return date.toLocaleString();
+}
+
+export function formatBytes(value: number | null | undefined): string {
+  if (!value || value <= 0) {
+    return "";
+  }
+  if (value < 1024) return `${value} B`;
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KB`;
+  return `${(value / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function normalizeNewNotePath(value: string): string {
+  const normalized = value.trim().replace(/\\/g, "/").replace(/^\/+/, "");
+  if (!normalized) {
+    return "";
+  }
+  if (/\.(md|markdown|mdx|txt)$/i.test(normalized)) {
+    return normalized;
+  }
+  return `${normalized}.md`;
+}
+
+export function buildNewNoteSeedContent(notePath: string): string {
+  const fileName = notePath.split("/").pop() ?? "Note";
+  const heading = fileName.replace(/\.(md|markdown|mdx|txt)$/i, "").replace(/[-_]+/g, " ").trim();
+  if (!heading) {
+    return "";
+  }
+  return `# ${heading.charAt(0).toUpperCase()}${heading.slice(1)}\n\n`;
+}
+
+export function extractWikilinks(text: string): string[] {
+  const matches = text.matchAll(/\[\[([^\]]+)\]\]/g);
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const match of matches) {
+    const target = match[1].trim();
+    if (target && !seen.has(target)) {
+      seen.add(target);
+      result.push(target);
+    }
+  }
+  return result;
+}
+
+export function extractTags(text: string): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  const lines = text.split("\n");
+  for (const line of lines) {
+    // Find inline tags: #tag but not # heading (must not be at start of line followed by space)
+    const tagMatches = line.matchAll(/(?:^|[\s(])(#([a-zA-Z][\w/-]*))/g);
+    for (const match of tagMatches) {
+      const fullMatch = match[1];
+      const tagName = match[2];
+      // Skip if it looks like a markdown heading (# at start of line followed by space)
+      if (fullMatch.startsWith("#") && match.index === 0 && line.startsWith("# ")) continue;
+      if (tagName && !seen.has(tagName)) {
+        seen.add(tagName);
+        result.push(tagName);
+      }
+    }
+  }
+  return result;
+}
+
+export function resolveWikilinkTarget(name: string, files: NoteFile[]): string | null {
+  // Try exact path match
+  const exactPath = files.find((f) => f.path === name);
+  if (exactPath) return exactPath.path;
+
+  // Try name match
+  const byName = files.find((f) => f.name === name || f.name === `${name}.md`);
+  if (byName) return byName.path;
+
+  // Try display path match
+  const byDisplay = files.find((f) => f.displayPath === name);
+  if (byDisplay) return byDisplay.path;
+
+  // Try case-insensitive name match
+  const lowerName = name.toLowerCase();
+  const byLower = files.find(
+    (f) => f.name.toLowerCase() === lowerName || f.name.toLowerCase() === `${lowerName}.md`,
+  );
+  if (byLower) return byLower.path;
+
+  // Try partial match on display path
+  const byPartial = files.find((f) => f.displayPath.toLowerCase().endsWith(`/${lowerName}.md`) || f.displayPath.toLowerCase() === `${lowerName}.md`);
+  if (byPartial) return byPartial.path;
+
+  return null;
+}
+
+export interface FuzzyMatchResult {
+  item: string;
+  score: number;
+}
+
+export function fuzzyMatch(query: string, items: string[]): FuzzyMatchResult[] {
+  const lowerQuery = query.toLowerCase();
+  const results: FuzzyMatchResult[] = [];
+
+  for (const item of items) {
+    const lowerItem = item.toLowerCase();
+    let score = 0;
+    let queryIdx = 0;
+
+    // Exact substring match gets highest score
+    if (lowerItem.includes(lowerQuery)) {
+      score = 100 - lowerItem.indexOf(lowerQuery);
+    } else {
+      // Character-by-character fuzzy match
+      for (let i = 0; i < lowerItem.length && queryIdx < lowerQuery.length; i++) {
+        if (lowerItem[i] === lowerQuery[queryIdx]) {
+          score += 1;
+          queryIdx += 1;
+        }
+      }
+      if (queryIdx < lowerQuery.length) {
+        // Didn't match all characters
+        continue;
+      }
+    }
+
+    results.push({ item, score });
+  }
+
+  results.sort((a, b) => b.score - a.score);
+  return results;
+}

--- a/packages/web/src/components/notes/wikilinkPlugin.ts
+++ b/packages/web/src/components/notes/wikilinkPlugin.ts
@@ -1,0 +1,84 @@
+import { Decoration, type DecorationSet, type EditorView, ViewPlugin, type ViewUpdate } from "@codemirror/view";
+import { type EditorState, RangeSetBuilder } from "@codemirror/state";
+
+const wikilinkDecoration = Decoration.mark({
+  class: "cm-wikilink",
+  attributes: { style: "background-color: rgba(139, 92, 246, 0.15); border-radius: 3px; padding: 1px 3px; cursor: pointer; color: #cdb4ff;" },
+});
+
+const tagDecoration = Decoration.mark({
+  class: "cm-tag",
+  attributes: { style: "background-color: rgba(248, 147, 30, 0.12); border-radius: 3px; padding: 1px 3px; color: #f6c56f;" },
+});
+
+function buildDecorations(state: EditorState): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>();
+  const doc = state.doc;
+
+  // Process the full document text for wikilinks and tags
+  const text = doc.toString();
+  const lines = text.split("\n");
+
+  let offset = 0;
+  const decorations: { from: number; to: number; deco: Decoration }[] = [];
+
+  for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
+    const line = lines[lineIdx];
+
+    // Find wikilinks: [[target]]
+    const wikilinkRegex = /\[\[([^\]]+)\]\]/g;
+    let match: RegExpExecArray | null;
+    while ((match = wikilinkRegex.exec(line)) !== null) {
+      const from = offset + match.index;
+      const to = from + match[0].length;
+      decorations.push({ from, to, deco: wikilinkDecoration });
+    }
+
+    // Find inline tags: #tag (but not # heading at start of line)
+    const tagRegex = /(^|[\s(])(#[a-zA-Z][\w/-]*)/g;
+    while ((match = tagRegex.exec(line)) !== null) {
+      // Check it's not a heading
+      const fullMatch = match[2];
+      const prefix = match[1];
+      if (prefix === "" && match.index === 0) {
+        // Check if it's followed by a space (heading)
+        const afterHash = line.substring(match.index + 1);
+        if (afterHash.startsWith(" ")) continue;
+      }
+      // It's a tag if the prefix is whitespace or paren or start-of-line, and it's not # followed by space
+      const tagFrom = offset + match.index + match[1].length;
+      const tagTo = tagFrom + fullMatch.length;
+      decorations.push({ from: tagFrom, to: tagTo, deco: tagDecoration });
+    }
+
+    offset += line.length + 1; // +1 for newline
+  }
+
+  // Sort decorations by position
+  decorations.sort((a, b) => a.from - b.from);
+
+  for (const { from, to, deco } of decorations) {
+    builder.add(from, to, deco);
+  }
+
+  return builder.finish();
+}
+
+export const wikilinkPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+
+    constructor(view: EditorView) {
+      this.decorations = buildDecorations(view.state);
+    }
+
+    update(update: ViewUpdate) {
+      if (update.docChanged || update.viewportChanged) {
+        this.decorations = buildDecorations(update.state);
+      }
+    }
+  },
+  {
+    decorations: (v) => v.decorations,
+  },
+);


### PR DESCRIPTION
## User-Facing Release Notes
- Notes workspace now supports Obsidian-like `[[wikilinks]]` for connecting notes
- New backlinks panel shows all notes that reference the current note
- Tag system: use `#tag` in notes, browse and filter by tags in the sidebar
- Daily notes: one-click create/open today's note (`daily/YYYY-MM-DD.md`)
- Quick switcher: press `Cmd+K` / `Ctrl+K` to fuzzy-search and jump to any note
- Graph view: visual force-directed graph of note connections
- Editor upgraded from plain textarea to CodeMirror 6 with syntax highlighting and wikilink/tag token styling

## Type of Change
- [ ] Breaking Change
- [x] New Feature
- [ ] Plugin Addition / Modification
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Summary

Transforms the existing basic markdown file browser into a full Obsidian-like notes experience.

**Backend (Rust) — 4 new endpoints:**
- `GET /api/project-notes` enhanced with `tags` and `forwardLinks` fields
- `GET /api/project-notes/backlinks` — returns notes linking to the current note
- `POST /api/project-notes/daily` — auto-creates daily note
- `GET /api/project-notes/graph` — returns nodes + edges for graph visualization

**Frontend (React) — 11 component files:**
- `NotesEditor.tsx` — CodeMirror 6 with markdown syntax, wikilink/tag highlighting
- `NotesPreview.tsx` — ReactMarkdown with clickable wikilinks and tag chips
- `NotesBacklinks.tsx` — collapsible backlinks panel with context snippets
- `NotesSidebar.tsx` — file tree + collapsible tags pane with filter
- `NotesToolbar.tsx` — save, refresh, daily note, graph toggle, view modes
- `QuickSwitcher.tsx` — Cmd+K fuzzy search modal
- `NotesGraph.tsx` — SVG force-directed graph (d3-force)
- `wikilinkPlugin.ts` — CodeMirror extension for [[link]] and #tag tokens
- `types.ts` / `utils.ts` — shared types, tree builder, fuzzy matcher
- `ProjectNotesWorkspace.tsx` — rewritten as orchestrator composing all sub-components

**Dependencies added:** `@codemirror/*`, `d3-force`

## Testing
- `cargo fmt --check` ✅
- `cargo clippy --workspace -D warnings` ✅
- `cargo test --workspace` ✅
- `bun run typecheck` ✅ (0 errors)
- `bun run build` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notes editor with Markdown, wikilink/tag highlighting, and editor keybindings.
  * Live markdown preview with interactive wikilinks and tag handling.
  * Notes graph visualization with pan/zoom and navigation.
  * Backlinks panel showing linked references with context.
  * Quick switcher with fuzzy search and keyboard navigation.
  * Daily note creation (auto-seed for YYYY-MM-DD).
  * Sidebar, toolbar, and overall workspace UI improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->