### PR TITLE
fix: upgrade notes graph and mobile workspace UX

### DIFF
--- a/packages/web/src/components/layout/AppUpdateNotice.test.ts
+++ b/packages/web/src/components/layout/AppUpdateNotice.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 import { noticeTitle } from "./AppUpdateNotice";
 import type { AppUpdateStatus } from "@/lib/types";
@@ -27,4 +28,13 @@ test("noticeTitle includes the installed build version alongside an available re
   } as AppUpdateStatus;
 
   assert.equal(noticeTitle(status), "Conductor 0.3.5 is available (build 0.3.4)");
+});
+
+test("mobile update notice collapses into a compact card instead of covering the whole workspace", () => {
+  const source = readFileSync(new URL("./AppUpdateNotice.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /window\.matchMedia\("\(max-width: 639px\)"\)/);
+  assert.match(source, /compactNotice/);
+  assert.match(source, /mobileExpanded/);
+  assert.match(source, /Details/);
 });

--- a/packages/web/src/components/layout/AppUpdateNotice.tsx
+++ b/packages/web/src/components/layout/AppUpdateNotice.tsx
@@ -83,6 +83,8 @@ export function AppUpdateNotice() {
   const [copied, setCopied] = useState(false);
   const [requestingUpdate, setRequestingUpdate] = useState(false);
   const [reconnecting, setReconnecting] = useState(false);
+  const [compactViewport, setCompactViewport] = useState(false);
+  const [mobileExpanded, setMobileExpanded] = useState(false);
 
   const activeBridgeId = useMemo(() => {
     if (typeof window === "undefined") {
@@ -163,8 +165,29 @@ export function AppUpdateNotice() {
     };
   }, [activeBridgeId, refreshUpdate]);
 
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    const mediaQuery = window.matchMedia("(max-width: 639px)");
+    const syncViewport = () => setCompactViewport(mediaQuery.matches);
+    syncViewport();
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", syncViewport);
+      return () => mediaQuery.removeEventListener("change", syncViewport);
+    }
+    mediaQuery.addListener?.(syncViewport);
+    return () => mediaQuery.removeListener?.(syncViewport);
+  }, []);
+
+  useEffect(() => {
+    if (!compactViewport) {
+      setMobileExpanded(false);
+    }
+  }, [compactViewport]);
+
   const hiddenForVersion = update?.latestVersion && dismissedVersion === update.latestVersion;
   const restarting = Boolean(update?.restarting) || reconnecting;
+  const compactNotice = compactViewport && !restarting && update?.jobStatus !== "running" && update?.jobStatus !== "failed";
+  const showDetailedBody = !compactNotice || mobileExpanded;
   const visible = useMemo(() => {
     if (!update) return false;
     if (hiddenForVersion) return false;
@@ -279,10 +302,11 @@ export function AppUpdateNotice() {
   if (!visible) return null;
 
   return (
-    <div className="pointer-events-none fixed bottom-3 right-3 z-[70] w-[min(calc(100vw-1.5rem),24rem)] sm:bottom-4 sm:right-4">
+    <div className="pointer-events-none fixed bottom-2 left-2 right-2 z-[70] sm:bottom-4 sm:left-auto sm:right-4 sm:w-[min(calc(100vw-1.5rem),24rem)]">
       <section
         className={cn(
-          "pointer-events-auto rounded-[14px] border bg-[var(--vk-bg-panel)] p-4 shadow-[0_16px_40px_rgba(0,0,0,0.35)]",
+          "pointer-events-auto rounded-[14px] border bg-[var(--vk-bg-panel)] p-3 shadow-[0_16px_40px_rgba(0,0,0,0.35)] sm:p-4",
+          compactNotice && "max-w-[min(calc(100vw-1rem),18rem)] ml-auto",
           update?.jobStatus === "failed"
             ? "border-[color:color-mix(in_srgb,var(--vk-red)_55%,var(--vk-border))]"
             : "border-[var(--vk-border)]",
@@ -306,47 +330,70 @@ export function AppUpdateNotice() {
                 {update ? noticeTitle(update) : "Conductor update"}
               </h2>
             </div>
-            <p className="mt-2 text-[12px] leading-5 text-[var(--vk-text-muted)]">
-              {update ? noticeDescription(update) : "Checking for updates..."}
-            </p>
+            {compactNotice && !showDetailedBody ? null : (
+              <p className={cn(
+                "mt-2 text-[12px] leading-5 text-[var(--vk-text-muted)]",
+                compactNotice && !showDetailedBody && "line-clamp-2",
+              )}>
+                {update ? noticeDescription(update) : "Checking for updates..."}
+              </p>
+            )}
           </div>
-          <button
-            type="button"
-            onClick={handleDismiss}
-            className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-[7px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] hover:text-[var(--vk-text-normal)]"
-            aria-label="Dismiss update notice"
-          >
-            <X className="h-4 w-4" />
-          </button>
+          <div className="flex shrink-0 items-center gap-1.5">
+            {compactNotice ? (
+              <button
+                type="button"
+                onClick={() => setMobileExpanded((current) => !current)}
+                className="inline-flex min-h-[28px] items-center rounded-[7px] border border-[var(--vk-border)] px-2 text-[11px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] hover:text-[var(--vk-text-normal)]"
+              >
+                {showDetailedBody ? "Hide" : "Details"}
+              </button>
+            ) : null}
+            <button
+              type="button"
+              onClick={handleDismiss}
+              className="inline-flex h-7 w-7 items-center justify-center rounded-[7px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] hover:text-[var(--vk-text-normal)]"
+              aria-label="Dismiss update notice"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
         </div>
 
-        {update?.updateCommand ? (
-          <div className="mt-3 rounded-[10px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-3 py-2 font-mono text-[11px] leading-5 text-[var(--vk-text-muted)]">
-            {update.updateCommand}
-          </div>
+        {showDetailedBody ? (
+          <>
+            {update?.updateCommand ? (
+              <div className="mt-3 rounded-[10px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-3 py-2 font-mono text-[11px] leading-5 text-[var(--vk-text-muted)]">
+                {update.updateCommand}
+              </div>
+            ) : null}
+
+            {update ? (
+              <p className="mt-2 text-[11px] leading-5 text-[var(--vk-text-faint)]">
+                {installModeHint(update.installMode) ?? (update.restartRequired
+                  ? "Restart the current Conductor process after the installer completes."
+                  : "Update state streams from the running Conductor runtime.")}
+              </p>
+            ) : null}
+
+            {loadError ? (
+              <p className="mt-2 text-[11px] text-[var(--vk-red)]">{loadError}</p>
+            ) : update?.error ? (
+              <p className="mt-2 text-[11px] text-[var(--vk-red)]">{update.error}</p>
+            ) : null}
+
+            {update?.logsTail && update.jobStatus === "failed" ? (
+              <pre className="mt-2 max-h-32 overflow-auto rounded-[10px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] p-2 text-[10px] leading-4 text-[var(--vk-text-faint)]">
+                {update.logsTail}
+              </pre>
+            ) : null}
+          </>
         ) : null}
 
-        {update ? (
-          <p className="mt-2 text-[11px] leading-5 text-[var(--vk-text-faint)]">
-            {installModeHint(update.installMode) ?? (update.restartRequired
-              ? "Restart the current Conductor process after the installer completes."
-              : "Update state streams from the running Conductor runtime.")}
-          </p>
-        ) : null}
-
-        {loadError ? (
-          <p className="mt-2 text-[11px] text-[var(--vk-red)]">{loadError}</p>
-        ) : update?.error ? (
-          <p className="mt-2 text-[11px] text-[var(--vk-red)]">{update.error}</p>
-        ) : null}
-
-        {update?.logsTail && update.jobStatus === "failed" ? (
-          <pre className="mt-2 max-h-32 overflow-auto rounded-[10px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] p-2 text-[10px] leading-4 text-[var(--vk-text-faint)]">
-            {update.logsTail}
-          </pre>
-        ) : null}
-
-        <div className="mt-3 flex items-center justify-end gap-2">
+        <div className={cn(
+          "mt-3 flex items-center justify-end gap-2",
+          compactNotice && !showDetailedBody && "mt-2",
+        )}>
           {update?.jobStatus === "failed" && update.canAutoUpdate ? (
             <Button
               type="button"

--- a/packages/web/src/components/notes/NotesGraph.tsx
+++ b/packages/web/src/components/notes/NotesGraph.tsx
@@ -1,56 +1,159 @@
 "use client";
 
-import { useEffect, useRef, useState, useCallback } from "react";
-import { forceSimulation, forceLink, forceManyBody, forceCenter, forceCollide } from "d3-force";
-import type { GraphNode, GraphEdge } from "./types";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  forceCollide,
+  forceLink,
+  forceManyBody,
+  forceSimulation,
+  forceX,
+  forceY,
+} from "d3-force";
+import {
+  ArrowUpRight,
+  LocateFixed,
+  Network,
+  Search,
+  Settings2,
+  Sparkles,
+  ZoomIn,
+  ZoomOut,
+} from "lucide-react";
+
 import { withBridgeQuery } from "@/lib/bridgeQuery";
+
+import type { GraphEdge, GraphNode, NoteFile } from "./types";
+import {
+  buildNotesGraphIndex,
+  collectReachableNodes,
+  filterNotesGraph,
+  type NotesGraphEdgeRecord,
+  type NotesGraphNodeRecord,
+} from "./notesGraphModel";
 
 interface NotesGraphProps {
   projectId: string;
   bridgeId?: string | null;
   onNavigate: (path: string) => void;
+  noteFiles: NoteFile[];
+  selectedPath?: string | null;
 }
 
-interface SimNode extends GraphNode {
+interface SimNode extends NotesGraphNodeRecord {
   x: number;
   y: number;
-  fx?: number | null;
-  fy?: number | null;
 }
 
 interface SimEdge {
+  id: string;
   source: SimNode | string;
   target: SimNode | string;
 }
 
-const NODE_RADIUS = 6;
 const NOTES_GRAPH_SURFACE_CLASS_NAME = "flex h-full min-h-[min(560px,70dvh)] flex-col overflow-hidden bg-[var(--vk-bg-main)] xl:min-h-0";
-const COLORS = [
-  "#8b5cf6", // purple
-  "#06b6d4", // cyan
-  "#f59e0b", // amber
-  "#10b981", // green
-  "#ef4444", // red
-  "#ec4899", // pink
-  "#3b82f6", // blue
-  "#f97316", // orange
+const NOTES_GRAPH_PANEL_CLASS_NAME = "rounded-[14px] border border-[color:rgba(148,163,184,0.16)] bg-[linear-gradient(180deg,rgba(15,23,42,0.88),rgba(2,6,23,0.96))] shadow-[0_26px_80px_rgba(2,6,23,0.45)] backdrop-blur-sm";
+const NOTES_GRAPH_RANGE_CLASS_NAME = "h-1.5 w-full cursor-pointer accent-[var(--vk-accent)]";
+const NOTES_GRAPH_GROUP_COLORS = [
+  "#8b5cf6",
+  "#14b8a6",
+  "#f59e0b",
+  "#ef4444",
+  "#22c55e",
+  "#ec4899",
+  "#3b82f6",
+  "#f97316",
 ];
 
-function getNodeColor(path: string): string {
-  const depth = path.split("/").length - 1;
-  return COLORS[depth % COLORS.length];
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
 }
 
-export function NotesGraph({ projectId, bridgeId, onNavigate }: NotesGraphProps) {
-  const svgRef = useRef<SVGSVGElement>(null);
-  const [nodes, setNodes] = useState<SimNode[]>([]);
-  const [edges, setEdges] = useState<SimEdge[]>([]);
+function getFittedTransform(nodes: SimNode[], width: number, height: number): { x: number; y: number; k: number } {
+  if (nodes.length === 0 || width <= 0 || height <= 0) {
+    return { x: 0, y: 0, k: 1 };
+  }
+
+  let minX = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+
+  for (const node of nodes) {
+    minX = Math.min(minX, node.x);
+    maxX = Math.max(maxX, node.x);
+    minY = Math.min(minY, node.y);
+    maxY = Math.max(maxY, node.y);
+  }
+
+  const graphWidth = Math.max(maxX - minX, 120);
+  const graphHeight = Math.max(maxY - minY, 120);
+  const padding = Math.min(width, height) * 0.12;
+  const k = clamp(
+    Math.min((width - padding) / graphWidth, (height - padding) / graphHeight),
+    0.32,
+    2.4,
+  );
+  const centerX = (minX + maxX) / 2;
+  const centerY = (minY + maxY) / 2;
+
+  return {
+    x: -(centerX * k),
+    y: -(centerY * k),
+    k,
+  };
+}
+
+function getNodeRadius(node: NotesGraphNodeRecord, nodeSize: number): number {
+  return clamp(nodeSize + node.degree * 1.1, 5, 24);
+}
+
+function nodeMatchesSearch(node: NotesGraphNodeRecord, search: string): boolean {
+  const query = search.trim().toLowerCase();
+  if (!query) return false;
+  return [node.name, node.displayPath, node.folder, ...node.tags]
+    .join(" ")
+    .toLowerCase()
+    .includes(query);
+}
+
+export function NotesGraph({
+  projectId,
+  bridgeId,
+  onNavigate,
+  noteFiles,
+  selectedPath = null,
+}: NotesGraphProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const defaultsInitializedRef = useRef(false);
+  const panStateRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    originX: number;
+    originY: number;
+  } | null>(null);
+
+  const [rawNodes, setRawNodes] = useState<GraphNode[]>([]);
+  const [rawEdges, setRawEdges] = useState<GraphEdge[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [hoveredNode, setHoveredNode] = useState<string | null>(null);
+  const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
+  const [focusedNodeId, setFocusedNodeId] = useState<string | null>(selectedPath);
+  const [settingsOpen, setSettingsOpen] = useState(true);
+  const [search, setSearch] = useState("");
+  const [activeGroupId, setActiveGroupId] = useState<string | null>(null);
+  const [localGraphEnabled, setLocalGraphEnabled] = useState(false);
+  const [localDepth, setLocalDepth] = useState(1);
+  const [showLabels, setShowLabels] = useState(true);
+  const [showOrphans, setShowOrphans] = useState(true);
+  const [showArrows, setShowArrows] = useState(false);
+  const [nodeSize, setNodeSize] = useState(7);
+  const [linkThickness, setLinkThickness] = useState(1.15);
+  const [linkDistance, setLinkDistance] = useState(120);
+  const [repelForce, setRepelForce] = useState(220);
+  const [centerForce, setCenterForce] = useState(0.09);
   const [transform, setTransform] = useState({ x: 0, y: 0, k: 1 });
-  const isPanning = useRef(false);
-  const lastMouse = useRef({ x: 0, y: 0 });
+  const [viewport, setViewport] = useState({ width: 0, height: 0 });
 
   const fetchGraph = useCallback(async () => {
     setLoading(true);
@@ -76,44 +179,12 @@ export function NotesGraph({ projectId, bridgeId, onNavigate }: NotesGraphProps)
       }
 
       const graphData = payload as { nodes: GraphNode[]; edges: GraphEdge[] };
-
-      // Initialize node positions
-      const simNodes: SimNode[] = graphData.nodes.map((n, i) => ({
-        ...n,
-        x: Math.cos((i / graphData.nodes.length) * 2 * Math.PI) * 200,
-        y: Math.sin((i / graphData.nodes.length) * 2 * Math.PI) * 200,
-      }));
-
-      const simEdges: SimEdge[] = graphData.edges.map((e) => ({
-        source: e.source,
-        target: e.target,
-      }));
-
-      setNodes(simNodes);
-      setEdges(simEdges);
-
-      // Run simulation
-      const simulation = forceSimulation<SimNode>(simNodes)
-        .force(
-          "link",
-          forceLink<SimNode, SimEdge>(simEdges)
-            .id((d) => d.id)
-            .distance(80),
-        )
-        .force("charge", forceManyBody().strength(-120))
-        .force("center", forceCenter(0, 0))
-        .force("collide", forceCollide(NODE_RADIUS * 2.5))
-        .stop();
-
-      // Run synchronously for 300 ticks
-      for (let i = 0; i < 300; i++) {
-        simulation.tick();
-      }
-
-      setNodes([...simNodes]);
-      setEdges([...simEdges]);
+      setRawNodes(graphData.nodes ?? []);
+      setRawEdges(graphData.edges ?? []);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load graph");
+      setRawNodes([]);
+      setRawEdges([]);
     } finally {
       setLoading(false);
     }
@@ -123,50 +194,252 @@ export function NotesGraph({ projectId, bridgeId, onNavigate }: NotesGraphProps)
     void fetchGraph();
   }, [fetchGraph]);
 
-  // Pan handlers
-  const handleMouseDown = useCallback(
-    (e: React.MouseEvent<SVGSVGElement>) => {
-      if (e.button === 0) {
-        isPanning.current = true;
-        lastMouse.current = { x: e.clientX, y: e.clientY };
-      }
-    },
-    [],
-  );
+  useEffect(() => {
+    if (selectedPath) {
+      setFocusedNodeId(selectedPath);
+    }
+  }, [selectedPath]);
 
-  const handleMouseMove = useCallback(
-    (e: React.MouseEvent<SVGSVGElement>) => {
-      if (isPanning.current) {
-        const dx = e.clientX - lastMouse.current.x;
-        const dy = e.clientY - lastMouse.current.y;
-        lastMouse.current = { x: e.clientX, y: e.clientY };
-        setTransform((prev) => ({
-          x: prev.x + dx,
-          y: prev.y + dy,
-          k: prev.k,
-        }));
-      }
-    },
-    [],
-  );
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
 
-  const handleMouseUp = useCallback(() => {
-    isPanning.current = false;
+    const syncViewport = () => {
+      setViewport({
+        width: container.clientWidth,
+        height: container.clientHeight,
+      });
+    };
+
+    syncViewport();
+    const observer = typeof ResizeObserver === "undefined"
+      ? null
+      : new ResizeObserver(syncViewport);
+    observer?.observe(container);
+    return () => observer?.disconnect();
   }, []);
 
-  const handleWheel = useCallback((e: React.WheelEvent<SVGSVGElement>) => {
-    e.preventDefault();
-    const delta = e.deltaY > 0 ? 0.9 : 1.1;
-    setTransform((prev) => ({
-      x: prev.x,
-      y: prev.y,
-      k: Math.max(0.2, Math.min(4, prev.k * delta)),
+  useEffect(() => {
+    if (defaultsInitializedRef.current || viewport.width <= 0) return;
+    const compactGraphViewport = viewport.width < 960;
+    setSettingsOpen(!compactGraphViewport);
+    setShowLabels(!compactGraphViewport);
+    defaultsInitializedRef.current = true;
+  }, [viewport.width]);
+
+  const graphIndex = useMemo(
+    () => buildNotesGraphIndex(rawNodes, rawEdges, noteFiles),
+    [noteFiles, rawEdges, rawNodes],
+  );
+
+  const groupColorById = useMemo(
+    () => new Map(graphIndex.groups.map((group) => [group.id, group.color])),
+    [graphIndex.groups],
+  );
+
+  const prefilteredGraph = useMemo(
+    () =>
+      filterNotesGraph(graphIndex, {
+        search,
+        showOrphans,
+        activeGroupId,
+        localRootId: null,
+        localDepth,
+      }),
+    [activeGroupId, graphIndex, localDepth, search, showOrphans],
+  );
+
+  const effectiveLocalRootId = useMemo(() => {
+    if (!localGraphEnabled) return null;
+    if (focusedNodeId && prefilteredGraph.nodes.some((node) => node.id === focusedNodeId)) {
+      return focusedNodeId;
+    }
+    if (selectedPath && prefilteredGraph.nodes.some((node) => node.id === selectedPath)) {
+      return selectedPath;
+    }
+    return prefilteredGraph.nodes[0]?.id ?? null;
+  }, [focusedNodeId, localGraphEnabled, prefilteredGraph.nodes, selectedPath]);
+
+  const visibleGraph = useMemo(() => {
+    if (!localGraphEnabled || !effectiveLocalRootId) {
+      return prefilteredGraph;
+    }
+    return filterNotesGraph(graphIndex, {
+      search,
+      showOrphans,
+      activeGroupId,
+      localRootId: effectiveLocalRootId,
+      localDepth,
+    });
+  }, [
+    activeGroupId,
+    effectiveLocalRootId,
+    graphIndex,
+    localDepth,
+    localGraphEnabled,
+    prefilteredGraph,
+    search,
+    showOrphans,
+  ]);
+
+  useEffect(() => {
+    if (focusedNodeId && visibleGraph.nodes.some((node) => node.id === focusedNodeId)) {
+      return;
+    }
+    if (selectedPath && visibleGraph.nodes.some((node) => node.id === selectedPath)) {
+      setFocusedNodeId(selectedPath);
+      return;
+    }
+    setFocusedNodeId(visibleGraph.nodes[0]?.id ?? null);
+  }, [focusedNodeId, selectedPath, visibleGraph.nodes]);
+
+  const activeNodeId = hoveredNodeId ?? focusedNodeId ?? effectiveLocalRootId;
+  const highlightedNodeIds = useMemo(() => {
+    if (!activeNodeId) return null;
+    return collectReachableNodes(graphIndex, activeNodeId, 1);
+  }, [activeNodeId, graphIndex]);
+
+  const layout = useMemo(() => {
+    const groupOrder = new Map(graphIndex.groups.map((group, index) => [group.id, index]));
+    const groupCount = Math.max(graphIndex.groups.length, 1);
+
+    const simNodes: SimNode[] = visibleGraph.nodes.map((node, index) => {
+      const groupIndexForNode = groupOrder.get(node.folder) ?? 0;
+      const angle = (groupIndexForNode / groupCount) * Math.PI * 2 + (index % 9) * 0.37;
+      const radius = 180 + (index % 11) * 16;
+      return {
+        ...node,
+        x: Math.cos(angle) * radius,
+        y: Math.sin(angle) * radius,
+      };
+    });
+
+    const simEdges: SimEdge[] = visibleGraph.edges.map((edge) => ({
+      id: edge.id,
+      source: edge.source,
+      target: edge.target,
     }));
+
+    const simulation = forceSimulation<SimNode>(simNodes)
+      .force(
+        "link",
+        forceLink<SimNode, SimEdge>(simEdges)
+          .id((node) => node.id)
+          .distance(linkDistance)
+          .strength(0.32),
+      )
+      .force("charge", forceManyBody<SimNode>().strength(-repelForce))
+      .force("center-x", forceX<SimNode>(0).strength(centerForce))
+      .force("center-y", forceY<SimNode>(0).strength(centerForce))
+      .force("collide", forceCollide<SimNode>((node) => getNodeRadius(node, nodeSize) + 8))
+      .stop();
+
+    for (let tick = 0; tick < 220; tick += 1) {
+      simulation.tick();
+    }
+
+    const edges: NotesGraphEdgeRecord[] = simEdges
+      .map((edge) => {
+        const source = typeof edge.source === "object" ? edge.source : simNodes.find((node) => node.id === edge.source);
+        const target = typeof edge.target === "object" ? edge.target : simNodes.find((node) => node.id === edge.target);
+        if (!source || !target) return null;
+        return {
+          id: edge.id,
+          source: source.id,
+          target: target.id,
+        };
+      })
+      .filter((edge): edge is NotesGraphEdgeRecord => edge !== null);
+
+    return { nodes: simNodes, edges };
+  }, [
+    centerForce,
+    graphIndex.groups,
+    linkDistance,
+    nodeSize,
+    repelForce,
+    visibleGraph.edges,
+    visibleGraph.nodes,
+  ]);
+
+  useEffect(() => {
+    setTransform(getFittedTransform(layout.nodes, viewport.width, viewport.height));
+  }, [layout.nodes, viewport.height, viewport.width]);
+
+  const searchMatches = useMemo(
+    () => new Set(visibleGraph.nodes.filter((node) => nodeMatchesSearch(node, search)).map((node) => node.id)),
+    [search, visibleGraph.nodes],
+  );
+
+  const focusedNode = layout.nodes.find((node) => node.id === focusedNodeId) ?? null;
+  const visibleNodeCount = layout.nodes.length;
+  const visibleEdgeCount = layout.edges.length;
+  const compactGraphViewport = viewport.width > 0 && viewport.width < 960;
+  const labelVisibilityThreshold = compactGraphViewport ? 1.32 : 0.9;
+
+  const zoomAtPoint = useCallback((nextScale: number, clientX?: number, clientY?: number) => {
+    setTransform((current) => {
+      const k = clamp(nextScale, 0.28, 3.4);
+      const container = containerRef.current;
+      if (!container) {
+        return { ...current, k };
+      }
+      const rect = container.getBoundingClientRect();
+      const screenX = clientX == null ? rect.width / 2 : clientX - rect.left;
+      const screenY = clientY == null ? rect.height / 2 : clientY - rect.top;
+      const centerX = rect.width / 2;
+      const centerY = rect.height / 2;
+      const worldX = (screenX - centerX - current.x) / current.k;
+      const worldY = (screenY - centerY - current.y) / current.k;
+      return {
+        x: screenX - centerX - worldX * k,
+        y: screenY - centerY - worldY * k,
+        k,
+      };
+    });
+  }, []);
+
+  const handleWheel = useCallback((event: React.WheelEvent<SVGSVGElement>) => {
+    event.preventDefault();
+    const nextScale = event.deltaY > 0 ? transform.k * 0.9 : transform.k * 1.1;
+    zoomAtPoint(nextScale, event.clientX, event.clientY);
+  }, [transform.k, zoomAtPoint]);
+
+  const handleStartPan = useCallback((event: React.PointerEvent<SVGRectElement>) => {
+    if (event.button !== 0 && event.pointerType !== "touch") return;
+    panStateRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      originX: transform.x,
+      originY: transform.y,
+    };
+    event.currentTarget.setPointerCapture(event.pointerId);
+  }, [transform.x, transform.y]);
+
+  const handlePointerMove = useCallback((event: React.PointerEvent<SVGSVGElement>) => {
+    const panState = panStateRef.current;
+    if (!panState || panState.pointerId !== event.pointerId) return;
+    setTransform((current) => ({
+      ...current,
+      x: panState.originX + (event.clientX - panState.startX),
+      y: panState.originY + (event.clientY - panState.startY),
+    }));
+  }, []);
+
+  const handleStopPan = useCallback((event: React.PointerEvent<SVGSVGElement | SVGRectElement>) => {
+    const panState = panStateRef.current;
+    if (!panState || panState.pointerId !== event.pointerId) return;
+    panStateRef.current = null;
+    if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
   }, []);
 
   if (loading) {
     return (
       <div className="flex h-full items-center justify-center gap-2 text-[13px] text-[var(--vk-text-muted)]">
+        <Sparkles className="h-4 w-4 animate-pulse text-[var(--vk-accent)]" />
         Loading graph…
       </div>
     );
@@ -174,111 +447,455 @@ export function NotesGraph({ projectId, bridgeId, onNavigate }: NotesGraphProps)
 
   if (error) {
     return (
-      <div className="flex h-full items-center justify-center text-[13px] text-[var(--vk-red)]">
+      <div className="flex h-full items-center justify-center px-4 text-center text-[13px] text-[var(--vk-red)]">
         {error}
       </div>
     );
   }
 
-  if (nodes.length === 0) {
-    return (
-      <div className="flex h-full items-center justify-center text-[13px] text-[var(--vk-text-muted)]">
-        No notes to graph
-      </div>
-    );
-  }
-
-  const svgWidth = 800;
-  const svgHeight = 600;
-  const centerX = svgWidth / 2 + transform.x;
-  const centerY = svgHeight / 2 + transform.y;
-
   return (
     <div className={NOTES_GRAPH_SURFACE_CLASS_NAME}>
-      {/* Header */}
       <div className="flex items-center justify-between border-b border-[var(--vk-border)] px-4 py-2">
-        <span className="text-[12px] text-[var(--vk-text-muted)]">
-          {nodes.length} notes · {edges.length} links
-        </span>
-        <button
-          type="button"
-          onClick={() => void fetchGraph()}
-          className="text-[12px] text-[var(--vk-text-muted)] hover:text-[var(--vk-text-normal)]"
-        >
-          Refresh
-        </button>
+        <div>
+          <p className="text-[13px] font-medium text-[var(--vk-text-strong)]">Obsidian-style graph</p>
+          <p className="text-[11px] text-[var(--vk-text-muted)]">
+            {visibleNodeCount} visible notes, {visibleEdgeCount} visible links
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setSettingsOpen((current) => !current)}
+            className="inline-flex min-h-[32px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-2.5 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)]"
+          >
+            <Settings2 className="h-3.5 w-3.5" />
+            Settings
+          </button>
+          <button
+            type="button"
+            onClick={() => void fetchGraph()}
+            className="inline-flex min-h-[32px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-2.5 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)]"
+          >
+            <Network className="h-3.5 w-3.5" />
+            Refresh
+          </button>
+        </div>
       </div>
 
-      {/* SVG */}
-      <div className="min-h-0 flex-1 overflow-hidden">
-        <svg
-          ref={svgRef}
-          width="100%"
-          height="100%"
-          viewBox={`0 0 ${svgWidth} ${svgHeight}`}
-          onMouseDown={handleMouseDown}
-          onMouseMove={handleMouseMove}
-          onMouseUp={handleMouseUp}
-          onMouseLeave={handleMouseUp}
-          onWheel={handleWheel}
-          style={{ cursor: isPanning.current ? "grabbing" : "grab" }}
-        >
-          <g transform={`translate(${centerX}, ${centerY}) scale(${transform.k})`}>
-            {/* Edges */}
-            {edges.map((edge, idx) => {
-              const source = typeof edge.source === "object" ? edge.source : null;
-              const target = typeof edge.target === "object" ? edge.target : null;
-              if (!source || !target) return null;
-              return (
-                <line
-                  key={`edge-${idx}`}
-                  x1={source.x}
-                  y1={source.y}
-                  x2={target.x}
-                  y2={target.y}
-                  stroke="var(--vk-border)"
-                  strokeWidth={1}
-                  opacity={0.6}
+      <div className="grid min-h-0 flex-1 gap-3 overflow-hidden p-3 xl:grid-cols-[320px_minmax(0,1fr)]">
+        {settingsOpen ? (
+          <aside className={`${NOTES_GRAPH_PANEL_CLASS_NAME} min-h-0 overflow-auto px-4 py-4`}>
+            <section>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--vk-text-muted)]">
+                Search files
+              </p>
+              <label className="mt-2 flex items-center gap-2 rounded-[10px] border border-[color:rgba(148,163,184,0.16)] bg-black/20 px-3 py-2">
+                <Search className="h-4 w-4 text-[var(--vk-text-muted)]" />
+                <input
+                  value={search}
+                  onChange={(event) => setSearch(event.target.value)}
+                  placeholder="Search files, folders, or tags"
+                  className="min-w-0 flex-1 bg-transparent text-[13px] text-[var(--vk-text-normal)] outline-none placeholder:text-[var(--vk-text-muted)]"
                 />
-              );
-            })}
+              </label>
+            </section>
 
-            {/* Nodes */}
-            {nodes.map((node) => {
-              const color = getNodeColor(node.id);
-              const isHovered = hoveredNode === node.id;
-              return (
-                <g
-                  key={node.id}
-                  transform={`translate(${node.x}, ${node.y})`}
-                  onClick={() => onNavigate(node.id)}
-                  onMouseEnter={() => setHoveredNode(node.id)}
-                  onMouseLeave={() => setHoveredNode(null)}
-                  style={{ cursor: "pointer" }}
-                >
-                  <circle
-                    r={isHovered ? NODE_RADIUS * 1.5 : NODE_RADIUS}
-                    fill={color}
-                    stroke={isHovered ? "var(--vk-text-strong)" : "transparent"}
-                    strokeWidth={isHovered ? 2 : 0}
-                    opacity={0.85}
-                  />
-                  {(isHovered || transform.k > 1.2) && (
-                    <text
-                      x={NODE_RADIUS + 4}
-                      y={4}
-                      fontSize={10}
-                      fill="var(--vk-text-normal)"
-                      style={{ pointerEvents: "none" }}
+            <section className="mt-5">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--vk-text-muted)]">
+                  Groups
+                </p>
+                {activeGroupId ? (
+                  <button
+                    type="button"
+                    onClick={() => setActiveGroupId(null)}
+                    className="text-[11px] text-[var(--vk-accent)] hover:underline"
+                  >
+                    Clear
+                  </button>
+                ) : null}
+              </div>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {graphIndex.groups.map((group) => {
+                  const active = activeGroupId === group.id;
+                  return (
+                    <button
+                      key={group.id}
+                      type="button"
+                      onClick={() => setActiveGroupId(active ? null : group.id)}
+                      className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-[11px] ${
+                        active
+                          ? "border-[var(--vk-accent)] bg-[rgba(139,92,246,0.16)] text-[var(--vk-text-strong)]"
+                          : "border-[color:rgba(148,163,184,0.16)] bg-black/20 text-[var(--vk-text-muted)] hover:bg-[rgba(255,255,255,0.04)]"
+                      }`}
                     >
-                      {node.name}
-                    </text>
-                  )}
+                      <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: group.color }} />
+                      <span>{group.label}</span>
+                      <span className="opacity-70">{group.count}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </section>
+
+            <section className="mt-5 space-y-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--vk-text-muted)]">
+                Local graph
+              </p>
+              <label className="flex items-center justify-between gap-3 rounded-[10px] border border-[color:rgba(148,163,184,0.16)] bg-black/20 px-3 py-2 text-[13px] text-[var(--vk-text-normal)]">
+                <span>Focus on the active note neighborhood</span>
+                <input
+                  checked={localGraphEnabled}
+                  onChange={(event) => setLocalGraphEnabled(event.target.checked)}
+                  type="checkbox"
+                  className="h-4 w-4 accent-[var(--vk-accent)]"
+                />
+              </label>
+              <label className="block text-[12px] text-[var(--vk-text-muted)]">
+                <span className="flex items-center justify-between">
+                  <span>Depth</span>
+                  <span>{localDepth}</span>
+                </span>
+                <input
+                  type="range"
+                  min={1}
+                  max={4}
+                  step={1}
+                  value={localDepth}
+                  onChange={(event) => setLocalDepth(Number(event.target.value))}
+                  className={`${NOTES_GRAPH_RANGE_CLASS_NAME} mt-2`}
+                />
+              </label>
+              <p className="rounded-[10px] border border-[color:rgba(148,163,184,0.12)] bg-black/10 px-3 py-2 text-[11px] leading-5 text-[var(--vk-text-muted)]">
+                {effectiveLocalRootId
+                  ? `Rooting around ${graphIndex.nodesById.get(effectiveLocalRootId)?.displayPath ?? effectiveLocalRootId}.`
+                  : "Pick a note to use local graph depth controls."}
+              </p>
+            </section>
+
+            <section className="mt-5 space-y-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--vk-text-muted)]">
+                Display
+              </p>
+              <label className="flex items-center justify-between gap-3 rounded-[10px] border border-[color:rgba(148,163,184,0.16)] bg-black/20 px-3 py-2 text-[13px] text-[var(--vk-text-normal)]">
+                <span>Labels</span>
+                <input
+                  checked={showLabels}
+                  onChange={(event) => setShowLabels(event.target.checked)}
+                  type="checkbox"
+                  className="h-4 w-4 accent-[var(--vk-accent)]"
+                />
+              </label>
+              <label className="flex items-center justify-between gap-3 rounded-[10px] border border-[color:rgba(148,163,184,0.16)] bg-black/20 px-3 py-2 text-[13px] text-[var(--vk-text-normal)]">
+                <span>Arrows</span>
+                <input
+                  checked={showArrows}
+                  onChange={(event) => setShowArrows(event.target.checked)}
+                  type="checkbox"
+                  className="h-4 w-4 accent-[var(--vk-accent)]"
+                />
+              </label>
+              <label className="flex items-center justify-between gap-3 rounded-[10px] border border-[color:rgba(148,163,184,0.16)] bg-black/20 px-3 py-2 text-[13px] text-[var(--vk-text-normal)]">
+                <span>Show orphans</span>
+                <input
+                  checked={showOrphans}
+                  onChange={(event) => setShowOrphans(event.target.checked)}
+                  type="checkbox"
+                  className="h-4 w-4 accent-[var(--vk-accent)]"
+                />
+              </label>
+              <label className="block text-[12px] text-[var(--vk-text-muted)]">
+                <span className="flex items-center justify-between">
+                  <span>Node size</span>
+                  <span>{nodeSize.toFixed(0)}</span>
+                </span>
+                <input
+                  type="range"
+                  min={5}
+                  max={14}
+                  step={1}
+                  value={nodeSize}
+                  onChange={(event) => setNodeSize(Number(event.target.value))}
+                  className={`${NOTES_GRAPH_RANGE_CLASS_NAME} mt-2`}
+                />
+              </label>
+              <label className="block text-[12px] text-[var(--vk-text-muted)]">
+                <span className="flex items-center justify-between">
+                  <span>Link thickness</span>
+                  <span>{linkThickness.toFixed(1)}</span>
+                </span>
+                <input
+                  type="range"
+                  min={0.6}
+                  max={3}
+                  step={0.1}
+                  value={linkThickness}
+                  onChange={(event) => setLinkThickness(Number(event.target.value))}
+                  className={`${NOTES_GRAPH_RANGE_CLASS_NAME} mt-2`}
+                />
+              </label>
+            </section>
+
+            <section className="mt-5 space-y-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--vk-text-muted)]">
+                Forces
+              </p>
+              <label className="block text-[12px] text-[var(--vk-text-muted)]">
+                <span className="flex items-center justify-between">
+                  <span>Link distance</span>
+                  <span>{linkDistance.toFixed(0)}</span>
+                </span>
+                <input
+                  type="range"
+                  min={70}
+                  max={220}
+                  step={5}
+                  value={linkDistance}
+                  onChange={(event) => setLinkDistance(Number(event.target.value))}
+                  className={`${NOTES_GRAPH_RANGE_CLASS_NAME} mt-2`}
+                />
+              </label>
+              <label className="block text-[12px] text-[var(--vk-text-muted)]">
+                <span className="flex items-center justify-between">
+                  <span>Repel force</span>
+                  <span>{repelForce.toFixed(0)}</span>
+                </span>
+                <input
+                  type="range"
+                  min={120}
+                  max={460}
+                  step={10}
+                  value={repelForce}
+                  onChange={(event) => setRepelForce(Number(event.target.value))}
+                  className={`${NOTES_GRAPH_RANGE_CLASS_NAME} mt-2`}
+                />
+              </label>
+              <label className="block text-[12px] text-[var(--vk-text-muted)]">
+                <span className="flex items-center justify-between">
+                  <span>Center force</span>
+                  <span>{centerForce.toFixed(2)}</span>
+                </span>
+                <input
+                  type="range"
+                  min={0.02}
+                  max={0.2}
+                  step={0.01}
+                  value={centerForce}
+                  onChange={(event) => setCenterForce(Number(event.target.value))}
+                  className={`${NOTES_GRAPH_RANGE_CLASS_NAME} mt-2`}
+                />
+              </label>
+            </section>
+
+            {focusedNode ? (
+              <section className="mt-5">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--vk-text-muted)]">
+                  Selected note
+                </p>
+                <div className="mt-2 rounded-[12px] border border-[color:rgba(148,163,184,0.16)] bg-black/25 p-3">
+                  <p className="text-[13px] font-medium text-[var(--vk-text-strong)]">{focusedNode.name}</p>
+                  <p className="mt-1 break-all text-[11px] text-[var(--vk-text-muted)]">{focusedNode.displayPath}</p>
+                  <p className="mt-2 text-[11px] text-[var(--vk-text-muted)]">
+                    {focusedNode.degree} connections{focusedNode.tags.length > 0 ? ` · #${focusedNode.tags.join(" #")}` : ""}
+                  </p>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() => onNavigate(focusedNode.id)}
+                      className="inline-flex min-h-[32px] items-center gap-1.5 rounded-[8px] border border-[var(--vk-accent)] bg-[rgba(139,92,246,0.16)] px-3 text-[12px] text-[var(--vk-text-strong)] hover:bg-[rgba(139,92,246,0.22)]"
+                    >
+                      <ArrowUpRight className="h-3.5 w-3.5" />
+                      Open note
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setFocusedNodeId(focusedNode.id);
+                        setLocalGraphEnabled(true);
+                      }}
+                      className="inline-flex min-h-[32px] items-center gap-1.5 rounded-[8px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)]"
+                    >
+                      <LocateFixed className="h-3.5 w-3.5" />
+                      Use as local root
+                    </button>
+                  </div>
+                </div>
+              </section>
+            ) : null}
+          </aside>
+        ) : null}
+
+        <div className="relative min-h-[420px] min-w-0 overflow-hidden rounded-[16px] border border-[color:rgba(148,163,184,0.14)] bg-[radial-gradient(circle_at_top,rgba(30,41,59,0.96),rgba(2,6,23,0.98))] shadow-[0_30px_90px_rgba(2,6,23,0.52)]">
+          <div className="absolute left-3 top-3 z-10 flex flex-wrap gap-2">
+            <span className="rounded-full border border-[color:rgba(148,163,184,0.16)] bg-black/30 px-2.5 py-1 text-[11px] text-[var(--vk-text-muted)]">
+              {graphIndex.nodes.length} total notes
+            </span>
+            {localGraphEnabled ? (
+              <span className="rounded-full border border-[color:rgba(139,92,246,0.24)] bg-[rgba(139,92,246,0.16)] px-2.5 py-1 text-[11px] text-[var(--vk-text-strong)]">
+                Local graph depth {localDepth}
+              </span>
+            ) : null}
+            {search ? (
+              <span className="rounded-full border border-[color:rgba(56,189,248,0.24)] bg-[rgba(56,189,248,0.16)] px-2.5 py-1 text-[11px] text-[var(--vk-text-strong)]">
+                Search: {search}
+              </span>
+            ) : null}
+          </div>
+
+          <div className="absolute right-3 top-3 z-10 flex items-center gap-2">
+            <button
+              type="button"
+              title="Zoom out"
+              aria-label="Zoom out"
+              onClick={() => zoomAtPoint(transform.k * 0.88)}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-[color:rgba(148,163,184,0.16)] bg-black/35 text-[var(--vk-text-normal)] hover:bg-black/55"
+            >
+              <ZoomOut className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              title="Zoom in"
+              aria-label="Zoom in"
+              onClick={() => zoomAtPoint(transform.k * 1.12)}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-[color:rgba(148,163,184,0.16)] bg-black/35 text-[var(--vk-text-normal)] hover:bg-black/55"
+            >
+              <ZoomIn className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              title="Fit graph"
+              aria-label="Fit graph"
+              onClick={() => setTransform(getFittedTransform(layout.nodes, viewport.width, viewport.height))}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-[color:rgba(148,163,184,0.16)] bg-black/35 text-[var(--vk-text-normal)] hover:bg-black/55"
+            >
+              <LocateFixed className="h-4 w-4" />
+            </button>
+          </div>
+
+          {compactGraphViewport ? null : (
+            <div className="absolute bottom-3 left-3 z-10 rounded-[10px] border border-[color:rgba(148,163,184,0.14)] bg-black/35 px-3 py-2 text-[11px] leading-5 text-[var(--vk-text-muted)] backdrop-blur-sm">
+              Hover to highlight neighbors, drag the canvas to pan, double-click a node to open its note.
+            </div>
+          )}
+
+          <div ref={containerRef} className="h-full w-full touch-none">
+            {visibleNodeCount === 0 ? (
+              <div className="flex h-full items-center justify-center px-6 text-center text-[13px] text-[var(--vk-text-muted)]">
+                No notes match the current graph filters. Clear the search or group filter to widen the graph.
+              </div>
+            ) : (
+              <svg
+                width="100%"
+                height="100%"
+                viewBox={`0 0 ${Math.max(viewport.width, 900)} ${Math.max(viewport.height, 620)}`}
+                onPointerMove={handlePointerMove}
+                onPointerUp={handleStopPan}
+                onPointerCancel={handleStopPan}
+                onWheel={handleWheel}
+                className="h-full w-full"
+              >
+                <defs>
+                  <marker
+                    id="notes-graph-arrow"
+                    viewBox="0 0 10 10"
+                    refX="8"
+                    refY="5"
+                    markerWidth="6"
+                    markerHeight="6"
+                    orient="auto-start-reverse"
+                  >
+                    <path d="M 0 0 L 10 5 L 0 10 z" fill="rgba(148,163,184,0.55)" />
+                  </marker>
+                  <filter id="notes-graph-node-glow" x="-120%" y="-120%" width="340%" height="340%">
+                    <feGaussianBlur stdDeviation="3.4" result="blur" />
+                    <feMerge>
+                      <feMergeNode in="blur" />
+                      <feMergeNode in="SourceGraphic" />
+                    </feMerge>
+                  </filter>
+                </defs>
+                <rect
+                  x={0}
+                  y={0}
+                  width="100%"
+                  height="100%"
+                  fill="transparent"
+                  onPointerDown={handleStartPan}
+                  onPointerUp={handleStopPan}
+                  onPointerCancel={handleStopPan}
+                />
+                <g
+                  transform={`translate(${Math.max(viewport.width, 900) / 2 + transform.x}, ${Math.max(viewport.height, 620) / 2 + transform.y}) scale(${transform.k})`}
+                >
+                  {layout.edges.map((edge) => {
+                    const source = layout.nodes.find((node) => node.id === edge.source);
+                    const target = layout.nodes.find((node) => node.id === edge.target);
+                    if (!source || !target) return null;
+                    const edgeHighlighted = !highlightedNodeIds
+                      || (highlightedNodeIds.has(edge.source) && highlightedNodeIds.has(edge.target));
+                    return (
+                      <line
+                        key={edge.id}
+                        x1={source.x}
+                        y1={source.y}
+                        x2={target.x}
+                        y2={target.y}
+                        stroke="rgba(148,163,184,0.72)"
+                        strokeOpacity={edgeHighlighted ? 0.58 : 0.12}
+                        strokeWidth={linkThickness}
+                        markerEnd={showArrows ? "url(#notes-graph-arrow)" : undefined}
+                      />
+                    );
+                  })}
+                  {layout.nodes.map((node) => {
+                    const radius = getNodeRadius(node, nodeSize);
+                    const color = groupColorById.get(node.folder) ?? NOTES_GRAPH_GROUP_COLORS[0];
+                    const connectedToActive = !highlightedNodeIds || highlightedNodeIds.has(node.id);
+                    const matchesSearch = searchMatches.size === 0 || searchMatches.has(node.id);
+                    const selected = focusedNodeId === node.id;
+                    const labelVisible = showLabels && (selected || hoveredNodeId === node.id || transform.k >= labelVisibilityThreshold);
+                    return (
+                      <g
+                        key={node.id}
+                        transform={`translate(${node.x}, ${node.y})`}
+                        onClick={() => setFocusedNodeId(node.id)}
+                        onDoubleClick={() => onNavigate(node.id)}
+                        onMouseEnter={() => setHoveredNodeId(node.id)}
+                        onMouseLeave={() => setHoveredNodeId(null)}
+                        style={{ cursor: "pointer" }}
+                      >
+                        <circle
+                          r={radius + 2}
+                          fill={color}
+                          opacity={connectedToActive ? 0.18 : 0.05}
+                          filter="url(#notes-graph-node-glow)"
+                        />
+                        <circle
+                          r={radius}
+                          fill={color}
+                          opacity={connectedToActive ? (matchesSearch ? 0.92 : 0.66) : 0.16}
+                          stroke={selected ? "rgba(248,250,252,0.95)" : "rgba(15,23,42,0.9)"}
+                          strokeWidth={selected ? 2.4 : 1.1}
+                        />
+                        {labelVisible ? (
+                          <text
+                            x={radius + 6}
+                            y={4}
+                            fontSize={11}
+                            fill="rgba(226,232,240,0.94)"
+                            style={{ pointerEvents: "none", userSelect: "none" }}
+                          >
+                            {node.displayPath}
+                          </text>
+                        ) : null}
+                      </g>
+                    );
+                  })}
                 </g>
-              );
-            })}
-          </g>
-        </svg>
+              </svg>
+            )}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/packages/web/src/components/notes/NotesSidebar.tsx
+++ b/packages/web/src/components/notes/NotesSidebar.tsx
@@ -23,6 +23,7 @@ interface NotesSidebarProps {
   editorLabel?: string;
   tags?: TagMap;
   onTagClick?: (tag: string) => void;
+  className?: string;
 }
 
 const NOTES_SIDEBAR_CLASS_NAME = "flex min-h-0 max-h-[min(42dvh,360px)] flex-col border-b border-[var(--vk-border)] bg-[var(--vk-bg-panel)]/35 xl:max-h-none xl:border-b-0 xl:border-r";
@@ -115,6 +116,7 @@ export function NotesSidebar({
   editorLabel,
   tags,
   onTagClick,
+  className,
 }: NotesSidebarProps) {
   const [tagsExpanded, setTagsExpanded] = useState(true);
 
@@ -140,7 +142,7 @@ export function NotesSidebar({
   );
 
   return (
-    <aside className={NOTES_SIDEBAR_CLASS_NAME}>
+    <aside className={`${NOTES_SIDEBAR_CLASS_NAME} ${className ?? ""}`.trim()}>
       {/* Search + header */}
       <div className="flex items-center justify-between border-b border-[var(--vk-border)] px-3 py-2 text-[12px] text-[var(--vk-text-muted)]">
         <span>

--- a/packages/web/src/components/notes/NotesToolbar.tsx
+++ b/packages/web/src/components/notes/NotesToolbar.tsx
@@ -1,14 +1,19 @@
 "use client";
 
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import {
+  CalendarDays,
   ExternalLink,
+  FolderOpen,
   Loader2,
+  MoreHorizontal,
   Network,
   RefreshCcw,
   Save,
+  Send,
   TriangleAlert,
-  CalendarDays,
 } from "lucide-react";
+
 import type { ViewMode } from "./types";
 
 interface NotesToolbarProps {
@@ -28,6 +33,47 @@ interface NotesToolbarProps {
   fileTruncated: boolean;
   editorName?: string;
   canSave?: boolean;
+  compact?: boolean;
+  onOpenFiles?: () => void;
+  onOpenShare?: () => void;
+}
+
+const BUTTON_CLASS_NAME = "inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-60";
+const SEGMENT_CLASS_NAME = "inline-flex rounded-[6px] border border-[var(--vk-border)] p-0.5 text-[12px]";
+const MENU_CONTENT_CLASS_NAME = "z-[120] min-w-[190px] rounded-[10px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] p-1 shadow-[0_20px_48px_rgba(0,0,0,0.35)]";
+const MENU_ITEM_CLASS_NAME = "flex min-h-[36px] cursor-default items-center gap-2 rounded-[6px] px-3 text-[12px] text-[var(--vk-text-normal)] outline-none hover:bg-[var(--vk-bg-hover)] focus:bg-[var(--vk-bg-hover)] data-[disabled]:pointer-events-none data-[disabled]:opacity-45";
+
+function ViewModeSwitcher({
+  compact,
+  viewMode,
+  onViewModeChange,
+}: {
+  compact: boolean;
+  viewMode: ViewMode;
+  onViewModeChange: (mode: ViewMode) => void;
+}) {
+  const options = compact
+    ? (["edit", "preview"] as ViewMode[])
+    : (["split", "edit", "preview"] as ViewMode[]);
+
+  return (
+    <div className={SEGMENT_CLASS_NAME}>
+      {options.map((mode) => (
+        <button
+          key={mode}
+          type="button"
+          onClick={() => onViewModeChange(mode)}
+          className={`rounded-[4px] px-3 py-1.5 ${
+            viewMode === mode
+              ? "bg-[var(--vk-bg-active)] text-[var(--vk-text-strong)]"
+              : "text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)]"
+          }`}
+        >
+          {mode === "split" ? "Split" : mode === "edit" ? "Edit" : "Preview"}
+        </button>
+      ))}
+    </div>
+  );
 }
 
 export function NotesToolbar({
@@ -47,104 +93,128 @@ export function NotesToolbar({
   fileTruncated,
   editorName = "editor",
   canSave = true,
+  compact = false,
+  onOpenFiles,
+  onOpenShare,
 }: NotesToolbarProps) {
+  const saveDisabled = !selectedFile || !dirty || saving || fileTruncated;
+
   return (
-    <div className="flex flex-wrap items-center gap-2">
-      {/* View mode switcher */}
-      <div className="inline-flex rounded-[6px] border border-[var(--vk-border)] p-0.5 text-[12px]">
-        {(["split", "edit", "preview"] as ViewMode[]).map((mode) => (
+    <div className="border-b border-[var(--vk-border)] bg-[var(--vk-bg-panel)]/50 px-3 py-2 sm:px-4">
+      {compact ? (
+        <div className="flex flex-wrap items-center gap-2">
           <button
-            key={mode}
             type="button"
-            onClick={() => onViewModeChange(mode)}
-            className={`rounded-[4px] px-3 py-1.5 ${
-              viewMode === mode
-                ? "bg-[var(--vk-bg-active)] text-[var(--vk-text-strong)]"
-                : "text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)]"
+            onClick={onOpenFiles}
+            className={BUTTON_CLASS_NAME}
+          >
+            <FolderOpen className="h-3.5 w-3.5" />
+            Files
+          </button>
+
+          <ViewModeSwitcher compact={compact} viewMode={viewMode} onViewModeChange={onViewModeChange} />
+
+          <button
+            type="button"
+            onClick={onToggleGraph}
+            className={`inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border px-3 text-[12px] hover:bg-[var(--vk-bg-hover)] ${
+              graphOpen
+                ? "border-[var(--vk-accent)] bg-[rgba(139,92,246,0.12)] text-[var(--vk-accent)]"
+                : "border-[var(--vk-border)] text-[var(--vk-text-normal)]"
             }`}
           >
-            {mode === "split" ? "Split" : mode === "edit" ? "Edit" : "Preview"}
+            <Network className="h-3.5 w-3.5" />
+            Graph
           </button>
-        ))}
-      </div>
 
-      {/* Refresh */}
-      <button
-        type="button"
-        onClick={onRefresh}
-        disabled={indexLoading}
-        className="inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-60"
-      >
-        {indexLoading ? (
-          <Loader2 className="h-3.5 w-3.5 animate-spin" />
-        ) : (
-          <RefreshCcw className="h-3.5 w-3.5" />
-        )}
-        Refresh
-      </button>
+          <DropdownMenu.Root>
+            <DropdownMenu.Trigger asChild>
+              <button type="button" className={BUTTON_CLASS_NAME}>
+                <MoreHorizontal className="h-3.5 w-3.5" />
+                More
+              </button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Portal>
+              <DropdownMenu.Content align="end" sideOffset={8} className={MENU_CONTENT_CLASS_NAME}>
+                <DropdownMenu.Item onSelect={onRefresh} className={MENU_ITEM_CLASS_NAME} disabled={indexLoading}>
+                  {indexLoading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCcw className="h-3.5 w-3.5" />}
+                  Refresh
+                </DropdownMenu.Item>
+                {canSave ? (
+                  <DropdownMenu.Item onSelect={onSave} className={MENU_ITEM_CLASS_NAME} disabled={saveDisabled}>
+                    {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
+                    Save
+                  </DropdownMenu.Item>
+                ) : null}
+                <DropdownMenu.Item onSelect={onOpenExternally} className={MENU_ITEM_CLASS_NAME} disabled={!selectedFile || opening}>
+                  {opening ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <ExternalLink className="h-3.5 w-3.5" />}
+                  Open in {editorName}
+                </DropdownMenu.Item>
+                <DropdownMenu.Item onSelect={onDailyNote} className={MENU_ITEM_CLASS_NAME}>
+                  <CalendarDays className="h-3.5 w-3.5" />
+                  Today
+                </DropdownMenu.Item>
+                <DropdownMenu.Item onSelect={onOpenShare} className={MENU_ITEM_CLASS_NAME}>
+                  <Send className="h-3.5 w-3.5" />
+                  Share note
+                </DropdownMenu.Item>
+              </DropdownMenu.Content>
+            </DropdownMenu.Portal>
+          </DropdownMenu.Root>
 
-      {/* Save */}
-      {canSave && (
-        <button
-          type="button"
-          onClick={onSave}
-          disabled={!selectedFile || !dirty || saving || fileTruncated}
-          className="inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-60"
-        >
-          {saving ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
-          ) : (
-            <Save className="h-3.5 w-3.5" />
-          )}
-          Save
-        </button>
-      )}
+          {dirty ? (
+            <span className="inline-flex items-center gap-1.5 text-[12px] text-[#f6c56f]">
+              <TriangleAlert className="h-3.5 w-3.5" />
+              Unsaved
+            </span>
+          ) : null}
+        </div>
+      ) : (
+        <div className="flex flex-wrap items-center gap-2">
+          <ViewModeSwitcher compact={compact} viewMode={viewMode} onViewModeChange={onViewModeChange} />
 
-      {/* Open in editor */}
-      <button
-        type="button"
-        onClick={onOpenExternally}
-        disabled={!selectedFile || opening}
-        className="inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-60"
-      >
-        {opening ? (
-          <Loader2 className="h-3.5 w-3.5 animate-spin" />
-        ) : (
-          <ExternalLink className="h-3.5 w-3.5" />
-        )}
-        Open in {editorName}
-      </button>
+          <button type="button" onClick={onRefresh} disabled={indexLoading} className={BUTTON_CLASS_NAME}>
+            {indexLoading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCcw className="h-3.5 w-3.5" />}
+            Refresh
+          </button>
 
-      {/* Today / Daily note */}
-      <button
-        type="button"
-        onClick={onDailyNote}
-        className="inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)]"
-      >
-        <CalendarDays className="h-3.5 w-3.5" />
-        Today
-      </button>
+          {canSave ? (
+            <button type="button" onClick={onSave} disabled={saveDisabled} className={BUTTON_CLASS_NAME}>
+              {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
+              Save
+            </button>
+          ) : null}
 
-      {/* Graph view toggle */}
-      <button
-        type="button"
-        onClick={onToggleGraph}
-        className={`inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border px-3 text-[12px] hover:bg-[var(--vk-bg-hover)] ${
-          graphOpen
-            ? "border-[var(--vk-accent)] bg-[rgba(139,92,246,0.12)] text-[var(--vk-accent)]"
-            : "border-[var(--vk-border)] text-[var(--vk-text-normal)]"
-        }`}
-      >
-        <Network className="h-3.5 w-3.5" />
-        Graph
-      </button>
+          <button type="button" onClick={onOpenExternally} disabled={!selectedFile || opening} className={BUTTON_CLASS_NAME}>
+            {opening ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <ExternalLink className="h-3.5 w-3.5" />}
+            Open in {editorName}
+          </button>
 
-      {/* Unsaved changes indicator */}
-      {dirty && (
-        <span className="inline-flex items-center gap-1.5 text-[12px] text-[#f6c56f]">
-          <TriangleAlert className="h-3.5 w-3.5" />
-          Unsaved
-        </span>
+          <button type="button" onClick={onDailyNote} className={BUTTON_CLASS_NAME}>
+            <CalendarDays className="h-3.5 w-3.5" />
+            Today
+          </button>
+
+          <button
+            type="button"
+            onClick={onToggleGraph}
+            className={`inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border px-3 text-[12px] hover:bg-[var(--vk-bg-hover)] ${
+              graphOpen
+                ? "border-[var(--vk-accent)] bg-[rgba(139,92,246,0.12)] text-[var(--vk-accent)]"
+                : "border-[var(--vk-border)] text-[var(--vk-text-normal)]"
+            }`}
+          >
+            <Network className="h-3.5 w-3.5" />
+            Graph
+          </button>
+
+          {dirty ? (
+            <span className="inline-flex items-center gap-1.5 text-[12px] text-[#f6c56f]">
+              <TriangleAlert className="h-3.5 w-3.5" />
+              Unsaved
+            </span>
+          ) : null}
+        </div>
       )}
     </div>
   );

--- a/packages/web/src/components/notes/ProjectNotesWorkspace.tsx
+++ b/packages/web/src/components/notes/ProjectNotesWorkspace.tsx
@@ -1,9 +1,13 @@
 "use client";
 
+import * as Dialog from "@radix-ui/react-dialog";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   BookText,
+  FolderOpen,
   Loader2,
+  Send,
+  X,
 } from "lucide-react";
 
 import type { DashboardSession } from "@/lib/types";
@@ -49,8 +53,11 @@ interface ProjectNotesWorkspaceProps {
 const NOTES_WORKSPACE_ROOT_CLASS_NAME = "flex h-full min-h-0 flex-col overflow-y-auto overscroll-contain touch-pan-y [-webkit-overflow-scrolling:touch] bg-[var(--vk-bg-main)]";
 const NOTES_WORKSPACE_LAYOUT_CLASS_NAME = "flex min-h-0 flex-1 flex-col xl:grid xl:grid-cols-[280px_minmax(0,1fr)] xl:overflow-hidden";
 const NOTES_MAIN_PANEL_CLASS_NAME = "flex min-h-[min(560px,70dvh)] flex-1 flex-col overflow-hidden xl:min-h-0";
+const NOTES_MAIN_PANEL_COMPACT_CLASS_NAME = "flex min-h-0 flex-1 flex-col overflow-hidden";
 const NOTES_EDITOR_PANEL_CLASS_NAME = "min-h-[320px] overflow-hidden xl:min-h-0";
 const NOTES_PREVIEW_PANEL_CLASS_NAME = "min-h-[280px] overflow-auto bg-[var(--vk-bg-panel)]/25 px-4 py-4 xl:min-h-0";
+const NOTES_SHEET_OVERLAY_CLASS_NAME = "fixed inset-0 z-[130] bg-black/60 backdrop-blur-[2px]";
+const NOTES_SHEET_CONTENT_CLASS_NAME = "fixed inset-x-0 bottom-0 top-[10%] z-[131] flex flex-col overflow-hidden rounded-t-[20px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_-24px_80px_rgba(0,0,0,0.42)]";
 
 // ---------------------------------------------------------------------------
 // Component
@@ -78,6 +85,9 @@ export function ProjectNotesWorkspace({
   const [graphOpen, setGraphOpen] = useState(false);
   const [quickSwitcherOpen, setQuickSwitcherOpen] = useState(false);
   const [activeTag, setActiveTag] = useState<string | null>(null);
+  const [compactViewport, setCompactViewport] = useState(false);
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+  const [mobileShareOpen, setMobileShareOpen] = useState(false);
 
   // -- File content state --------------------------------------------------
   const [draftContent, setDraftContent] = useState("");
@@ -159,6 +169,35 @@ export function ProjectNotesWorkspace({
       );
     }
   }, [selectedSessionId, sessionTargets, targetSessionId]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    const mediaQuery = window.matchMedia("(max-width: 1279px)");
+    const syncViewport = () => setCompactViewport(mediaQuery.matches);
+    syncViewport();
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", syncViewport);
+      return () => mediaQuery.removeEventListener("change", syncViewport);
+    }
+    mediaQuery.addListener?.(syncViewport);
+    return () => mediaQuery.removeListener?.(syncViewport);
+  }, []);
+
+  useEffect(() => {
+    if (compactViewport && viewMode === "split") {
+      setViewMode("edit");
+    }
+    if (!compactViewport) {
+      setMobileSidebarOpen(false);
+      setMobileShareOpen(false);
+    }
+  }, [compactViewport, viewMode]);
+
+  useEffect(() => {
+    if (compactViewport && sendSuccess) {
+      setMobileShareOpen(false);
+    }
+  }, [compactViewport, sendSuccess]);
 
   // -- Index loading -------------------------------------------------------
   const refreshIndex = useCallback(() => {
@@ -381,6 +420,11 @@ export function ProjectNotesWorkspace({
       const created = payload as SaveNotePayload;
       setNewNotePath("");
       setSelectedPath(created.path);
+      if (compactViewport) {
+        setMobileSidebarOpen(false);
+        setGraphOpen(false);
+        setViewMode("edit");
+      }
       setSaveSuccess("Note created.");
       refreshIndex();
     } catch (err) {
@@ -388,7 +432,7 @@ export function ProjectNotesWorkspace({
     } finally {
       setCreatingNote(false);
     }
-  }, [bridgeId, creatingNote, newNotePath, projectId, refreshIndex]);
+  }, [bridgeId, compactViewport, creatingNote, newNotePath, projectId, refreshIndex]);
 
   // -- Daily note ----------------------------------------------------------
   const handleDailyNote = useCallback(async () => {
@@ -406,6 +450,11 @@ export function ProjectNotesWorkspace({
       }
       if (payload?.path) {
         setSelectedPath(payload.path);
+        if (compactViewport) {
+          setMobileSidebarOpen(false);
+          setGraphOpen(false);
+          setViewMode("edit");
+        }
         // Expand daily folder
         setExpandedFolders((prev) =>
           prev.includes("daily") ? prev : [...prev, "daily"],
@@ -415,7 +464,7 @@ export function ProjectNotesWorkspace({
     } catch (err) {
       setSaveError(err instanceof Error ? err.message : "Failed to create daily note");
     }
-  }, [bridgeId, projectId, refreshIndex]);
+  }, [bridgeId, compactViewport, projectId, refreshIndex]);
 
   // -- Send to dispatcher --------------------------------------------------
   const sendToDispatcher = useCallback(async () => {
@@ -501,15 +550,23 @@ export function ProjectNotesWorkspace({
 
   // -- File select ---------------------------------------------------------
   const selectFile = useCallback((path: string) => {
-    if (path === selectedPath) return;
+    if (path === selectedPath) {
+      if (compactViewport) setMobileSidebarOpen(false);
+      return;
+    }
     if (dirty && typeof window !== "undefined") {
       const discard = window.confirm("Discard unsaved note changes and switch notes?");
       if (!discard) return;
     }
     setSelectedPath(path);
+    if (compactViewport) {
+      setMobileSidebarOpen(false);
+      setGraphOpen(false);
+      setViewMode("edit");
+    }
     // Track recent files
     recentPaths.current = [path, ...recentPaths.current.filter((p) => p !== path)].slice(0, 20);
-  }, [dirty, selectedPath]);
+  }, [compactViewport, dirty, selectedPath]);
 
   // -- Wikilink navigation -------------------------------------------------
   const handleWikilinkClick = useCallback((target: string) => {
@@ -558,13 +615,14 @@ export function ProjectNotesWorkspace({
     : indexPayload?.editor?.trim().toLowerCase() === "notion"
       ? "Notion"
       : "Project markdown files";
+  const effectiveViewMode: ViewMode = compactViewport && viewMode === "split" ? "edit" : viewMode;
 
   // -- Render --------------------------------------------------------------
   return (
     <div className={NOTES_WORKSPACE_ROOT_CLASS_NAME}>
       {/* Toolbar */}
       <NotesToolbar
-        viewMode={viewMode}
+        viewMode={effectiveViewMode}
         onViewModeChange={setViewMode}
         onSave={() => void saveCurrentNote()}
         onRefresh={refreshIndex}
@@ -580,6 +638,9 @@ export function ProjectNotesWorkspace({
         fileTruncated={fileTruncated}
         editorName={indexPayload?.editor}
         canSave={supportedLocalNotes}
+        compact={compactViewport}
+        onOpenFiles={() => setMobileSidebarOpen(true)}
+        onOpenShare={() => setMobileShareOpen(true)}
       />
 
       {/* Header info bar */}
@@ -677,27 +738,31 @@ export function ProjectNotesWorkspace({
         <NotesGraph
           projectId={projectId}
           bridgeId={bridgeId}
+          noteFiles={noteFiles}
+          selectedPath={selectedPath}
           onNavigate={selectFile}
         />
       ) : (
         /* Normal view: sidebar + editor/preview */
-        <div className={NOTES_WORKSPACE_LAYOUT_CLASS_NAME}>
+        <div className={compactViewport ? "min-h-0 flex-1" : NOTES_WORKSPACE_LAYOUT_CLASS_NAME}>
           {/* Sidebar */}
-          <NotesSidebar
-            noteFiles={noteFiles}
-            selectedPath={selectedPath}
-            expandedFolders={expandedFolders}
-            onToggleFolder={toggleFolder}
-            onSelectFile={selectFile}
-            search={search}
-            onSearchChange={setSearch}
-            editorLabel={indexPayload?.editor}
-            tags={tags}
-            onTagClick={handleTagClick}
-          />
+          {compactViewport ? null : (
+            <NotesSidebar
+              noteFiles={noteFiles}
+              selectedPath={selectedPath}
+              expandedFolders={expandedFolders}
+              onToggleFolder={toggleFolder}
+              onSelectFile={selectFile}
+              search={search}
+              onSearchChange={setSearch}
+              editorLabel={indexPayload?.editor}
+              tags={tags}
+              onTagClick={handleTagClick}
+            />
+          )}
 
           {/* Main panel */}
-          <div className={NOTES_MAIN_PANEL_CLASS_NAME}>
+          <div className={compactViewport ? NOTES_MAIN_PANEL_COMPACT_CLASS_NAME : NOTES_MAIN_PANEL_CLASS_NAME}>
             {/* File info + send-to bar */}
             <div className="border-b border-[var(--vk-border)] bg-[var(--vk-bg-panel)]/45 px-3 py-2">
               <div className="flex flex-col gap-2 xl:flex-row xl:items-start xl:justify-between">
@@ -715,58 +780,60 @@ export function ProjectNotesWorkspace({
                 </div>
 
                 {/* Send-to controls */}
-                <div className="grid gap-2 xl:min-w-[420px]">
-                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-                    <input
-                      value={composerMessage}
-                      onChange={(e) => setComposerMessage(e.target.value)}
-                      placeholder="Optional message to send with this note"
-                      className="min-h-[34px] min-w-0 flex-1 rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-3 text-[12px] text-[var(--vk-text-normal)] outline-none placeholder:text-[var(--vk-text-muted)]"
-                    />
-                    <select
-                      value={targetSessionId}
-                      onChange={(e) => setTargetSessionId(e.target.value)}
-                      className="min-h-[34px] rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-3 text-[12px] text-[var(--vk-text-normal)] outline-none"
-                      disabled={sessionTargets.length === 0}
-                    >
-                      {sessionTargets.length === 0 ? (
-                        <option value="">No active sessions</option>
-                      ) : null}
-                      {sessionTargets.map((s) => (
-                        <option key={s.id} value={s.id}>
-                          {(s.branch || s.id.slice(0, 8)).trim()} · {s.status}
-                        </option>
-                      ))}
-                    </select>
+                {compactViewport ? null : (
+                  <div className="grid gap-2 xl:min-w-[420px]">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                      <input
+                        value={composerMessage}
+                        onChange={(e) => setComposerMessage(e.target.value)}
+                        placeholder="Optional message to send with this note"
+                        className="min-h-[34px] min-w-0 flex-1 rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-3 text-[12px] text-[var(--vk-text-normal)] outline-none placeholder:text-[var(--vk-text-muted)]"
+                      />
+                      <select
+                        value={targetSessionId}
+                        onChange={(e) => setTargetSessionId(e.target.value)}
+                        className="min-h-[34px] rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-3 text-[12px] text-[var(--vk-text-normal)] outline-none"
+                        disabled={sessionTargets.length === 0}
+                      >
+                        {sessionTargets.length === 0 ? (
+                          <option value="">No active sessions</option>
+                        ) : null}
+                        {sessionTargets.map((s) => (
+                          <option key={s.id} value={s.id}>
+                            {(s.branch || s.id.slice(0, 8)).trim()} · {s.status}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => void sendToDispatcher()}
+                        disabled={sendingDispatcher || (!selectedFile && composerMessage.trim().length === 0)}
+                        className="inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-60"
+                      >
+                        {sendingDispatcher ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "✦"}
+                        Send to dispatcher
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void sendToSession()}
+                        disabled={sendingSession || !targetSessionId || (!selectedFile && composerMessage.trim().length === 0)}
+                        className="inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-60"
+                      >
+                        {sendingSession ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "→"}
+                        Send to session
+                      </button>
+                    </div>
                   </div>
-                  <div className="flex flex-wrap items-center gap-2">
-                    <button
-                      type="button"
-                      onClick={() => void sendToDispatcher()}
-                      disabled={sendingDispatcher || (!selectedFile && composerMessage.trim().length === 0)}
-                      className="inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-60"
-                    >
-                      {sendingDispatcher ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "✦"}
-                      Send to dispatcher
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => void sendToSession()}
-                      disabled={sendingSession || !targetSessionId || (!selectedFile && composerMessage.trim().length === 0)}
-                      className="inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-60"
-                    >
-                      {sendingSession ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "→"}
-                      Send to session
-                    </button>
-                  </div>
-                </div>
+                )}
               </div>
             </div>
 
             {/* Editor / Preview area */}
-            <div className={`grid min-h-0 flex-1 ${viewMode === "split" ? "xl:grid-cols-2" : "grid-cols-1"}`}>
-              {viewMode !== "preview" ? (
-                <div className={`${NOTES_EDITOR_PANEL_CLASS_NAME} ${viewMode === "split" ? "border-b border-[var(--vk-border)] xl:border-b-0 xl:border-r" : ""}`}>
+            <div className={`grid min-h-0 flex-1 ${effectiveViewMode === "split" ? "xl:grid-cols-2" : "grid-cols-1"}`}>
+              {effectiveViewMode !== "preview" ? (
+                <div className={`${NOTES_EDITOR_PANEL_CLASS_NAME} ${effectiveViewMode === "split" ? "border-b border-[var(--vk-border)] xl:border-b-0 xl:border-r" : ""}`}>
                   {fileLoading ? (
                     <div className="flex h-full items-center justify-center gap-2 text-[13px] text-[var(--vk-text-muted)]">
                       <Loader2 className="h-4 w-4 animate-spin" />
@@ -786,7 +853,7 @@ export function ProjectNotesWorkspace({
                 </div>
               ) : null}
 
-              {viewMode !== "edit" ? (
+              {effectiveViewMode !== "edit" ? (
                 <div className={NOTES_PREVIEW_PANEL_CLASS_NAME}>
                   <NotesPreview
                     content={draftContent}
@@ -807,6 +874,133 @@ export function ProjectNotesWorkspace({
           </div>
         </div>
       )}
+
+      <Dialog.Root open={mobileSidebarOpen} onOpenChange={setMobileSidebarOpen}>
+        <Dialog.Portal>
+          <Dialog.Overlay className={NOTES_SHEET_OVERLAY_CLASS_NAME} />
+          <Dialog.Content className={NOTES_SHEET_CONTENT_CLASS_NAME}>
+            <div className="flex items-center justify-between border-b border-[var(--vk-border)] px-4 py-3">
+              <div>
+                <Dialog.Title className="text-[14px] font-medium text-[var(--vk-text-strong)]">
+                  Browse notes
+                </Dialog.Title>
+                <Dialog.Description className="text-[11px] text-[var(--vk-text-muted)]">
+                  Jump between files without crowding the editor on mobile.
+                </Dialog.Description>
+              </div>
+              <Dialog.Close asChild>
+                <button
+                  type="button"
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-[var(--vk-border)] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)]"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </Dialog.Close>
+            </div>
+            <div className="min-h-0 flex-1 overflow-hidden">
+              <NotesSidebar
+                noteFiles={noteFiles}
+                selectedPath={selectedPath}
+                expandedFolders={expandedFolders}
+                onToggleFolder={toggleFolder}
+                onSelectFile={selectFile}
+                search={search}
+                onSearchChange={setSearch}
+                editorLabel={indexPayload?.editor}
+                tags={tags}
+                onTagClick={handleTagClick}
+                className="h-full max-h-none border-b-0 xl:border-r-0"
+              />
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+
+      <Dialog.Root open={mobileShareOpen} onOpenChange={setMobileShareOpen}>
+        <Dialog.Portal>
+          <Dialog.Overlay className={NOTES_SHEET_OVERLAY_CLASS_NAME} />
+          <Dialog.Content className={NOTES_SHEET_CONTENT_CLASS_NAME}>
+            <div className="flex items-center justify-between border-b border-[var(--vk-border)] px-4 py-3">
+              <div>
+                <Dialog.Title className="text-[14px] font-medium text-[var(--vk-text-strong)]">
+                  Share note
+                </Dialog.Title>
+                <Dialog.Description className="text-[11px] text-[var(--vk-text-muted)]">
+                  Send the current note to the dispatcher or an active session.
+                </Dialog.Description>
+              </div>
+              <Dialog.Close asChild>
+                <button
+                  type="button"
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-[var(--vk-border)] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)]"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </Dialog.Close>
+            </div>
+            <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-auto px-4 py-4">
+              <div className="rounded-[12px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)]/35 px-3 py-3">
+                <p className="text-[13px] font-medium text-[var(--vk-text-strong)]">
+                  {selectedFile?.displayPath || "No note selected"}
+                </p>
+                {selectedFile ? (
+                  <p className="mt-1 text-[11px] text-[var(--vk-text-muted)]">
+                    {selectedFile.source || "notes"}
+                    {selectedFile.modifiedAt ? ` · ${new Date(selectedFile.modifiedAt).toLocaleString()}` : ""}
+                  </p>
+                ) : null}
+              </div>
+              <label className="grid gap-2 text-[12px] text-[var(--vk-text-muted)]">
+                <span>Optional message</span>
+                <input
+                  value={composerMessage}
+                  onChange={(e) => setComposerMessage(e.target.value)}
+                  placeholder="Optional message to send with this note"
+                  className="min-h-[40px] rounded-[10px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-3 text-[13px] text-[var(--vk-text-normal)] outline-none placeholder:text-[var(--vk-text-muted)]"
+                />
+              </label>
+              <label className="grid gap-2 text-[12px] text-[var(--vk-text-muted)]">
+                <span>Target session</span>
+                <select
+                  value={targetSessionId}
+                  onChange={(e) => setTargetSessionId(e.target.value)}
+                  className="min-h-[40px] rounded-[10px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-3 text-[13px] text-[var(--vk-text-normal)] outline-none"
+                  disabled={sessionTargets.length === 0}
+                >
+                  {sessionTargets.length === 0 ? (
+                    <option value="">No active sessions</option>
+                  ) : null}
+                  {sessionTargets.map((s) => (
+                    <option key={s.id} value={s.id}>
+                      {(s.branch || s.id.slice(0, 8)).trim()} · {s.status}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <div className="mt-auto flex flex-col gap-2 pb-[env(safe-area-inset-bottom)]">
+                <button
+                  type="button"
+                  onClick={() => void sendToDispatcher()}
+                  disabled={sendingDispatcher || (!selectedFile && composerMessage.trim().length === 0)}
+                  className="inline-flex min-h-[42px] items-center justify-center gap-2 rounded-[10px] border border-[var(--vk-border)] px-4 text-[13px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-60"
+                >
+                  {sendingDispatcher ? <Loader2 className="h-4 w-4 animate-spin" /> : <FolderOpen className="h-4 w-4" />}
+                  Send to dispatcher
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void sendToSession()}
+                  disabled={sendingSession || !targetSessionId || (!selectedFile && composerMessage.trim().length === 0)}
+                  className="inline-flex min-h-[42px] items-center justify-center gap-2 rounded-[10px] border border-[var(--vk-accent)] bg-[rgba(139,92,246,0.14)] px-4 text-[13px] text-[var(--vk-text-strong)] hover:bg-[rgba(139,92,246,0.2)] disabled:opacity-60"
+                >
+                  {sendingSession ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+                  Send to session
+                </button>
+              </div>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
 
       {/* Quick Switcher overlay */}
       <QuickSwitcher

--- a/packages/web/src/components/notes/notesGraphModel.test.ts
+++ b/packages/web/src/components/notes/notesGraphModel.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { GraphEdge, GraphNode, NoteFile } from "./types";
+import { buildNotesGraphIndex, collectReachableNodes, filterNotesGraph } from "./notesGraphModel";
+
+const noteFiles: NoteFile[] = [
+  {
+    path: "/vault/project/design.md",
+    displayPath: "project/design.md",
+    name: "design.md",
+    source: "vault",
+    sizeBytes: 128,
+    modifiedAt: null,
+    kind: "file",
+  },
+  {
+    path: "/vault/project/overview.md",
+    displayPath: "project/overview.md",
+    name: "overview.md",
+    source: "vault",
+    sizeBytes: 256,
+    modifiedAt: null,
+    kind: "file",
+  },
+  {
+    path: "/vault/strategy/launch.md",
+    displayPath: "strategy/launch.md",
+    name: "launch.md",
+    source: "vault",
+    sizeBytes: 512,
+    modifiedAt: null,
+    kind: "file",
+  },
+  {
+    path: "/vault/inbox/orphan.md",
+    displayPath: "inbox/orphan.md",
+    name: "orphan.md",
+    source: "vault",
+    sizeBytes: 64,
+    modifiedAt: null,
+    kind: "file",
+  },
+];
+
+const nodes: GraphNode[] = [
+  { id: "/vault/project/design.md", name: "design.md", tags: ["architecture"] },
+  { id: "/vault/project/overview.md", name: "overview.md", tags: ["architecture"] },
+  { id: "/vault/strategy/launch.md", name: "launch.md", tags: ["launch"] },
+  { id: "/vault/inbox/orphan.md", name: "orphan.md", tags: [] },
+];
+
+const edges: GraphEdge[] = [
+  { source: "/vault/project/design.md", target: "/vault/project/overview.md" },
+  { source: "/vault/project/overview.md", target: "/vault/strategy/launch.md" },
+];
+
+test("buildNotesGraphIndex derives folder groups and connection counts from note metadata", () => {
+  const graphIndex = buildNotesGraphIndex(nodes, edges, noteFiles);
+
+  assert.equal(graphIndex.nodesById.get("/vault/project/overview.md")?.degree, 2);
+  assert.equal(graphIndex.nodesById.get("/vault/project/design.md")?.folder, "project");
+  assert.deepEqual(
+    Array.from(graphIndex.groups)
+      .map((group) => ({ id: group.id, count: group.count }))
+      .sort((left, right) => left.id.localeCompare(right.id)),
+    [
+      { id: "inbox", count: 1 },
+      { id: "project", count: 2 },
+      { id: "strategy", count: 1 },
+    ],
+  );
+});
+
+test("collectReachableNodes walks outward from the selected local graph node", () => {
+  const graphIndex = buildNotesGraphIndex(nodes, edges, noteFiles);
+
+  assert.deepEqual(
+    Array.from(collectReachableNodes(graphIndex, "/vault/project/overview.md", 1)).sort(),
+    [
+      "/vault/project/design.md",
+      "/vault/project/overview.md",
+      "/vault/strategy/launch.md",
+    ],
+  );
+
+  assert.deepEqual(
+    Array.from(collectReachableNodes(graphIndex, "/vault/project/overview.md", 0)),
+    ["/vault/project/overview.md"],
+  );
+});
+
+test("filterNotesGraph keeps neighbor context for search while hiding orphans and honoring group filters", () => {
+  const graphIndex = buildNotesGraphIndex(nodes, edges, noteFiles);
+
+  const searched = filterNotesGraph(graphIndex, {
+    search: "design",
+    showOrphans: false,
+    activeGroupId: null,
+    localRootId: null,
+    localDepth: 1,
+  });
+  assert.deepEqual(
+    searched.nodes.map((node) => node.id).sort(),
+    ["/vault/project/design.md", "/vault/project/overview.md"],
+  );
+  assert.deepEqual(searched.edges.map((edge) => `${edge.source}->${edge.target}`), [
+    "/vault/project/design.md->/vault/project/overview.md",
+  ]);
+
+  const grouped = filterNotesGraph(graphIndex, {
+    search: "",
+    showOrphans: false,
+    activeGroupId: "strategy",
+    localRootId: null,
+    localDepth: 1,
+  });
+  assert.deepEqual(grouped.nodes.map((node) => node.id), ["/vault/strategy/launch.md"]);
+  assert.equal(grouped.edges.length, 0);
+});

--- a/packages/web/src/components/notes/notesGraphModel.ts
+++ b/packages/web/src/components/notes/notesGraphModel.ts
@@ -1,0 +1,226 @@
+import type { GraphEdge, GraphNode, NoteFile } from "./types";
+
+const GROUP_COLORS = [
+  "#8b5cf6",
+  "#14b8a6",
+  "#f59e0b",
+  "#ef4444",
+  "#22c55e",
+  "#ec4899",
+  "#3b82f6",
+  "#f97316",
+];
+
+export type NotesGraphGroup = {
+  id: string;
+  label: string;
+  count: number;
+  color: string;
+};
+
+export type NotesGraphNodeRecord = {
+  id: string;
+  name: string;
+  displayPath: string;
+  source: string | null;
+  folder: string;
+  tags: string[];
+  degree: number;
+  isOrphan: boolean;
+};
+
+export type NotesGraphEdgeRecord = {
+  id: string;
+  source: string;
+  target: string;
+};
+
+export type NotesGraphIndex = {
+  nodes: NotesGraphNodeRecord[];
+  edges: NotesGraphEdgeRecord[];
+  nodesById: Map<string, NotesGraphNodeRecord>;
+  adjacency: Map<string, Set<string>>;
+  groups: NotesGraphGroup[];
+};
+
+export type NotesGraphFilterOptions = {
+  search: string;
+  showOrphans: boolean;
+  activeGroupId: string | null;
+  localRootId: string | null;
+  localDepth: number;
+};
+
+function normalizeFolderId(displayPath: string): string {
+  const normalized = displayPath.replace(/^\/+/, "");
+  const firstSegment = normalized.split("/").find((segment) => segment.trim().length > 0);
+  return firstSegment ?? "root";
+}
+
+function humanizeGroupLabel(groupId: string): string {
+  if (groupId === "root") return "Root";
+  return groupId
+    .split(/[-_]/g)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+function makeSearchHaystack(node: NotesGraphNodeRecord): string {
+  return [node.name, node.displayPath, node.folder, ...node.tags].join(" ").toLowerCase();
+}
+
+function intersectSets(left: Set<string>, right: Set<string>): Set<string> {
+  return new Set(Array.from(left).filter((value) => right.has(value)));
+}
+
+export function buildNotesGraphIndex(
+  rawNodes: GraphNode[],
+  rawEdges: GraphEdge[],
+  noteFiles: NoteFile[],
+): NotesGraphIndex {
+  const metadataById = new Map(noteFiles.map((file) => [file.path, file]));
+  const nodesById = new Map<string, NotesGraphNodeRecord>();
+  const adjacency = new Map<string, Set<string>>();
+  const groupCounts = new Map<string, number>();
+  const edges: NotesGraphEdgeRecord[] = [];
+  const seenEdgeIds = new Set<string>();
+
+  for (const rawNode of rawNodes) {
+    const metadata = metadataById.get(rawNode.id);
+    const displayPath = metadata?.displayPath ?? rawNode.name;
+    const folder = normalizeFolderId(displayPath);
+    const record: NotesGraphNodeRecord = {
+      id: rawNode.id,
+      name: rawNode.name,
+      displayPath,
+      source: metadata?.source ?? null,
+      folder,
+      tags: rawNode.tags ?? [],
+      degree: 0,
+      isOrphan: true,
+    };
+    nodesById.set(record.id, record);
+    adjacency.set(record.id, new Set());
+    groupCounts.set(folder, (groupCounts.get(folder) ?? 0) + 1);
+  }
+
+  for (const rawEdge of rawEdges) {
+    if (!nodesById.has(rawEdge.source) || !nodesById.has(rawEdge.target)) continue;
+    const id = `${rawEdge.source}->${rawEdge.target}`;
+    if (seenEdgeIds.has(id)) continue;
+    seenEdgeIds.add(id);
+    edges.push({ id, source: rawEdge.source, target: rawEdge.target });
+    adjacency.get(rawEdge.source)?.add(rawEdge.target);
+    adjacency.get(rawEdge.target)?.add(rawEdge.source);
+  }
+
+  const nodes = Array.from(nodesById.values()).map((node) => {
+    const degree = adjacency.get(node.id)?.size ?? 0;
+    const next = {
+      ...node,
+      degree,
+      isOrphan: degree === 0,
+    };
+    nodesById.set(node.id, next);
+    return next;
+  });
+
+  const groups = Array.from(groupCounts.entries())
+    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+    .map(([id, count], index) => ({
+      id,
+      label: humanizeGroupLabel(id),
+      count,
+      color: GROUP_COLORS[index % GROUP_COLORS.length],
+    }));
+
+  return {
+    nodes,
+    edges,
+    nodesById,
+    adjacency,
+    groups,
+  };
+}
+
+export function collectReachableNodes(
+  graphIndex: NotesGraphIndex,
+  startId: string,
+  depth: number,
+): Set<string> {
+  if (!graphIndex.nodesById.has(startId)) return new Set();
+  const clampedDepth = Math.max(0, Math.floor(depth));
+  const visited = new Set<string>([startId]);
+  const queue: Array<{ id: string; depth: number }> = [{ id: startId, depth: 0 }];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current) continue;
+    if (current.depth >= clampedDepth) continue;
+    for (const neighbor of Array.from(graphIndex.adjacency.get(current.id) ?? [])) {
+      if (visited.has(neighbor)) continue;
+      visited.add(neighbor);
+      queue.push({ id: neighbor, depth: current.depth + 1 });
+    }
+  }
+
+  return visited;
+}
+
+export function filterNotesGraph(
+  graphIndex: NotesGraphIndex,
+  options: NotesGraphFilterOptions,
+): { nodes: NotesGraphNodeRecord[]; edges: NotesGraphEdgeRecord[] } {
+  const search = options.search.trim().toLowerCase();
+  let visibleIds = new Set(graphIndex.nodes.map((node) => node.id));
+
+  if (options.activeGroupId) {
+    const groupedIds = new Set(
+      graphIndex.nodes
+        .filter((node) => node.folder === options.activeGroupId)
+        .map((node) => node.id),
+    );
+    visibleIds = intersectSets(visibleIds, groupedIds);
+  }
+
+  if (search.length > 0) {
+    const matches = graphIndex.nodes
+      .filter((node) => makeSearchHaystack(node).includes(search))
+      .map((node) => node.id);
+    const expandedMatches = new Set<string>();
+    for (const match of matches) {
+      for (const reachable of Array.from(collectReachableNodes(graphIndex, match, 1))) {
+        expandedMatches.add(reachable);
+      }
+    }
+    visibleIds = intersectSets(visibleIds, expandedMatches);
+  }
+
+  if (options.localRootId) {
+    const localIds = collectReachableNodes(graphIndex, options.localRootId, options.localDepth);
+    visibleIds = intersectSets(visibleIds, localIds);
+  }
+
+  let edges = graphIndex.edges.filter(
+    (edge) => visibleIds.has(edge.source) && visibleIds.has(edge.target),
+  );
+
+  if (!options.showOrphans) {
+    visibleIds = new Set(
+      Array.from(visibleIds).filter((id) => {
+        if (options.localRootId && id === options.localRootId) return true;
+        return graphIndex.nodesById.get(id)?.isOrphan === false;
+      }),
+    );
+    edges = edges.filter((edge) => visibleIds.has(edge.source) && visibleIds.has(edge.target));
+  }
+
+  const nodes = graphIndex.nodes
+    .filter((node) => visibleIds.has(node.id))
+    .sort((left, right) => {
+      return right.degree - left.degree || left.displayPath.localeCompare(right.displayPath);
+    });
+
+  return { nodes, edges };
+}

--- a/packages/web/src/components/notes/notesMobileLayout.test.ts
+++ b/packages/web/src/components/notes/notesMobileLayout.test.ts
@@ -2,31 +2,36 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 
-test("project notes workspace restores a mobile scroll owner", () => {
+test("project notes workspace keeps a compact mobile mode with dedicated file and share sheets", () => {
   const source = readFileSync(new URL("./ProjectNotesWorkspace.tsx", import.meta.url), "utf8");
 
-  assert.match(source, /overflow-y-auto/);
-  assert.match(source, /overscroll-contain/);
-  assert.match(source, /touch-pan-y/);
-  assert.match(source, /-webkit-overflow-scrolling:touch/);
+  assert.match(source, /window\.matchMedia\("\(max-width: 1279px\)"\)/);
+  assert.match(source, /mobileSidebarOpen/);
+  assert.match(source, /mobileShareOpen/);
+  assert.match(source, /compactViewport/);
+  assert.match(source, /<Dialog\.Root open=\{mobileSidebarOpen\}/);
+  assert.match(source, /<Dialog\.Root open=\{mobileShareOpen\}/);
 });
 
-test("project notes workspace keeps a stacked mobile fallback before switching to the desktop grid", () => {
-  const source = readFileSync(new URL("./ProjectNotesWorkspace.tsx", import.meta.url), "utf8");
+test("notes toolbar exposes a compact actions menu for mobile", () => {
+  const source = readFileSync(new URL("./NotesToolbar.tsx", import.meta.url), "utf8");
 
-  assert.match(source, /flex min-h-0 flex-1 flex-col/);
-  assert.match(source, /xl:grid xl:grid-cols-\[280px_minmax\(0,1fr\)\]/);
+  assert.match(source, /@radix-ui\/react-dropdown-menu/);
+  assert.match(source, /compact/);
+  assert.match(source, /Files/);
+  assert.match(source, /More/);
+  assert.match(source, /Share note/);
 });
 
-test("notes sidebar constrains its mobile height so the tree can scroll inside the tab", () => {
-  const source = readFileSync(new URL("./NotesSidebar.tsx", import.meta.url), "utf8");
-
-  assert.match(source, /max-h-\[min\(42dvh,360px\)\]/);
-  assert.match(source, /xl:border-r/);
-});
-
-test("notes graph keeps a usable mobile canvas height", () => {
+test("notes graph exposes obsidian-style search, groups, local graph, and force controls", () => {
   const source = readFileSync(new URL("./NotesGraph.tsx", import.meta.url), "utf8");
 
-  assert.match(source, /min-h-\[min\(560px,70dvh\)\]/);
+  assert.match(source, /Search files/);
+  assert.match(source, /Groups/);
+  assert.match(source, /Local graph/);
+  assert.match(source, /Link distance/);
+  assert.match(source, /Repel force/);
+  assert.match(source, /Node size/);
+  assert.match(source, /showArrows/);
+  assert.match(source, /Zoom in/);
 });


### PR DESCRIPTION
## Summary

Reworks the Notes workspace on phones so the file browser and share flow move into mobile sheets, replaces the bare graph canvas with an Obsidian-style graph experience, and trims the mobile update notice so it stops overwhelming the workspace.

## User-Facing Release Notes

- Reworked the Notes workspace on mobile with dedicated file browsing and share sheets so editing no longer feels cramped.
- Upgraded the Notes graph into an Obsidian-style experience with search, groups, local graph focus, graph force controls, and mobile zoom actions.
- Shrunk the mobile Conductor update notice so it interferes less with note editing and graph exploration.

## Type of Change

- [ ] Breaking Change
- [x] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Testing

- `bun test`
- `bun run typecheck`
- `bun run build`
- Mobile screenshots captured locally with Puppeteer against the updated Notes workspace and graph view.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App Update Notice: Added responsive mobile design with compact layout and expandable Details toggle.
  * Notes Graph: Introduced interactive visualization with search, group filtering, local graph scoping, and zoom/pan controls.
  * Mobile UI: Added modal sheets for browsing notes sidebar and sharing.
  * Toolbar: Added dropdown menu with additional actions and compact mode support.

* **Tests**
  * Added test coverage for responsive mobile layouts and graph filtering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->