### PR TITLE
fix: add missing project notes proxy routes

### DIFF
--- a/crates/conductor-server/src/routes/agents.rs
+++ b/crates/conductor-server/src/routes/agents.rs
@@ -631,7 +631,7 @@ fn collect_recent_file_contents(
 ) -> Vec<String> {
     let mut files: Vec<(PathBuf, std::time::SystemTime)> = Vec::new();
     collect_files_recursive(root, extensions, 0, max_depth, &mut files, 64);
-    files.sort_by(|a, b| b.1.cmp(&a.1));
+    files.sort_by_key(|entry| std::cmp::Reverse(entry.1));
     files
         .into_iter()
         .take(max_files)

--- a/crates/conductor-server/src/routes/skills.rs
+++ b/crates/conductor-server/src/routes/skills.rs
@@ -843,7 +843,7 @@ fn scan_skill_installs(
         let installed_workspace = !workspace_paths.is_empty();
         let install_paths = user_paths
             .into_iter()
-            .chain(workspace_paths.into_iter())
+            .chain(workspace_paths)
             .map(|path| path.to_string_lossy().to_string())
             .collect::<Vec<_>>();
         results.push(InstalledSkillStatus {

--- a/crates/conductor-server/src/routes/terminal.rs
+++ b/crates/conductor-server/src/routes/terminal.rs
@@ -2098,35 +2098,33 @@ async fn handle_ttyd_frontend_client_message(
         Some(ttyd_protocol::ClientMessage::Pause) => {
             *paused = true;
         }
-        Some(ttyd_protocol::ClientMessage::Resume) => {
-            if *paused {
-                *paused = false;
-                // Replay buffered chunks collected during pause, skipping any
-                // with stale sequence numbers.
-                for chunk in pause_buffer.drain(..) {
-                    if chunk.sequence <= *last_sequence_sent {
-                        continue;
-                    }
-                    *last_sequence_sent = chunk.sequence;
-                    client_socket
-                        .send(Message::Binary(
-                            ttyd_protocol::encode_output(&chunk.bytes).into(),
-                        ))
-                        .await?;
+        Some(ttyd_protocol::ClientMessage::Resume) if *paused => {
+            *paused = false;
+            // Replay buffered chunks collected during pause, skipping any
+            // with stale sequence numbers.
+            for chunk in pause_buffer.drain(..) {
+                if chunk.sequence <= *last_sequence_sent {
+                    continue;
                 }
-                // Send the current snapshot as the authoritative terminal state.
-                // The snapshot includes all output up to this point, so it
-                // provides a smooth transition from the pause gap.
-                let bytes =
-                    render_current_restore_snapshot_bytes(state, session_id, last_sequence_sent)
-                        .await;
-                if !bytes.is_empty() {
-                    client_socket
-                        .send(Message::Binary(ttyd_protocol::encode_output(&bytes).into()))
-                        .await?;
-                }
+                *last_sequence_sent = chunk.sequence;
+                client_socket
+                    .send(Message::Binary(
+                        ttyd_protocol::encode_output(&chunk.bytes).into(),
+                    ))
+                    .await?;
+            }
+            // Send the current snapshot as the authoritative terminal state.
+            // The snapshot includes all output up to this point, so it
+            // provides a smooth transition from the pause gap.
+            let bytes =
+                render_current_restore_snapshot_bytes(state, session_id, last_sequence_sent).await;
+            if !bytes.is_empty() {
+                client_socket
+                    .send(Message::Binary(ttyd_protocol::encode_output(&bytes).into()))
+                    .await?;
             }
         }
+        Some(ttyd_protocol::ClientMessage::Resume) => {}
         None => {}
     }
 

--- a/crates/conductor-server/src/state/runtime_status.rs
+++ b/crates/conductor-server/src/state/runtime_status.rs
@@ -205,35 +205,33 @@ fn read_codex_runtime_status_from_home(home: &Path, cwd: &str) -> Option<Session
 
     for value in lines.iter().rev() {
         match value.get("type").and_then(Value::as_str) {
-            Some("turn_context") => {
-                if model.is_none() {
-                    model = value
-                        .pointer("/payload/model")
-                        .and_then(Value::as_str)
-                        .and_then(trimmed_or_none);
-                }
+            Some("turn_context") if model.is_none() => {
+                model = value
+                    .pointer("/payload/model")
+                    .and_then(Value::as_str)
+                    .and_then(trimmed_or_none);
             }
+            Some("turn_context") => {}
             Some("event_msg")
                 if value.pointer("/payload/type").and_then(Value::as_str)
-                    == Some("token_count") =>
+                    == Some("token_count")
+                    && usage.total_tokens.is_none() =>
             {
-                if usage.total_tokens.is_none() {
-                    if let Some(info) = value.pointer("/payload/info") {
-                        if let Some(total_usage) = info.get("total_token_usage") {
-                            usage.input_tokens = json_u64(total_usage.get("input_tokens"));
-                            usage.output_tokens = json_u64(total_usage.get("output_tokens"));
-                            usage.cached_input_tokens =
-                                json_u64(total_usage.get("cached_input_tokens"));
-                            usage.reasoning_tokens =
-                                json_u64(total_usage.get("reasoning_output_tokens"));
-                            usage.total_tokens = json_u64(total_usage.get("total_tokens"));
-                        }
-                        if let Some(max_tokens) = json_u64(info.get("model_context_window")) {
-                            context_window.max_tokens = Some(max_tokens);
-                            context_window.source = "cli".to_string();
-                            context_window.note =
-                                Some("Reported directly by the active Codex session.".to_string());
-                        }
+                if let Some(info) = value.pointer("/payload/info") {
+                    if let Some(total_usage) = info.get("total_token_usage") {
+                        usage.input_tokens = json_u64(total_usage.get("input_tokens"));
+                        usage.output_tokens = json_u64(total_usage.get("output_tokens"));
+                        usage.cached_input_tokens =
+                            json_u64(total_usage.get("cached_input_tokens"));
+                        usage.reasoning_tokens =
+                            json_u64(total_usage.get("reasoning_output_tokens"));
+                        usage.total_tokens = json_u64(total_usage.get("total_tokens"));
+                    }
+                    if let Some(max_tokens) = json_u64(info.get("model_context_window")) {
+                        context_window.max_tokens = Some(max_tokens);
+                        context_window.source = "cli".to_string();
+                        context_window.note =
+                            Some("Reported directly by the active Codex session.".to_string());
                     }
                 }
             }

--- a/packages/web/custom-types.d.ts
+++ b/packages/web/custom-types.d.ts
@@ -23,7 +23,10 @@ type AppRouteHandlerRoutes =
   | "/api/notifications"
   | "/api/preferences"
   | "/api/project-notes"
+  | "/api/project-notes/backlinks"
+  | "/api/project-notes/daily"
   | "/api/project-notes/file"
+  | "/api/project-notes/graph"
   | "/api/project-notes/open"
   | "/api/repositories"
   | "/api/repositories/[id]"
@@ -71,7 +74,10 @@ interface ParamMap {
   "/api/notifications": {}
   "/api/preferences": {}
   "/api/project-notes": {}
+  "/api/project-notes/backlinks": {}
+  "/api/project-notes/daily": {}
   "/api/project-notes/file": {}
+  "/api/project-notes/graph": {}
   "/api/project-notes/open": {}
   "/api/repositories": {}
   "/api/repositories/[id]": { "id": string; }

--- a/packages/web/src/app/api/project-notes/backlinks/route.ts
+++ b/packages/web/src/app/api/project-notes/backlinks/route.ts
@@ -1,0 +1,8 @@
+import { guardedProxyRoute } from "@/lib/proxyRoutes";
+
+export const dynamic = "force-dynamic";
+
+export const GET = guardedProxyRoute("/api/project-notes/backlinks", {
+  role: "viewer",
+  bridgeAware: true,
+});

--- a/packages/web/src/app/api/project-notes/daily/route.ts
+++ b/packages/web/src/app/api/project-notes/daily/route.ts
@@ -1,0 +1,9 @@
+import { guardedProxyRoute } from "@/lib/proxyRoutes";
+
+export const dynamic = "force-dynamic";
+
+export const POST = guardedProxyRoute("/api/project-notes/daily", {
+  role: "operator",
+  requireActionGuard: true,
+  bridgeAware: true,
+});

--- a/packages/web/src/app/api/project-notes/graph/route.ts
+++ b/packages/web/src/app/api/project-notes/graph/route.ts
@@ -1,0 +1,8 @@
+import { guardedProxyRoute } from "@/lib/proxyRoutes";
+
+export const dynamic = "force-dynamic";
+
+export const GET = guardedProxyRoute("/api/project-notes/graph", {
+  role: "viewer",
+  bridgeAware: true,
+});

--- a/packages/web/src/lib/projectNotesProxyRoutes.test.ts
+++ b/packages/web/src/lib/projectNotesProxyRoutes.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { GET as getBacklinks } from "@/app/api/project-notes/backlinks/route";
+import { POST as postDaily } from "@/app/api/project-notes/daily/route";
+import { GET as getGraph } from "@/app/api/project-notes/graph/route";
+
+test("project notes advanced proxy routes are registered", () => {
+  assert.equal(typeof getBacklinks, "function");
+  assert.equal(typeof postDaily, "function");
+  assert.equal(typeof getGraph, "function");
+});


### PR DESCRIPTION
## Summary

Add the missing Next API proxy handlers for the project notes backlinks, graph, and daily-note endpoints so the hosted dashboard can reach the Rust notes routes. This also folds in the current Rust clippy cleanups needed to get the branch through the required CI gate.

## User-Facing Release Notes

- Fixed the hosted Notes workspace so graph, backlinks, and daily note actions no longer hit missing API routes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Plugin addition / modification
- [ ] Documentation update
- [x] Refactor / chore

## Testing

- `bun run --cwd packages/web typecheck`
- `bun run --cwd packages/web test`
- `cargo clippy --workspace -- -D warnings`
- `cargo test -p conductor-server project_notes_routes_list_read_and_save_markdown_files -- --nocapture`
- Verified local `/api/project-notes?projectId=carevm` now returns note files after restarting the correct local conductor backend with the workspace config.
- Verified hosted unauthenticated route behavior: `https://app.conductross.com/api/project-notes` returns `403` while the missing subroutes currently return `404`, matching the fix scope.
