### PR TITLE
fix: restore dispatcher chat thread resolution and idle state

### DIFF
--- a/crates/conductor-server/src/routes/dispatcher.rs
+++ b/crates/conductor-server/src/routes/dispatcher.rs
@@ -249,10 +249,14 @@ async fn serialize_dispatcher_binding(
         },
         None => Value::Null,
     };
-    let dispatcher_query = binding
-        .dispatcher_thread_id
-        .as_deref()
-        .map(|thread_id| format!("threadId={thread_id}"));
+    let dispatcher_query = binding.dispatcher_thread_id.as_deref().map(|thread_id| {
+        let mut query = format!("threadId={thread_id}");
+        if let Some(bridge_id) = binding.bridge_id.as_deref() {
+            query.push_str("&bridgeId=");
+            query.push_str(bridge_id);
+        }
+        query
+    });
     let base_path = format!("/api/projects/{project_id}/dispatcher");
     let tasks_endpoint = dispatcher_query
         .as_ref()
@@ -306,10 +310,21 @@ async fn resolve_project_dispatcher(
     thread_id: Option<&str>,
 ) -> Option<SessionRecord> {
     if let Some(thread_id) = trimmed_query_value(thread_id) {
-        return state
+        let dispatcher = state
             .get_dispatcher_thread(thread_id)
             .await
-            .filter(|dispatcher| dispatcher_matches_scope(dispatcher, project_id, bridge_id));
+            .filter(|dispatcher| {
+                dispatcher.project_id == project_id && is_project_dispatcher_session(dispatcher)
+            });
+        return match (dispatcher, bridge_id) {
+            (Some(dispatcher), Some(expected_bridge_id))
+                if dispatcher_matches_scope(&dispatcher, project_id, Some(expected_bridge_id)) =>
+            {
+                Some(dispatcher)
+            }
+            (Some(dispatcher), None) => Some(dispatcher),
+            _ => None,
+        };
     }
 
     state
@@ -635,15 +650,20 @@ async fn dispatcher_task_context(
     state: &Arc<AppState>,
     project_id: &str,
     query: &DispatcherQuery,
-) -> DispatcherTaskMutationContext {
+) -> Result<DispatcherTaskMutationContext, String> {
     let bridge_id = trimmed_query_value(query.bridge_id.as_deref());
     let dispatcher =
         resolve_project_dispatcher(state, project_id, bridge_id, query.thread_id.as_deref()).await;
-    DispatcherTaskMutationContext {
+    if trimmed_query_value(query.thread_id.as_deref()).is_some() && dispatcher.is_none() {
+        return Err(format!(
+            "Dispatcher thread for project {project_id} not found"
+        ));
+    }
+    Ok(DispatcherTaskMutationContext {
         activity_source: "dispatcher",
         caller_session: dispatcher.clone(),
         dispatcher_thread_id: dispatcher.map(|thread| thread.id),
-    }
+    })
 }
 
 async fn create_dispatcher_task_route(
@@ -652,7 +672,10 @@ async fn create_dispatcher_task_route(
     Query(query): Query<DispatcherQuery>,
     Json(mut body): Json<DispatcherTaskCreateInput>,
 ) -> ApiResponse {
-    let context = dispatcher_task_context(&state, &project_id, &query).await;
+    let context = match dispatcher_task_context(&state, &project_id, &query).await {
+        Ok(context) => context,
+        Err(message) => return error(StatusCode::NOT_FOUND, message),
+    };
     body.project = Some(project_id);
     match create_dispatcher_task(&state, context, body).await {
         Ok(result) => created(result.response_payload()),
@@ -666,7 +689,10 @@ async fn update_dispatcher_task_route(
     Query(query): Query<DispatcherQuery>,
     Json(mut body): Json<DispatcherTaskUpdateInput>,
 ) -> ApiResponse {
-    let context = dispatcher_task_context(&state, &project_id, &query).await;
+    let context = match dispatcher_task_context(&state, &project_id, &query).await {
+        Ok(context) => context,
+        Err(message) => return error(StatusCode::NOT_FOUND, message),
+    };
     body.project = Some(project_id);
     body.task = Some(task_lookup);
     match update_dispatcher_task(&state, context, body).await {
@@ -681,7 +707,10 @@ async fn handoff_dispatcher_task_route(
     Query(query): Query<DispatcherQuery>,
     Json(mut body): Json<DispatcherTaskUpdateInput>,
 ) -> ApiResponse {
-    let context = dispatcher_task_context(&state, &project_id, &query).await;
+    let context = match dispatcher_task_context(&state, &project_id, &query).await {
+        Ok(context) => context,
+        Err(message) => return error(StatusCode::NOT_FOUND, message),
+    };
     body.project = Some(project_id);
     body.task = Some(task_lookup);
     match handoff_dispatcher_task(&state, context, body).await {

--- a/crates/conductor-server/src/state/acp_dispatcher.rs
+++ b/crates/conductor-server/src/state/acp_dispatcher.rs
@@ -3223,7 +3223,7 @@ impl AppState {
     pub(crate) async fn dispatcher_runtime_attached(&self, thread_id: &str) -> bool {
         let mut runtimes = self.dispatcher_runtimes.lock().await;
         match runtimes.get(thread_id) {
-            Some(handle) if handle.accepts_input && handle.input_tx.is_closed() => {
+            Some(handle) if handle.input_tx.is_closed() => {
                 runtimes.remove(thread_id);
                 false
             }
@@ -3670,24 +3670,49 @@ impl AppState {
                     .metadata
                     .insert("exitCode".to_string(), exit_code.to_string());
                 if exit_code == 0 {
-                    if thread.status != SessionStatus::NeedsInput {
-                        thread.status = SessionStatus::NeedsInput;
-                        feed_dirty = true;
-                    }
-                    thread.activity = Some("waiting_input".to_string());
-                    thread
-                        .metadata
-                        .insert("finishedAt".to_string(), Utc::now().to_rfc3339());
-                    if thread
-                        .summary
-                        .as_ref()
-                        .map(|value| value.trim().is_empty())
-                        .unwrap_or(true)
-                    {
-                        thread.summary = Some("Ready for follow-up".to_string());
+                    let uses_headless_turns =
+                        dispatcher_uses_headless_turns(&AgentKind::parse(&thread.agent));
+                    if uses_headless_turns {
+                        if thread.status != SessionStatus::Idle {
+                            thread.status = SessionStatus::Idle;
+                            feed_dirty = true;
+                        }
+                        thread.activity = Some("idle".to_string());
                         thread
                             .metadata
-                            .insert("summary".to_string(), "Ready for follow-up".to_string());
+                            .insert("finishedAt".to_string(), Utc::now().to_rfc3339());
+                        if thread
+                            .summary
+                            .as_ref()
+                            .map(|value| value.trim().is_empty())
+                            .unwrap_or(true)
+                        {
+                            thread.summary = Some("Dispatcher ready for the next turn".to_string());
+                            thread.metadata.insert(
+                                "summary".to_string(),
+                                "Dispatcher ready for the next turn".to_string(),
+                            );
+                        }
+                    } else {
+                        if thread.status != SessionStatus::NeedsInput {
+                            thread.status = SessionStatus::NeedsInput;
+                            feed_dirty = true;
+                        }
+                        thread.activity = Some("waiting_input".to_string());
+                        thread
+                            .metadata
+                            .insert("finishedAt".to_string(), Utc::now().to_rfc3339());
+                        if thread
+                            .summary
+                            .as_ref()
+                            .map(|value| value.trim().is_empty())
+                            .unwrap_or(true)
+                        {
+                            thread.summary = Some("Ready for follow-up".to_string());
+                            thread
+                                .metadata
+                                .insert("summary".to_string(), "Ready for follow-up".to_string());
+                        }
                     }
                 } else {
                     if thread.status != SessionStatus::Errored {
@@ -3754,11 +3779,11 @@ impl AppState {
 
         let should_sync_memory = should_sync_dispatcher_session_memory(thread, force_memory_sync);
         let updated = thread.clone();
-        drop(threads);
         if clear_runtime {
             self.clear_dispatcher_runtime_if(thread_id, runtime_id)
                 .await;
         }
+        drop(threads);
         self.persist_dispatcher_thread(&updated).await?;
         if should_sync_memory {
             self.sync_acp_dispatcher_state(&updated).await?;
@@ -4571,15 +4596,16 @@ mod tests {
                     entry.kind == "assistant_message"
                         && entry.text.contains("headless assistant reply")
                 });
-                if has_reply && updated.status == SessionStatus::NeedsInput {
+                if has_reply && updated.status == SessionStatus::Idle {
                     break updated;
                 }
                 tokio::time::sleep(Duration::from_millis(25)).await;
             }
         })
         .await
-        .expect("headless runtime should eventually emit the assistant reply and reach NeedsInput");
-        assert_eq!(updated.status, SessionStatus::NeedsInput);
+        .expect("headless runtime should eventually emit the assistant reply and reach Idle");
+        assert_eq!(updated.status, SessionStatus::Idle);
+        assert_eq!(updated.activity.as_deref(), Some("idle"));
 
         let _ = fs::remove_dir_all(root);
     }
@@ -5001,7 +5027,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn headless_runtime_without_input_receiver_still_counts_as_attached() {
+    async fn headless_runtime_with_closed_input_is_cleared() {
         let (root, state) = build_test_state("acp-headless-runtime-attached").await;
         let thread = state
             .create_project_dispatcher_thread("demo", CreateDispatcherThreadOptions::default())
@@ -5015,9 +5041,9 @@ mod tests {
             .store_dispatcher_runtime(&thread.id, input_tx, false, kill_tx)
             .await;
 
-        assert!(state.dispatcher_runtime_attached(&thread.id).await);
+        assert!(!state.dispatcher_runtime_attached(&thread.id).await);
         assert!(state.dispatcher_runtime_input(&thread.id).await.is_none());
-        assert!(state.dispatcher_runtime_attached(&thread.id).await);
+        assert!(!state.dispatcher_runtime_attached(&thread.id).await);
 
         let _ = fs::remove_dir_all(root);
     }

--- a/crates/conductor-server/tests/board_test.rs
+++ b/crates/conductor-server/tests/board_test.rs
@@ -219,6 +219,46 @@ async fn dispatcher_task_routes_create_update_and_handoff_deterministically() {
 }
 
 #[tokio::test]
+async fn dispatcher_task_routes_reject_unknown_explicit_thread_scope() {
+    let harness = TestHarness::new("dispatcher-task-lifecycle-missing-thread", "direct").await;
+    fs::write(
+        &harness.board_path,
+        ["## To do", "", "## Ready", "", "## In review", ""].join("\n"),
+    )
+    .unwrap();
+    let app = build_app(harness.state.clone());
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/projects/demo/dispatcher/tasks?threadId=missing-dispatcher")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "title": "Broken scoped task",
+                        "objective": "This should fail before mutating the board.",
+                        "executionMode": "worktree",
+                        "surfaces": ["crates/conductor-server/src/routes/dispatcher.rs"],
+                        "acceptance": ["No board mutation occurs when the dispatcher thread is missing."],
+                        "skills": ["rust", "dispatcher orchestration"],
+                        "deliverables": ["no-op"],
+                        "role": "intake"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let board_contents = fs::read_to_string(&harness.board_path).unwrap();
+    assert!(!board_contents.contains("Broken scoped task"));
+}
+
+#[tokio::test]
 async fn dispatcher_bindings_route_binds_openclaw_thread_to_dispatcher() {
     let harness = TestHarness::new("dispatcher-bindings-route-test", "direct").await;
     let app = build_app(harness.state.clone());
@@ -236,6 +276,7 @@ async fn dispatcher_bindings_route_binds_openclaw_thread_to_dispatcher() {
                         "threadId": "discord-thread-42",
                         "sessionId": "openclaw-session-9",
                         "channelId": "discord-channel-7",
+                        "bridgeId": "bridge-openclaw",
                         "createDispatcher": true,
                         "implementationAgent": "codex",
                         "title": "OpenClaw project thread"
@@ -265,13 +306,44 @@ async fn dispatcher_bindings_route_binds_openclaw_thread_to_dispatcher() {
     assert_eq!(binding["sessionId"], "openclaw-session-9");
     assert_eq!(binding["channelId"], "discord-channel-7");
     assert_eq!(binding["dispatcherThread"]["id"], dispatcher_thread_id);
+    let binding_bridge_query = format!(
+        "threadId={}&bridgeId={}",
+        dispatcher_thread_id, "bridge-openclaw"
+    );
+    assert_eq!(
+        binding["dispatcherEndpoints"]["dispatcher"],
+        format!("/api/projects/demo/dispatcher?{binding_bridge_query}")
+    );
+    assert_eq!(
+        binding["dispatcherEndpoints"]["feed"],
+        format!("/api/projects/demo/dispatcher/feed?{binding_bridge_query}")
+    );
+    assert_eq!(
+        binding["dispatcherEndpoints"]["stream"],
+        format!("/api/projects/demo/dispatcher/feed/stream?{binding_bridge_query}")
+    );
+    assert_eq!(
+        binding["dispatcherEndpoints"]["send"],
+        format!("/api/projects/demo/dispatcher/send?{binding_bridge_query}")
+    );
     assert_eq!(
         binding["dispatcherEndpoints"]["tasks"],
-        format!(
-            "/api/projects/demo/dispatcher/tasks?threadId={}",
-            dispatcher_thread_id
-        )
+        format!("/api/projects/demo/dispatcher/tasks?{binding_bridge_query}")
     );
+
+    let dispatcher_feed_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/api/projects/demo/dispatcher/feed?{binding_bridge_query}"
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(dispatcher_feed_response.status(), StatusCode::OK);
 
     let get_response = app
         .clone()
@@ -305,10 +377,7 @@ async fn dispatcher_bindings_route_binds_openclaw_thread_to_dispatcher() {
     );
     assert_eq!(
         get_payload["binding"]["dispatcherEndpoints"]["tasks"],
-        format!(
-            "/api/projects/demo/dispatcher/tasks?threadId={}",
-            dispatcher_thread_id
-        )
+        format!("/api/projects/demo/dispatcher/tasks?{binding_bridge_query}")
     );
 
     let update_response = app


### PR DESCRIPTION
## Summary

Fixes the dispatcher chat path so bridge-bound threads resolve through the URLs Conductor emits, explicit task mutations fail fast when the scoped dispatcher thread is missing, and headless dispatcher turns return to an idle ready state instead of looking stuck.

## User-Facing Release Notes

- Fixed dispatcher chat links for bound project threads so feed, send, and task actions resolve the intended dispatcher session.
- Fixed dispatcher task mutations to fail cleanly when a scoped dispatcher thread is missing, instead of mutating the board without linking the dispatcher context.
- Fixed headless dispatcher turns so completed runs return to an idle ready state and stale closed runtimes no longer leave the dispatcher looking busy.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Testing

- `cargo fmt`
- `cargo test -p conductor-server`
- `cargo clippy -p conductor-server --all-targets -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dispatcher now validates thread scope when processing tasks and returns 404 errors for missing threads.
  * Updated dispatcher completion handling to properly transition idle states.
  * Enhanced runtime attachment detection for closed-input scenarios.

* **Tests**
  * Added test coverage for dispatcher task route validation.
  * Updated existing tests to validate scope queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->