### PR TITLE
fix: restore notes mobile scroll and graph discovery

### DIFF
--- a/crates/conductor-server/src/routes/project_notes.rs
+++ b/crates/conductor-server/src/routes/project_notes.rs
@@ -106,72 +106,7 @@ async fn list_project_notes(
         }));
     }
 
-    let mut files = Vec::new();
-    if let Some(board_path) = context.board_path.as_deref().filter(|path| path.exists()) {
-        files.push(note_descriptor(
-            board_path,
-            board_path.parent(),
-            Some("board"),
-            Some("Board/CONDUCTOR.md"),
-        ));
-    }
-
-    if let Some(notes_root) = context.notes_root.as_deref() {
-        collect_note_files(
-            notes_root,
-            Some(notes_root),
-            context.source_label,
-            &mut files,
-            MAX_NOTE_COUNT,
-            MAX_NOTE_DEPTH,
-        );
-    } else {
-        let mut seen_roots = HashSet::new();
-        for root in [
-            context.project_workspace_root.as_ref(),
-            Some(&context.project_root),
-            context.board_parent.as_ref(),
-            Some(&context.workspace_root),
-        ]
-        .into_iter()
-        .flatten()
-        {
-            let dedupe_key = canonicalize_for_access(root).to_string_lossy().to_string();
-            if !seen_roots.insert(dedupe_key) {
-                continue;
-            }
-            collect_note_files(
-                root,
-                Some(root),
-                context.source_label,
-                &mut files,
-                MAX_NOTE_COUNT,
-                MAX_NOTE_DEPTH,
-            );
-            if files.len() >= MAX_NOTE_COUNT {
-                break;
-            }
-        }
-    }
-
-    files.sort_by(|left, right| {
-        left["path"]
-            .as_str()
-            .unwrap_or_default()
-            .cmp(right["path"].as_str().unwrap_or_default())
-            .then_with(|| {
-                source_sort_rank(left["source"].as_str().unwrap_or_default()).cmp(
-                    &source_sort_rank(right["source"].as_str().unwrap_or_default()),
-                )
-            })
-            .then_with(|| {
-                left["displayPath"]
-                    .as_str()
-                    .unwrap_or_default()
-                    .cmp(right["displayPath"].as_str().unwrap_or_default())
-            })
-    });
-    files.dedup_by(|left, right| left["path"] == right["path"]);
+    let files = collect_indexed_note_files(&context);
 
     // Build tags and forwardLinks maps by scanning file contents
     let (tags, forward_links) = {
@@ -418,6 +353,58 @@ fn source_sort_rank(source: &str) -> usize {
     }
 }
 
+fn collect_indexed_note_files(context: &ProjectNotesContext) -> Vec<Value> {
+    let mut files = Vec::new();
+    if let Some(board_path) = context.board_path.as_deref().filter(|path| path.exists()) {
+        files.push(note_descriptor(
+            board_path,
+            board_path.parent(),
+            Some("board"),
+            Some("Board/CONDUCTOR.md"),
+        ));
+    }
+
+    let discovery_roots: Vec<PathBuf> = if let Some(notes_root) = context.notes_root.as_ref() {
+        vec![notes_root.clone()]
+    } else {
+        allowed_note_roots(context)
+    };
+
+    for root in discovery_roots {
+        collect_note_files(
+            &root,
+            Some(&root),
+            context.source_label,
+            &mut files,
+            MAX_NOTE_COUNT,
+            MAX_NOTE_DEPTH,
+        );
+        if files.len() >= MAX_NOTE_COUNT {
+            break;
+        }
+    }
+
+    files.sort_by(|left, right| {
+        left["path"]
+            .as_str()
+            .unwrap_or_default()
+            .cmp(right["path"].as_str().unwrap_or_default())
+            .then_with(|| {
+                source_sort_rank(left["source"].as_str().unwrap_or_default()).cmp(
+                    &source_sort_rank(right["source"].as_str().unwrap_or_default()),
+                )
+            })
+            .then_with(|| {
+                left["displayPath"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .cmp(right["displayPath"].as_str().unwrap_or_default())
+            })
+    });
+    files.dedup_by(|left, right| left["path"] == right["path"]);
+    files
+}
+
 fn collect_note_files(
     root: &Path,
     display_root: Option<&Path>,
@@ -478,24 +465,28 @@ fn note_descriptor(
     source: Option<&str>,
     display_override: Option<&str>,
 ) -> Value {
+    let canonical_path = canonicalize_for_access(path);
     let display_path = display_override
         .map(str::to_string)
         .or_else(|| {
             display_root.map(|root| {
-                path.strip_prefix(root)
+                let canonical_root = canonicalize_for_access(root);
+                canonical_path
+                    .strip_prefix(&canonical_root)
+                    .or_else(|_| path.strip_prefix(root))
                     .map(|value| value.to_string_lossy().replace('\\', "/"))
-                    .unwrap_or_else(|_| path.to_string_lossy().to_string())
+                    .unwrap_or_else(|_| canonical_path.to_string_lossy().to_string())
             })
         })
-        .unwrap_or_else(|| path.to_string_lossy().to_string());
+        .unwrap_or_else(|| canonical_path.to_string_lossy().to_string());
 
     json!({
-        "path": path.to_string_lossy().to_string(),
+        "path": canonical_path.to_string_lossy().to_string(),
         "displayPath": display_path,
-        "name": path.file_name().and_then(|value| value.to_str()).unwrap_or_default(),
+        "name": canonical_path.file_name().and_then(|value| value.to_str()).unwrap_or_default(),
         "source": source,
-        "sizeBytes": fs::metadata(path).ok().map(|value| value.len()),
-        "modifiedAt": file_modified_at(path),
+        "sizeBytes": fs::metadata(&canonical_path).ok().map(|value| value.len()),
+        "modifiedAt": file_modified_at(&canonical_path),
         "kind": "file",
     })
 }
@@ -1013,18 +1004,7 @@ async fn get_backlinks(
     let backlinks = {
         let note_name_clone = note_name.clone();
         let current_path_str = current_path.to_string_lossy().to_string();
-        let mut files = Vec::new();
-        if let Some(notes_root) = context.notes_root.as_deref() {
-            collect_note_files(
-                notes_root,
-                Some(notes_root),
-                context.source_label,
-                &mut files,
-                MAX_NOTE_COUNT,
-                MAX_NOTE_DEPTH,
-            );
-        }
-        let files_clone = files.clone();
+        let files_clone = collect_indexed_note_files(&context);
         tokio::task::spawn_blocking(move || {
             scan_backlinks(&files_clone, &note_name_clone, &current_path_str)
         })
@@ -1179,20 +1159,8 @@ async fn get_notes_graph(
         return ok(json!({ "nodes": [], "edges": [] }));
     }
 
-    let mut files = Vec::new();
-    if let Some(notes_root) = context.notes_root.as_deref() {
-        collect_note_files(
-            notes_root,
-            Some(notes_root),
-            context.source_label,
-            &mut files,
-            MAX_NOTE_COUNT,
-            MAX_NOTE_DEPTH,
-        );
-    }
-
     let graph_data = {
-        let files_snapshot = files;
+        let files_snapshot = collect_indexed_note_files(&context);
         tokio::task::spawn_blocking(move || build_graph_data(&files_snapshot))
             .await
             .unwrap_or_else(|_| (json!([]), json!([])))

--- a/crates/conductor-server/tests/project_notes_test.rs
+++ b/crates/conductor-server/tests/project_notes_test.rs
@@ -117,6 +117,133 @@ async fn project_notes_routes_list_read_and_save_markdown_files() {
 }
 
 #[tokio::test]
+async fn project_notes_graph_and_backlinks_use_fallback_project_roots_when_notes_root_is_unset() {
+    let harness = TestHarness::new("conductor-project-notes-fallback", "direct").await;
+    let notes_dir = harness.repo.join("architecture");
+    std::fs::create_dir_all(&notes_dir).expect("create fallback notes directory");
+    let design_path = notes_dir.join("design.md");
+    let overview_path = notes_dir.join("overview.md");
+    std::fs::write(
+        &design_path,
+        "# Design\n\nThe detailed plan lives in [[overview]].\n",
+    )
+    .expect("write design note");
+    std::fs::write(
+        &overview_path,
+        "# Overview\n\nReferences [[design]] for the detailed implementation.\n",
+    )
+    .expect("write overview note");
+    let design_path = design_path
+        .canonicalize()
+        .expect("canonicalize design note path");
+    let overview_path = overview_path
+        .canonicalize()
+        .expect("canonicalize overview note path");
+
+    {
+        let mut config = harness.state.config.write().await;
+        config.preferences.markdown_editor = "obsidian".to_string();
+        config.preferences.markdown_editor_path.clear();
+    }
+
+    let list_response = harness
+        .app()
+        .oneshot(
+            Request::builder()
+                .uri("/api/project-notes?projectId=demo")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("fallback project notes list response");
+    assert_eq!(list_response.status(), StatusCode::OK);
+    let list_payload = response_json(list_response).await;
+    assert_eq!(list_payload["notesRoot"].as_str(), None);
+    let files = list_payload["files"].as_array().expect("files array");
+    assert!(
+        files
+            .iter()
+            .any(|entry| entry["displayPath"].as_str() == Some("architecture/design.md")),
+        "expected fallback project note in list payload: {list_payload:#}"
+    );
+
+    let graph_response = harness
+        .app()
+        .oneshot(
+            Request::builder()
+                .uri("/api/project-notes/graph?projectId=demo")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("fallback notes graph response");
+    assert_eq!(graph_response.status(), StatusCode::OK);
+    let graph_payload = response_json(graph_response).await;
+    let graph_nodes = graph_payload["nodes"]
+        .as_array()
+        .expect("graph nodes array");
+    let graph_edges = graph_payload["edges"]
+        .as_array()
+        .expect("graph edges array");
+    assert!(
+        graph_nodes
+            .iter()
+            .any(|node| node["id"].as_str() == Some(design_path.to_string_lossy().as_ref())),
+        "expected fallback graph node for design note: {graph_payload:#}"
+    );
+    assert!(
+        graph_nodes
+            .iter()
+            .any(|node| node["id"].as_str() == Some(overview_path.to_string_lossy().as_ref())),
+        "expected fallback graph node for overview note: {graph_payload:#}"
+    );
+    assert!(
+        graph_edges.iter().any(|edge| {
+            edge["source"].as_str() == Some(design_path.to_string_lossy().as_ref())
+                && edge["target"].as_str() == Some(overview_path.to_string_lossy().as_ref())
+        }),
+        "expected fallback graph edge for wikilinked notes: {graph_payload:#}"
+    );
+
+    let backlinks_response = harness
+        .app()
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/api/project-notes/backlinks?projectId=demo&path={}",
+                    url::form_urlencoded::byte_serialize(
+                        overview_path.to_string_lossy().as_bytes()
+                    )
+                    .collect::<String>()
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("fallback backlinks response");
+    assert_eq!(backlinks_response.status(), StatusCode::OK);
+    let backlinks_payload = response_json(backlinks_response).await;
+    let backlinks = backlinks_payload["backlinks"]
+        .as_array()
+        .expect("backlinks array");
+    assert!(
+        backlinks
+            .iter()
+            .any(|entry| entry["path"].as_str() == Some(design_path.to_string_lossy().as_ref())),
+        "expected backlink from fallback project note: {backlinks_payload:#}"
+    );
+    let forward_links = backlinks_payload["forwardLinks"]
+        .as_array()
+        .expect("forward links array");
+    assert!(
+        forward_links
+            .iter()
+            .any(|entry| entry.as_str() == Some("design")),
+        "expected forward link extracted from fallback project note: {backlinks_payload:#}"
+    );
+}
+
+#[tokio::test]
 async fn project_notes_routes_reject_stale_writes_and_outside_paths() {
     let harness = TestHarness::new("conductor-project-notes-conflict", "direct").await;
     let notes_root = harness.repo.join("vault");

--- a/packages/web/src/components/notes/NotesGraph.tsx
+++ b/packages/web/src/components/notes/NotesGraph.tsx
@@ -24,6 +24,7 @@ interface SimEdge {
 }
 
 const NODE_RADIUS = 6;
+const NOTES_GRAPH_SURFACE_CLASS_NAME = "flex h-full min-h-[min(560px,70dvh)] flex-col overflow-hidden bg-[var(--vk-bg-main)] xl:min-h-0";
 const COLORS = [
   "#8b5cf6", // purple
   "#06b6d4", // cyan
@@ -193,7 +194,7 @@ export function NotesGraph({ projectId, bridgeId, onNavigate }: NotesGraphProps)
   const centerY = svgHeight / 2 + transform.y;
 
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-[var(--vk-bg-main)]">
+    <div className={NOTES_GRAPH_SURFACE_CLASS_NAME}>
       {/* Header */}
       <div className="flex items-center justify-between border-b border-[var(--vk-border)] px-4 py-2">
         <span className="text-[12px] text-[var(--vk-text-muted)]">

--- a/packages/web/src/components/notes/NotesSidebar.tsx
+++ b/packages/web/src/components/notes/NotesSidebar.tsx
@@ -25,6 +25,8 @@ interface NotesSidebarProps {
   onTagClick?: (tag: string) => void;
 }
 
+const NOTES_SIDEBAR_CLASS_NAME = "flex min-h-0 max-h-[min(42dvh,360px)] flex-col border-b border-[var(--vk-border)] bg-[var(--vk-bg-panel)]/35 xl:max-h-none xl:border-b-0 xl:border-r";
+
 function NotesTree({
   nodes,
   expandedFolders,
@@ -138,7 +140,7 @@ export function NotesSidebar({
   );
 
   return (
-    <aside className="flex min-h-0 flex-col border-r border-[var(--vk-border)] bg-[var(--vk-bg-panel)]/35">
+    <aside className={NOTES_SIDEBAR_CLASS_NAME}>
       {/* Search + header */}
       <div className="flex items-center justify-between border-b border-[var(--vk-border)] px-3 py-2 text-[12px] text-[var(--vk-text-muted)]">
         <span>
@@ -163,7 +165,7 @@ export function NotesSidebar({
       </div>
 
       {/* File tree */}
-      <div className="min-h-0 flex-1 overflow-auto py-2">
+      <div className="min-h-0 flex-1 overflow-auto overscroll-contain [-webkit-overflow-scrolling:touch] py-2">
         <NotesTree
           nodes={filteredTree}
           expandedFolders={folderPathsSet}

--- a/packages/web/src/components/notes/ProjectNotesWorkspace.tsx
+++ b/packages/web/src/components/notes/ProjectNotesWorkspace.tsx
@@ -46,6 +46,12 @@ interface ProjectNotesWorkspaceProps {
   selectedSessionId?: string | null;
 }
 
+const NOTES_WORKSPACE_ROOT_CLASS_NAME = "flex h-full min-h-0 flex-col overflow-y-auto overscroll-contain touch-pan-y [-webkit-overflow-scrolling:touch] bg-[var(--vk-bg-main)]";
+const NOTES_WORKSPACE_LAYOUT_CLASS_NAME = "flex min-h-0 flex-1 flex-col xl:grid xl:grid-cols-[280px_minmax(0,1fr)] xl:overflow-hidden";
+const NOTES_MAIN_PANEL_CLASS_NAME = "flex min-h-[min(560px,70dvh)] flex-1 flex-col overflow-hidden xl:min-h-0";
+const NOTES_EDITOR_PANEL_CLASS_NAME = "min-h-[320px] overflow-hidden xl:min-h-0";
+const NOTES_PREVIEW_PANEL_CLASS_NAME = "min-h-[280px] overflow-auto bg-[var(--vk-bg-panel)]/25 px-4 py-4 xl:min-h-0";
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -555,7 +561,7 @@ export function ProjectNotesWorkspace({
 
   // -- Render --------------------------------------------------------------
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-[var(--vk-bg-main)]">
+    <div className={NOTES_WORKSPACE_ROOT_CLASS_NAME}>
       {/* Toolbar */}
       <NotesToolbar
         viewMode={viewMode}
@@ -675,7 +681,7 @@ export function ProjectNotesWorkspace({
         />
       ) : (
         /* Normal view: sidebar + editor/preview */
-        <div className="min-h-0 flex-1 overflow-hidden xl:grid xl:grid-cols-[280px_minmax(0,1fr)]">
+        <div className={NOTES_WORKSPACE_LAYOUT_CLASS_NAME}>
           {/* Sidebar */}
           <NotesSidebar
             noteFiles={noteFiles}
@@ -691,7 +697,7 @@ export function ProjectNotesWorkspace({
           />
 
           {/* Main panel */}
-          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <div className={NOTES_MAIN_PANEL_CLASS_NAME}>
             {/* File info + send-to bar */}
             <div className="border-b border-[var(--vk-border)] bg-[var(--vk-bg-panel)]/45 px-3 py-2">
               <div className="flex flex-col gap-2 xl:flex-row xl:items-start xl:justify-between">
@@ -760,7 +766,7 @@ export function ProjectNotesWorkspace({
             {/* Editor / Preview area */}
             <div className={`grid min-h-0 flex-1 ${viewMode === "split" ? "xl:grid-cols-2" : "grid-cols-1"}`}>
               {viewMode !== "preview" ? (
-                <div className={`min-h-0 overflow-hidden ${viewMode === "split" ? "border-b border-[var(--vk-border)] xl:border-b-0 xl:border-r" : ""}`}>
+                <div className={`${NOTES_EDITOR_PANEL_CLASS_NAME} ${viewMode === "split" ? "border-b border-[var(--vk-border)] xl:border-b-0 xl:border-r" : ""}`}>
                   {fileLoading ? (
                     <div className="flex h-full items-center justify-center gap-2 text-[13px] text-[var(--vk-text-muted)]">
                       <Loader2 className="h-4 w-4 animate-spin" />
@@ -781,7 +787,7 @@ export function ProjectNotesWorkspace({
               ) : null}
 
               {viewMode !== "edit" ? (
-                <div className="min-h-0 overflow-auto bg-[var(--vk-bg-panel)]/25 px-4 py-4">
+                <div className={NOTES_PREVIEW_PANEL_CLASS_NAME}>
                   <NotesPreview
                     content={draftContent}
                     onWikilinkClick={handleWikilinkClick}

--- a/packages/web/src/components/notes/notesMobileLayout.test.ts
+++ b/packages/web/src/components/notes/notesMobileLayout.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+test("project notes workspace restores a mobile scroll owner", () => {
+  const source = readFileSync(new URL("./ProjectNotesWorkspace.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /overflow-y-auto/);
+  assert.match(source, /overscroll-contain/);
+  assert.match(source, /touch-pan-y/);
+  assert.match(source, /-webkit-overflow-scrolling:touch/);
+});
+
+test("project notes workspace keeps a stacked mobile fallback before switching to the desktop grid", () => {
+  const source = readFileSync(new URL("./ProjectNotesWorkspace.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /flex min-h-0 flex-1 flex-col/);
+  assert.match(source, /xl:grid xl:grid-cols-\[280px_minmax\(0,1fr\)\]/);
+});
+
+test("notes sidebar constrains its mobile height so the tree can scroll inside the tab", () => {
+  const source = readFileSync(new URL("./NotesSidebar.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /max-h-\[min\(42dvh,360px\)\]/);
+  assert.match(source, /xl:border-r/);
+});
+
+test("notes graph keeps a usable mobile canvas height", () => {
+  const source = readFileSync(new URL("./NotesGraph.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /min-h-\[min\(560px,70dvh\)\]/);
+});


### PR DESCRIPTION
## Summary

Restores the project Notes workspace on phones and makes graph plus backlink discovery follow the same fallback roots as the notes index when no explicit notes root is configured.

## User-Facing Release Notes

- Fixed the Notes tab on mobile so the notes tree and editor stack can scroll instead of getting stuck.
- Restored Notes graph and backlink data when Conductor falls back to project files instead of a dedicated notes root.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Testing

- `cargo test -p conductor-server --test project_notes_test -- --nocapture`
- `bun test`
- `bun run typecheck`
- `bun run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project notes now correctly use fallback directories when notes root is unset.

* **Style**
  * Improved mobile scrolling experience in notes workspace with optimized viewport handling.
  * Enhanced sidebar with adjusted height constraints for improved mobile usability.

* **Tests**
  * Added mobile layout tests ensuring proper scroll behavior and responsive design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->