### PR TITLE
fix: harden dispatcher runtime isolation and approval flow

### DIFF
--- a/crates/conductor-executors/src/executor.rs
+++ b/crates/conductor-executors/src/executor.rs
@@ -224,6 +224,16 @@ where
                     let sanitized = sanitize_terminal_text(&line);
                     executor.parse_output(&sanitized)
                 }
+                ExecutorOutput::Stderr(line) => {
+                    let sanitized = sanitize_terminal_text(&line);
+                    let parsed = executor.parse_output(&sanitized);
+                    match parsed {
+                        ExecutorOutput::Stdout(ref text) if text == &sanitized => {
+                            ExecutorOutput::Stderr(sanitized)
+                        }
+                        other => other,
+                    }
+                }
                 other => other,
             };
 
@@ -400,6 +410,7 @@ mod tests {
                     ExecutorOutput::Stdout(String::new()),
                     ExecutorOutput::Stdout("second".to_string()),
                 ]),
+                "stderr-structured" => ExecutorOutput::Stdout("parsed stderr".to_string()),
                 _ => ExecutorOutput::Stdout(line.to_string()),
             }
         }
@@ -435,6 +446,30 @@ mod tests {
 
         let fourth = parsed_rx.recv().await.unwrap();
         assert!(matches!(fourth, ExecutorOutput::Stderr(ref text) if text == "stderr"));
+
+        assert!(parsed_rx.recv().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn wrap_parsed_output_parses_structured_stderr_without_losing_plain_stderr() {
+        let (raw_tx, raw_rx) = mpsc::channel::<ExecutorOutput>(8);
+        let mut parsed_rx = wrap_parsed_output(DummyExecutor, raw_rx);
+
+        raw_tx
+            .send(ExecutorOutput::Stderr("stderr-structured".to_string()))
+            .await
+            .unwrap();
+        raw_tx
+            .send(ExecutorOutput::Stderr("stderr".to_string()))
+            .await
+            .unwrap();
+        drop(raw_tx);
+
+        let first = parsed_rx.recv().await.unwrap();
+        assert!(matches!(first, ExecutorOutput::Stdout(ref text) if text == "parsed stderr"));
+
+        let second = parsed_rx.recv().await.unwrap();
+        assert!(matches!(second, ExecutorOutput::Stderr(ref text) if text == "stderr"));
 
         assert!(parsed_rx.recv().await.is_none());
     }

--- a/crates/conductor-executors/src/executor.rs
+++ b/crates/conductor-executors/src/executor.rs
@@ -311,7 +311,9 @@ fn flatten_parsed_output(event: ExecutorOutput) -> Vec<ExecutorOutput> {
         ExecutorOutput::Composite(events) => {
             events.into_iter().flat_map(flatten_parsed_output).collect()
         }
-        ExecutorOutput::Stdout(text) if text.trim().is_empty() => Vec::new(),
+        ExecutorOutput::Stdout(text) | ExecutorOutput::Stderr(text) if text.trim().is_empty() => {
+            Vec::new()
+        }
         other => vec![other],
     }
 }
@@ -457,6 +459,10 @@ mod tests {
 
         raw_tx
             .send(ExecutorOutput::Stderr("stderr-structured".to_string()))
+            .await
+            .unwrap();
+        raw_tx
+            .send(ExecutorOutput::Stderr("   ".to_string()))
             .await
             .unwrap();
         raw_tx

--- a/crates/conductor-executors/src/process.rs
+++ b/crates/conductor-executors/src/process.rs
@@ -445,13 +445,25 @@ pub async fn spawn_process_no_stdin_with_env_removals(
         use std::os::unix::process::CommandExt;
         unsafe {
             cmd.pre_exec(|| {
-                libc::setpgid(0, 0);
+                if libc::setpgid(0, 0) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
                 Ok(())
             });
         }
     }
 
     let mut child = cmd.spawn()?;
+    #[cfg(unix)]
+    if let Some(pid) = child.id() {
+        let result = unsafe { libc::setpgid(pid as libc::pid_t, pid as libc::pid_t) };
+        if result != 0 {
+            let error = std::io::Error::last_os_error();
+            if error.raw_os_error() != Some(libc::EACCES) {
+                return Err(error.into());
+            }
+        }
+    }
     let pid = child.id().unwrap_or(0);
 
     let stdout = child
@@ -608,6 +620,7 @@ mod tests {
         .await
         .expect("headless process should spawn");
 
+        assert_ne!(handle.pid, 0, "headless process should expose a valid pid");
         let parent_pgid = unsafe { libc::getpgrp() };
         let child_pgid = unsafe { libc::getpgid(handle.pid as libc::pid_t) };
 

--- a/crates/conductor-executors/src/process.rs
+++ b/crates/conductor-executors/src/process.rs
@@ -439,6 +439,18 @@ pub async fn spawn_process_no_stdin_with_env_removals(
 
     apply_tokio_command_env(&mut cmd, env, env_remove);
 
+    #[cfg(unix)]
+    {
+        #[allow(unused_imports)]
+        use std::os::unix::process::CommandExt;
+        unsafe {
+            cmd.pre_exec(|| {
+                libc::setpgid(0, 0);
+                Ok(())
+            });
+        }
+    }
+
     let mut child = cmd.spawn()?;
     let pid = child.id().unwrap_or(0);
 
@@ -571,7 +583,7 @@ fn flush_terminal_line_buffer(buffer: &mut Vec<u8>) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_process_alive, spawn_process, ExecutorOutput};
+    use super::{is_process_alive, spawn_process, spawn_process_no_stdin, ExecutorOutput};
     use std::collections::HashMap;
     use std::path::Path;
     use tokio::time::{timeout, Duration};
@@ -580,6 +592,32 @@ mod tests {
         line.split("child_pid=")
             .nth(1)
             .and_then(|value| value.trim().parse::<u32>().ok())
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn spawn_process_no_stdin_isolates_child_process_group() {
+        use nix::libc;
+
+        let handle = spawn_process_no_stdin(
+            Path::new("/bin/sh"),
+            &["-lc".to_string(), "sleep 5".to_string()],
+            Path::new("."),
+            &HashMap::new(),
+        )
+        .await
+        .expect("headless process should spawn");
+
+        let parent_pgid = unsafe { libc::getpgrp() };
+        let child_pgid = unsafe { libc::getpgid(handle.pid as libc::pid_t) };
+
+        let _ = handle.kill_tx.send(());
+
+        assert!(child_pgid > 0, "child process group should be valid");
+        assert_ne!(
+            child_pgid, parent_pgid,
+            "headless runtime should not share a process group with conductor"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/conductor-server/src/routes/dispatcher.rs
+++ b/crates/conductor-server/src/routes/dispatcher.rs
@@ -16,15 +16,33 @@ use crate::dispatcher_task_lifecycle::{
     DispatcherTaskCreateInput, DispatcherTaskMutationContext, DispatcherTaskUpdateInput,
 };
 use crate::state::{
-    build_normalized_chat_feed, is_project_dispatcher_session, AppState,
+    build_dispatcher_chat_feed, is_project_dispatcher_session, AppState,
     CreateDispatcherThreadOptions, DispatcherBindingLookup, DispatcherPreferencesPatch,
-    OpenClawDispatcherConfigPatch, SessionRecord, UpsertDispatcherBindingInput,
+    OpenClawDispatcherConfigPatch, SessionRecord, SessionStatus, UpsertDispatcherBindingInput,
 };
 
 type ApiResponse = (StatusCode, Json<Value>);
 
 const DEFAULT_FEED_WINDOW_LIMIT: usize = 120;
 const MAX_FEED_WINDOW_LIMIT: usize = 240;
+const DISPATCHER_APPROVAL_STATE_METADATA_KEY: &str = "acpPlanApprovalState";
+const DISPATCHER_APPROVAL_REQUIRED: &str = "approval_required";
+const DISPATCHER_APPROVAL_PARSER_STATE_KEY: &str = "parserState";
+
+fn dispatcher_is_waiting_for_plan_approval(dispatcher: &SessionRecord) -> bool {
+    dispatcher
+        .metadata
+        .get(DISPATCHER_APPROVAL_STATE_METADATA_KEY)
+        .map(String::as_str)
+        == Some(DISPATCHER_APPROVAL_REQUIRED)
+        && dispatcher.status == SessionStatus::NeedsInput
+        && (dispatcher.activity.as_deref() == Some("waiting_input")
+            || dispatcher
+                .metadata
+                .get(DISPATCHER_APPROVAL_PARSER_STATE_KEY)
+                .map(String::as_str)
+                == Some(DISPATCHER_APPROVAL_REQUIRED))
+}
 
 pub fn router() -> Router<Arc<AppState>> {
     Router::new()
@@ -70,6 +88,14 @@ pub fn router() -> Router<Arc<AppState>> {
         .route(
             "/api/projects/{project_id}/dispatcher/send",
             post(send_to_dispatcher),
+        )
+        .route(
+            "/api/projects/{project_id}/dispatcher/approve",
+            post(approve_dispatcher_plan),
+        )
+        .route(
+            "/api/projects/{project_id}/dispatcher/reject",
+            post(reject_dispatcher_plan),
         )
         .route(
             "/api/projects/{project_id}/dispatcher/interrupt",
@@ -760,7 +786,7 @@ async fn dispatcher_feed_payload(
             })
         });
 
-    let all_entries = build_normalized_chat_feed(dispatcher);
+    let all_entries = build_dispatcher_chat_feed(dispatcher);
     let total_entries = all_entries.len();
     let entries = if total_entries > window_limit {
         all_entries
@@ -780,7 +806,7 @@ async fn dispatcher_feed_payload(
         "approvalState": dispatcher.metadata.get("acpPlanApprovalState").cloned(),
         "parserState": parser_state,
         "runtimeStatus": Value::Null,
-        "source": if dispatcher.output.is_empty() { "conversation-only" } else { "runtime-output" },
+        "source": "dispatcher_conversation",
         "integration": dispatcher_integration_payload(dispatcher, &dispatcher.project_id),
     });
 
@@ -1140,6 +1166,73 @@ async fn send_to_dispatcher(
         }
         Err(err) => error(StatusCode::BAD_REQUEST, err.to_string()),
     }
+}
+
+async fn dispatch_approval_action(
+    state: Arc<AppState>,
+    project_id: String,
+    query: DispatcherQuery,
+    action: &'static str,
+) -> ApiResponse {
+    let bridge_id = trimmed_query_value(query.bridge_id.as_deref());
+    let dispatcher = match resolve_project_dispatcher(
+        &state,
+        &project_id,
+        bridge_id,
+        query.thread_id.as_deref(),
+    )
+    .await
+    {
+        Some(dispatcher) => dispatcher,
+        None => {
+            return error(
+                StatusCode::NOT_FOUND,
+                format!("Dispatcher thread for project {project_id} not found"),
+            );
+        }
+    };
+
+    if !dispatcher_is_waiting_for_plan_approval(&dispatcher) {
+        return error(
+            StatusCode::CONFLICT,
+            format!(
+                "Dispatcher thread {} is not waiting for plan approval",
+                dispatcher.id
+            ),
+        );
+    }
+
+    let request = crate::state::DispatcherTurnRequest::plain(
+        action.to_string(),
+        Vec::new(),
+        None,
+        None,
+        "dispatcher_approval",
+    );
+
+    match state
+        .send_to_dispatcher_thread(&dispatcher.id, request)
+        .await
+    {
+        Ok(()) => ok(json!({ "ok": true, "threadId": dispatcher.id })),
+        Err(err) => error(StatusCode::BAD_REQUEST, err.to_string()),
+    }
+}
+
+async fn approve_dispatcher_plan(
+    State(state): State<Arc<AppState>>,
+    Path(project_id): Path<String>,
+    Query(query): Query<DispatcherQuery>,
+) -> ApiResponse {
+    dispatch_approval_action(state, project_id, query, "approve").await
+}
+
+async fn reject_dispatcher_plan(
+    State(state): State<Arc<AppState>>,
+    Path(project_id): Path<String>,
+    Query(query): Query<DispatcherQuery>,
+) -> ApiResponse {
+    dispatch_approval_action(state, project_id, query, "reject").await
 }
 
 async fn interrupt_dispatcher(

--- a/crates/conductor-server/src/state/acp_dispatcher.rs
+++ b/crates/conductor-server/src/state/acp_dispatcher.rs
@@ -837,20 +837,25 @@ fn set_parser_state(
     }
 
     let mut changed = false;
-    changed |= session
+    let previous_kind = session
         .metadata
-        .insert(PARSER_STATE_KEY.to_string(), kind.to_string())
-        .is_some_and(|value| value != kind);
-    changed |= session
-        .metadata
-        .insert(PARSER_STATE_MESSAGE_KEY.to_string(), trimmed.to_string())
-        .is_some_and(|value| value != trimmed);
+        .insert(PARSER_STATE_KEY.to_string(), kind.to_string());
+    changed |= previous_kind.as_deref() != Some(kind);
 
-    if let Some(value) = command.filter(|value| !value.trim().is_empty()) {
-        changed |= session
+    let previous_message = session
+        .metadata
+        .insert(PARSER_STATE_MESSAGE_KEY.to_string(), trimmed.to_string());
+    changed |= previous_message.as_deref() != Some(trimmed);
+
+    if let Some(value) = command
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let previous_command = session
             .metadata
-            .insert(PARSER_STATE_COMMAND_KEY.to_string(), value.to_string())
-            .is_some_and(|current| current != value);
+            .insert(PARSER_STATE_COMMAND_KEY.to_string(), value.to_string());
+        changed |= previous_command.as_deref() != Some(value);
     } else {
         changed |= session.metadata.remove(PARSER_STATE_COMMAND_KEY).is_some();
     }
@@ -880,6 +885,9 @@ fn mark_dispatcher_waiting_for_approval(session: &mut SessionRecord) -> bool {
     }
     if session.summary.as_deref() != Some(ACP_APPROVAL_READY_MESSAGE) {
         session.summary = Some(ACP_APPROVAL_READY_MESSAGE.to_string());
+        changed = true;
+    }
+    if session.metadata.get("summary").map(String::as_str) != Some(ACP_APPROVAL_READY_MESSAGE) {
         session.metadata.insert(
             "summary".to_string(),
             ACP_APPROVAL_READY_MESSAGE.to_string(),
@@ -4259,7 +4267,84 @@ mod tests {
     }
 
     #[test]
-    fn prepare_dispatcher_runtime_env_removes_conflicting_color_overrides() {
+    fn set_parser_state_trims_commands_before_dirty_tracking() {
+        let mut session = SessionRecord::new(
+            "dispatcher-1".to_string(),
+            "demo".to_string(),
+            None,
+            None,
+            None,
+            "codex".to_string(),
+            None,
+            None,
+            "prompt".to_string(),
+            None,
+        );
+
+        assert!(super::set_parser_state(
+            &mut session,
+            ACP_APPROVAL_REQUIRED,
+            "Need approval",
+            Some(" resume-turn ".to_string()),
+        ));
+        assert_eq!(
+            session
+                .metadata
+                .get(super::PARSER_STATE_COMMAND_KEY)
+                .map(String::as_str),
+            Some("resume-turn")
+        );
+
+        assert!(!super::set_parser_state(
+            &mut session,
+            ACP_APPROVAL_REQUIRED,
+            "Need approval",
+            Some("resume-turn".to_string()),
+        ));
+    }
+
+    #[test]
+    fn mark_dispatcher_waiting_for_approval_tracks_summary_only_changes() {
+        let mut session = SessionRecord::new(
+            "dispatcher-1".to_string(),
+            "demo".to_string(),
+            None,
+            None,
+            None,
+            "codex".to_string(),
+            None,
+            None,
+            "prompt".to_string(),
+            None,
+        );
+        session.status = SessionStatus::NeedsInput;
+        session.activity = Some("waiting_input".to_string());
+        session.summary = Some("Old summary".to_string());
+        session
+            .metadata
+            .insert("summary".to_string(), "Old summary".to_string());
+        session.metadata.insert(
+            super::PARSER_STATE_KEY.to_string(),
+            ACP_APPROVAL_REQUIRED.to_string(),
+        );
+        session.metadata.insert(
+            super::PARSER_STATE_MESSAGE_KEY.to_string(),
+            super::ACP_APPROVAL_READY_MESSAGE.to_string(),
+        );
+
+        assert!(super::mark_dispatcher_waiting_for_approval(&mut session));
+        assert_eq!(
+            session.summary.as_deref(),
+            Some(super::ACP_APPROVAL_READY_MESSAGE)
+        );
+        assert_eq!(
+            session.metadata.get("summary").map(String::as_str),
+            Some(super::ACP_APPROVAL_READY_MESSAGE)
+        );
+    }
+
+    #[test]
+    fn prepare_dispatcher_runtime_env_preserves_existing_term() {
         let mut env = HashMap::from([
             ("NO_COLOR".to_string(), "1".to_string()),
             ("FORCE_COLOR".to_string(), "1".to_string()),

--- a/crates/conductor-server/src/state/acp_dispatcher.rs
+++ b/crates/conductor-server/src/state/acp_dispatcher.rs
@@ -1288,26 +1288,17 @@ fn normalize_loaded_dispatcher_thread(thread: &mut SessionRecord) -> bool {
             .insert("role".to_string(), "orchestrator".to_string());
         changed = true;
     }
-    let should_set_default_approval = thread
+    let approval_state = thread
         .metadata
         .get(ACP_APPROVAL_STATE_METADATA_KEY)
-        .map(String::as_str)
-        .is_none();
+        .cloned();
+    let approval_required = approval_state.as_deref() == Some(ACP_APPROVAL_REQUIRED);
+    let should_set_default_approval = approval_state.is_none();
     if should_set_default_approval {
         thread.metadata.insert(
             ACP_APPROVAL_STATE_METADATA_KEY.to_string(),
             ACP_APPROVAL_GRANTED.to_string(),
         );
-        changed = true;
-    } else if thread
-        .metadata
-        .get(ACP_APPROVAL_STATE_METADATA_KEY)
-        .map(String::as_str)
-        == Some(ACP_APPROVAL_REQUIRED)
-        && thread.status == SessionStatus::Idle
-        && thread.activity.as_deref() == Some("idle")
-        && mark_dispatcher_waiting_for_approval(thread)
-    {
         changed = true;
     }
 
@@ -1349,19 +1340,12 @@ fn normalize_loaded_dispatcher_thread(thread: &mut SessionRecord) -> bool {
         }
     }
 
-    if thread
-        .metadata
-        .get(ACP_APPROVAL_STATE_METADATA_KEY)
-        .map(String::as_str)
-        == Some(ACP_APPROVAL_REQUIRED)
-        && thread.status == SessionStatus::NeedsInput
-        && thread.activity.as_deref() == Some("waiting_input")
-        && set_parser_state(
-            thread,
-            ACP_APPROVAL_REQUIRED,
-            ACP_APPROVAL_READY_MESSAGE,
-            None,
+    if approval_required
+        && matches!(
+            thread.status,
+            SessionStatus::Idle | SessionStatus::NeedsInput
         )
+        && mark_dispatcher_waiting_for_approval(thread)
     {
         changed = true;
     }
@@ -4703,6 +4687,51 @@ mod tests {
                 .get(ACP_APPROVAL_STATE_METADATA_KEY)
                 .map(String::as_str),
             Some(ACP_APPROVAL_REQUIRED)
+        );
+        assert_eq!(
+            thread.metadata.get("parserState").map(String::as_str),
+            Some("approval_required")
+        );
+    }
+
+    #[test]
+    fn normalize_loaded_dispatcher_thread_restores_working_plan_reviews_to_needs_input() {
+        let mut thread = SessionRecord::new(
+            "dispatcher-load-approval-working".to_string(),
+            "demo".to_string(),
+            None,
+            None,
+            Some("/repo".to_string()),
+            "codex".to_string(),
+            None,
+            None,
+            "dispatcher prompt".to_string(),
+            None,
+        );
+        thread.status = SessionStatus::Working;
+        thread.activity = Some("active".to_string());
+        thread.summary = Some("Runtime still winding down".to_string());
+        thread
+            .metadata
+            .insert("sessionKind".to_string(), ACP_SESSION_KIND.to_string());
+        thread
+            .metadata
+            .insert("role".to_string(), "orchestrator".to_string());
+        thread.metadata.insert(
+            ACP_APPROVAL_STATE_METADATA_KEY.to_string(),
+            ACP_APPROVAL_REQUIRED.to_string(),
+        );
+
+        assert!(normalize_loaded_dispatcher_thread(&mut thread));
+        assert_eq!(thread.status, SessionStatus::NeedsInput);
+        assert_eq!(thread.activity.as_deref(), Some("waiting_input"));
+        assert_eq!(
+            thread.summary.as_deref(),
+            Some(super::ACP_APPROVAL_READY_MESSAGE)
+        );
+        assert_eq!(
+            thread.metadata.get("summary").map(String::as_str),
+            Some(super::ACP_APPROVAL_READY_MESSAGE)
         );
         assert_eq!(
             thread.metadata.get("parserState").map(String::as_str),

--- a/crates/conductor-server/src/state/acp_dispatcher.rs
+++ b/crates/conductor-server/src/state/acp_dispatcher.rs
@@ -45,6 +45,8 @@ const ACP_WATCHDOG_INTERVAL: std::time::Duration = std::time::Duration::from_sec
 const ACP_APPROVAL_STATE_METADATA_KEY: &str = "acpPlanApprovalState";
 const ACP_APPROVAL_REQUIRED: &str = "approval_required";
 const ACP_APPROVAL_GRANTED: &str = "approved_for_next_mutation";
+const ACP_APPROVAL_READY_MESSAGE: &str =
+    "Plan ready for approval. Review the proposal, then approve it or request changes.";
 pub(crate) const ACP_SESSION_MEMORY_SYNCED_AT_METADATA_KEY: &str = "acpSessionMemorySyncedAt";
 pub(crate) const ACP_ACTIVE_SKILLS_METADATA_KEY: &str = "acpActiveSkills";
 pub(crate) const ACP_IMPLEMENTATION_AGENT_METADATA_KEY: &str = "acpImplementationAgent";
@@ -866,6 +868,35 @@ fn parser_state_signature(
     )
 }
 
+fn mark_dispatcher_waiting_for_approval(session: &mut SessionRecord) -> bool {
+    let mut changed = false;
+    if session.status != SessionStatus::NeedsInput {
+        session.status = SessionStatus::NeedsInput;
+        changed = true;
+    }
+    if session.activity.as_deref() != Some("waiting_input") {
+        session.activity = Some("waiting_input".to_string());
+        changed = true;
+    }
+    if session.summary.as_deref() != Some(ACP_APPROVAL_READY_MESSAGE) {
+        session.summary = Some(ACP_APPROVAL_READY_MESSAGE.to_string());
+        session.metadata.insert(
+            "summary".to_string(),
+            ACP_APPROVAL_READY_MESSAGE.to_string(),
+        );
+        changed = true;
+    }
+    if set_parser_state(
+        session,
+        ACP_APPROVAL_REQUIRED,
+        ACP_APPROVAL_READY_MESSAGE,
+        None,
+    ) {
+        changed = true;
+    }
+    changed
+}
+
 fn auth_command_hint(agent: &str, text: &str) -> Option<String> {
     let lower = text.to_lowercase();
     for candidate in [
@@ -1249,24 +1280,26 @@ fn normalize_loaded_dispatcher_thread(thread: &mut SessionRecord) -> bool {
             .insert("role".to_string(), "orchestrator".to_string());
         changed = true;
     }
-    let should_grant_approval = thread
+    let should_set_default_approval = thread
         .metadata
         .get(ACP_APPROVAL_STATE_METADATA_KEY)
         .map(String::as_str)
-        .is_none()
-        || (thread
-            .metadata
-            .get(ACP_APPROVAL_STATE_METADATA_KEY)
-            .map(String::as_str)
-            == Some(ACP_APPROVAL_REQUIRED)
-            && thread.status == SessionStatus::Idle
-            && thread.activity.as_deref() == Some("idle")
-            && thread.summary.as_deref() == Some("Dispatcher ready"));
-    if should_grant_approval {
+        .is_none();
+    if should_set_default_approval {
         thread.metadata.insert(
             ACP_APPROVAL_STATE_METADATA_KEY.to_string(),
             ACP_APPROVAL_GRANTED.to_string(),
         );
+        changed = true;
+    } else if thread
+        .metadata
+        .get(ACP_APPROVAL_STATE_METADATA_KEY)
+        .map(String::as_str)
+        == Some(ACP_APPROVAL_REQUIRED)
+        && thread.status == SessionStatus::Idle
+        && thread.activity.as_deref() == Some("idle")
+        && mark_dispatcher_waiting_for_approval(thread)
+    {
         changed = true;
     }
 
@@ -1306,6 +1339,23 @@ fn normalize_loaded_dispatcher_thread(thread: &mut SessionRecord) -> bool {
         if thread.metadata.remove(key).is_some() {
             changed = true;
         }
+    }
+
+    if thread
+        .metadata
+        .get(ACP_APPROVAL_STATE_METADATA_KEY)
+        .map(String::as_str)
+        == Some(ACP_APPROVAL_REQUIRED)
+        && thread.status == SessionStatus::NeedsInput
+        && thread.activity.as_deref() == Some("waiting_input")
+        && set_parser_state(
+            thread,
+            ACP_APPROVAL_REQUIRED,
+            ACP_APPROVAL_READY_MESSAGE,
+            None,
+        )
+    {
+        changed = true;
     }
 
     if apply_dispatcher_implementation_preferences(thread, None, None, None) {
@@ -3670,48 +3720,64 @@ impl AppState {
                     .metadata
                     .insert("exitCode".to_string(), exit_code.to_string());
                 if exit_code == 0 {
-                    let uses_headless_turns =
-                        dispatcher_uses_headless_turns(&AgentKind::parse(&thread.agent));
-                    if uses_headless_turns {
-                        if thread.status != SessionStatus::Idle {
-                            thread.status = SessionStatus::Idle;
+                    let approval_required = thread
+                        .metadata
+                        .get(ACP_APPROVAL_STATE_METADATA_KEY)
+                        .map(String::as_str)
+                        == Some(ACP_APPROVAL_REQUIRED);
+                    if approval_required {
+                        if mark_dispatcher_waiting_for_approval(thread) {
                             feed_dirty = true;
                         }
-                        thread.activity = Some("idle".to_string());
                         thread
                             .metadata
                             .insert("finishedAt".to_string(), Utc::now().to_rfc3339());
-                        if thread
-                            .summary
-                            .as_ref()
-                            .map(|value| value.trim().is_empty())
-                            .unwrap_or(true)
-                        {
-                            thread.summary = Some("Dispatcher ready for the next turn".to_string());
-                            thread.metadata.insert(
-                                "summary".to_string(),
-                                "Dispatcher ready for the next turn".to_string(),
-                            );
-                        }
                     } else {
-                        if thread.status != SessionStatus::NeedsInput {
-                            thread.status = SessionStatus::NeedsInput;
-                            feed_dirty = true;
-                        }
-                        thread.activity = Some("waiting_input".to_string());
-                        thread
-                            .metadata
-                            .insert("finishedAt".to_string(), Utc::now().to_rfc3339());
-                        if thread
-                            .summary
-                            .as_ref()
-                            .map(|value| value.trim().is_empty())
-                            .unwrap_or(true)
-                        {
-                            thread.summary = Some("Ready for follow-up".to_string());
+                        let uses_headless_turns =
+                            dispatcher_uses_headless_turns(&AgentKind::parse(&thread.agent));
+                        if uses_headless_turns {
+                            if thread.status != SessionStatus::Idle {
+                                thread.status = SessionStatus::Idle;
+                                feed_dirty = true;
+                            }
+                            thread.activity = Some("idle".to_string());
                             thread
                                 .metadata
-                                .insert("summary".to_string(), "Ready for follow-up".to_string());
+                                .insert("finishedAt".to_string(), Utc::now().to_rfc3339());
+                            if thread
+                                .summary
+                                .as_ref()
+                                .map(|value| value.trim().is_empty())
+                                .unwrap_or(true)
+                            {
+                                thread.summary =
+                                    Some("Dispatcher ready for the next turn".to_string());
+                                thread.metadata.insert(
+                                    "summary".to_string(),
+                                    "Dispatcher ready for the next turn".to_string(),
+                                );
+                            }
+                        } else {
+                            if thread.status != SessionStatus::NeedsInput {
+                                thread.status = SessionStatus::NeedsInput;
+                                feed_dirty = true;
+                            }
+                            thread.activity = Some("waiting_input".to_string());
+                            thread
+                                .metadata
+                                .insert("finishedAt".to_string(), Utc::now().to_rfc3339());
+                            if thread
+                                .summary
+                                .as_ref()
+                                .map(|value| value.trim().is_empty())
+                                .unwrap_or(true)
+                            {
+                                thread.summary = Some("Ready for follow-up".to_string());
+                                thread.metadata.insert(
+                                    "summary".to_string(),
+                                    "Ready for follow-up".to_string(),
+                                );
+                            }
                         }
                     }
                 } else {
@@ -4059,11 +4125,11 @@ mod tests {
         merge_dispatcher_context_attachments, normalize_loaded_dispatcher_thread,
         prepare_dispatcher_runtime_env, read_json, AcpSessionMemoryState, AppState,
         CreateDispatcherThreadOptions, DispatcherPreferencesPatch, OpenClawDispatcherConfigPatch,
-        ACP_APPROVAL_GRANTED, ACP_APPROVAL_REQUIRED, ACP_APPROVAL_STATE_METADATA_KEY,
-        ACP_HEARTBEAT_INTERVAL, ACP_IMPLEMENTATION_AGENT_METADATA_KEY,
-        ACP_RESUME_TARGET_METADATA_KEY, ACP_SESSION_KIND, OPENCLAW_GATEWAY_SCOPES_METADATA_KEY,
-        OPENCLAW_GATEWAY_TOKEN_CONFIGURED_METADATA_KEY, OPENCLAW_GATEWAY_TOKEN_METADATA_KEY,
-        OPENCLAW_GATEWAY_URL_METADATA_KEY, OPENCLAW_SESSION_KEY_METADATA_KEY,
+        ACP_APPROVAL_REQUIRED, ACP_APPROVAL_STATE_METADATA_KEY, ACP_HEARTBEAT_INTERVAL,
+        ACP_IMPLEMENTATION_AGENT_METADATA_KEY, ACP_RESUME_TARGET_METADATA_KEY, ACP_SESSION_KIND,
+        OPENCLAW_GATEWAY_SCOPES_METADATA_KEY, OPENCLAW_GATEWAY_TOKEN_CONFIGURED_METADATA_KEY,
+        OPENCLAW_GATEWAY_TOKEN_METADATA_KEY, OPENCLAW_GATEWAY_URL_METADATA_KEY,
+        OPENCLAW_SESSION_KEY_METADATA_KEY,
     };
     use crate::state::{ConversationEntry, DispatcherTurnRequest, SessionRecord, SessionStatus};
     use anyhow::Result;
@@ -4516,7 +4582,7 @@ mod tests {
     }
 
     #[test]
-    fn normalize_loaded_dispatcher_thread_restores_ready_dispatchers_to_execution_mode() {
+    fn normalize_loaded_dispatcher_thread_restores_pending_plan_reviews_to_needs_input() {
         let mut thread = SessionRecord::new(
             "dispatcher-load-approval".to_string(),
             "demo".to_string(),
@@ -4544,13 +4610,90 @@ mod tests {
         );
 
         assert!(normalize_loaded_dispatcher_thread(&mut thread));
+        assert_eq!(thread.status, SessionStatus::NeedsInput);
+        assert_eq!(thread.activity.as_deref(), Some("waiting_input"));
         assert_eq!(
             thread
                 .metadata
                 .get(ACP_APPROVAL_STATE_METADATA_KEY)
                 .map(String::as_str),
-            Some(ACP_APPROVAL_GRANTED)
+            Some(ACP_APPROVAL_REQUIRED)
         );
+        assert_eq!(
+            thread.metadata.get("parserState").map(String::as_str),
+            Some("approval_required")
+        );
+    }
+
+    #[tokio::test]
+    async fn headless_plan_only_dispatcher_turn_waits_for_explicit_approval() {
+        let (root, state) = build_test_state("acp-headless-plan-only").await;
+        let thread = state
+            .create_project_dispatcher_thread("demo", CreateDispatcherThreadOptions::default())
+            .await
+            .expect("dispatcher thread should be created");
+
+        state.executors.write().await.insert(
+            AgentKind::Codex,
+            Arc::new(DelayedHeadlessExecutor {
+                assistant_text: "## Proposed plan\n\n1. Create a task.\n2. Ask for approval."
+                    .to_string(),
+                delay: Duration::from_millis(200),
+            }),
+        );
+
+        state
+            .send_to_dispatcher_thread(
+                &thread.id,
+                DispatcherTurnRequest::plain(
+                    "plan only".to_string(),
+                    Vec::new(),
+                    None,
+                    None,
+                    "chat",
+                ),
+            )
+            .await
+            .expect("dispatcher send should succeed");
+
+        let updated = timeout(Duration::from_secs(3), async {
+            loop {
+                let updated = state
+                    .get_dispatcher_thread(&thread.id)
+                    .await
+                    .expect("dispatcher thread should still exist");
+                let has_reply = updated.conversation.iter().any(|entry| {
+                    entry.kind == "assistant_message" && entry.text.contains("Proposed plan")
+                });
+                if has_reply && updated.status == SessionStatus::NeedsInput {
+                    break updated;
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .expect("plan-only runtime should eventually wait for approval");
+
+        assert_eq!(updated.status, SessionStatus::NeedsInput);
+        assert_eq!(updated.activity.as_deref(), Some("waiting_input"));
+        assert_eq!(
+            updated
+                .metadata
+                .get(ACP_APPROVAL_STATE_METADATA_KEY)
+                .map(String::as_str),
+            Some(ACP_APPROVAL_REQUIRED)
+        );
+        assert_eq!(
+            updated.metadata.get("parserState").map(String::as_str),
+            Some("approval_required")
+        );
+        assert!(updated
+            .summary
+            .as_deref()
+            .unwrap_or_default()
+            .contains("approval"));
+
+        let _ = fs::remove_dir_all(root);
     }
 
     #[tokio::test]

--- a/crates/conductor-server/src/state/helpers.rs
+++ b/crates/conductor-server/src/state/helpers.rs
@@ -1239,6 +1239,87 @@ pub fn build_normalized_chat_feed(session: &SessionRecord) -> Vec<Value> {
     feed
 }
 
+pub fn build_dispatcher_chat_feed(session: &SessionRecord) -> Vec<Value> {
+    let mut feed = Vec::new();
+    let is_streaming = is_streaming_status(&session.status);
+    let last_runtime_assistant_id = if is_streaming {
+        session
+            .conversation
+            .iter()
+            .rev()
+            .find(|entry| {
+                entry.kind == "assistant_message"
+                    && entry.source == "runtime"
+                    && !is_runtime_internal_noise_text(&entry.text)
+                    && !is_runtime_transport_dump(&entry.text)
+            })
+            .map(|entry| entry.id.clone())
+    } else {
+        None
+    };
+
+    for entry in &session.conversation {
+        let skip_runtime_dump = entry.source == "runtime"
+            && (is_runtime_transport_dump(&entry.text)
+                || is_runtime_internal_noise_text(&entry.text));
+        if skip_runtime_dump {
+            continue;
+        }
+
+        if entry.kind == "assistant_message" && entry.source == "runtime" {
+            push_runtime_assistant_segments(
+                &mut feed,
+                session,
+                entry,
+                last_runtime_assistant_id.as_deref() == Some(entry.id.as_str()),
+            );
+            continue;
+        }
+
+        let kind = match entry.kind.as_str() {
+            "user_message" => "user",
+            "assistant_message" => "assistant",
+            "system_message" => "system",
+            "tool_message" => "tool",
+            "status_message" => "status",
+            _ => "status",
+        };
+        let tool_kind_present = entry.metadata.contains_key("toolTitle");
+        let label = match entry.kind.as_str() {
+            "user_message" if entry.source == "feedback" => "Feedback",
+            "user_message" => "You",
+            "assistant_message" => "Assistant",
+            "system_message" if entry.source == "restore" => "Restored",
+            "system_message" => "System",
+            "tool_message" => "Tool",
+            "status_message" if tool_kind_present => "Tool",
+            "status_message" => "Session",
+            _ => "Session",
+        };
+        feed.push(json!({
+            "id": entry.id,
+            "kind": if entry.kind == "status_message" && tool_kind_present { "tool" } else { kind },
+            "label": label,
+            "text": entry.text,
+            "createdAt": entry.created_at,
+            "attachments": normalized_entry_attachments(session, entry),
+            "source": entry.source,
+            "streaming": entry.kind == "assistant_message"
+                && entry.source == "runtime"
+                && last_runtime_assistant_id.as_deref() == Some(entry.id.as_str()),
+            "metadata": entry.metadata,
+        }));
+    }
+
+    finalize_tool_statuses(&mut feed, &session.status);
+
+    if feed.len() > DEFAULT_SESSION_HISTORY_LIMIT {
+        feed = feed.split_off(feed.len() - DEFAULT_SESSION_HISTORY_LIMIT);
+    }
+
+    feed
+}
+
 fn finalize_tool_statuses(feed: &mut [Value], session_status: &SessionStatus) {
     let session_is_streaming = is_streaming_status(session_status);
     let session_failed = is_failed_session_status(session_status);
@@ -1889,6 +1970,66 @@ mod tests {
             attachments,
             &vec![Value::String("notes/spec.md".to_string())]
         );
+    }
+
+    #[test]
+    fn build_dispatcher_chat_feed_ignores_runtime_output_fallback_and_synthetic_status_rows() {
+        let mut session = SessionRecord::new(
+            "dispatcher-feed".to_string(),
+            "demo".to_string(),
+            None,
+            None,
+            Some("/tmp/demo".to_string()),
+            "codex".to_string(),
+            None,
+            None,
+            "Plan the work".to_string(),
+            None,
+        );
+        session.status = SessionStatus::NeedsInput;
+        session
+            .metadata
+            .insert("sessionKind".to_string(), "project_dispatcher".to_string());
+        session.output = "raw runtime fallback that should never appear".to_string();
+        session.conversation.push(ConversationEntry {
+            id: "user-turn".to_string(),
+            kind: "user_message".to_string(),
+            text: "plan this carefully".to_string(),
+            created_at: Utc::now().to_rfc3339(),
+            source: "dispatcher_ui".to_string(),
+            attachments: Vec::new(),
+            metadata: HashMap::new(),
+        });
+        session.conversation.push(ConversationEntry {
+            id: "assistant-plan".to_string(),
+            kind: "assistant_message".to_string(),
+            text: "## Proposed plan\n\n1. Review the board.\n2. Ask for approval.".to_string(),
+            created_at: Utc::now().to_rfc3339(),
+            source: "runtime".to_string(),
+            attachments: Vec::new(),
+            metadata: HashMap::new(),
+        });
+
+        let feed = build_dispatcher_chat_feed(&session);
+        let ids = feed
+            .iter()
+            .filter_map(|entry| entry.get("id").and_then(Value::as_str))
+            .collect::<Vec<_>>();
+        let texts = feed
+            .iter()
+            .filter_map(|entry| entry.get("text").and_then(Value::as_str))
+            .collect::<Vec<_>>();
+
+        assert_eq!(ids.len(), 2);
+        assert_eq!(ids[0], "user-turn");
+        assert!(ids[1].starts_with("assistant-plan"));
+        assert!(texts.iter().any(|text| text.contains("Proposed plan")));
+        assert!(texts
+            .iter()
+            .all(|text| !text.contains("raw runtime fallback that should never appear")));
+        assert!(feed
+            .iter()
+            .all(|entry| entry.get("kind").and_then(Value::as_str) != Some("status")));
     }
 
     #[test]

--- a/crates/conductor-server/src/state/mod.rs
+++ b/crates/conductor-server/src/state/mod.rs
@@ -40,7 +40,8 @@ pub(crate) use dispatcher_bindings::{
 pub(crate) use helpers::sanitize_terminal_text;
 pub(crate) use helpers::session_to_dashboard_value_with_bridge;
 pub use helpers::{
-    build_normalized_chat_feed, resolve_board_file, session_to_dashboard_value, trim_lines_tail,
+    build_dispatcher_chat_feed, build_normalized_chat_feed, resolve_board_file,
+    session_to_dashboard_value, trim_lines_tail,
 };
 pub(crate) use mcp_config::{
     build_claude_mcp_config_json, build_codex_mcp_config_args, deserialize_mcp_servers,

--- a/crates/conductor-server/tests/board_test.rs
+++ b/crates/conductor-server/tests/board_test.rs
@@ -10,6 +10,7 @@ use conductor_core::config::ProjectConfig;
 use conductor_core::event::Event;
 use conductor_core::types::AgentKind;
 use conductor_core::EventBus;
+use conductor_server::state::SessionStatus;
 use serde_json::json;
 use serde_json::Value;
 use std::fs;
@@ -256,6 +257,238 @@ async fn dispatcher_task_routes_reject_unknown_explicit_thread_scope() {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     let board_contents = fs::read_to_string(&harness.board_path).unwrap();
     assert!(!board_contents.contains("Broken scoped task"));
+}
+
+#[tokio::test]
+async fn dispatcher_approval_routes_resume_or_revise_pending_plans() {
+    let harness = TestHarness::new("dispatcher-approval-routes", "direct").await;
+    let app = build_app(harness.state.clone());
+
+    let dispatcher_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/projects/demo/dispatcher")
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "forceNew": true }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(dispatcher_response.status(), StatusCode::CREATED);
+    let dispatcher_body = axum::body::to_bytes(dispatcher_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let dispatcher_payload: Value = serde_json::from_slice(&dispatcher_body).unwrap();
+    let thread_id = dispatcher_payload["thread"]["id"]
+        .as_str()
+        .expect("dispatcher thread id should be present")
+        .to_string();
+
+    {
+        let mut threads = harness.state.dispatcher_threads.write().await;
+        let thread = threads
+            .get_mut(&thread_id)
+            .expect("dispatcher thread should exist");
+        thread.status = SessionStatus::NeedsInput;
+        thread.activity = Some("waiting_input".to_string());
+        thread.summary = Some("Plan ready for approval".to_string());
+        thread
+            .metadata
+            .insert("summary".to_string(), "Plan ready for approval".to_string());
+        thread.metadata.insert(
+            "acpPlanApprovalState".to_string(),
+            "approval_required".to_string(),
+        );
+        thread
+            .metadata
+            .insert("parserState".to_string(), "approval_required".to_string());
+        thread
+            .conversation
+            .push(conductor_server::state::ConversationEntry {
+                id: "assistant-plan".to_string(),
+                kind: "assistant_message".to_string(),
+                source: "runtime".to_string(),
+                text: "## Proposed plan\n\n1. Create task DEM-002\n2. Wait for approval"
+                    .to_string(),
+                created_at: chrono::Utc::now().to_rfc3339(),
+                attachments: Vec::new(),
+                metadata: std::collections::HashMap::new(),
+            });
+    }
+
+    let approve_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/projects/demo/dispatcher/approve?threadId={}",
+                    thread_id
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(approve_response.status(), StatusCode::OK);
+
+    let approved_thread = wait_for_condition_with_timeout(
+        "approval action persisted",
+        std::time::Duration::from_secs(3),
+        || {
+            let state = harness.state.clone();
+            let thread_id = thread_id.clone();
+            async move {
+                let threads = state.dispatcher_threads.read().await;
+                let thread = threads.get(&thread_id).cloned()?;
+                let approved = thread
+                    .conversation
+                    .iter()
+                    .any(|entry| entry.kind == "user_message" && entry.text == "approve");
+                approved.then_some(thread)
+            }
+        },
+    )
+    .await;
+    assert_eq!(approved_thread.status, SessionStatus::Working);
+    assert_eq!(
+        approved_thread
+            .metadata
+            .get("acpPlanApprovalState")
+            .map(String::as_str),
+        Some("approved_for_next_mutation")
+    );
+
+    let reject_dispatcher_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/projects/demo/dispatcher")
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "forceNew": true }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(reject_dispatcher_response.status(), StatusCode::CREATED);
+    let reject_dispatcher_body =
+        axum::body::to_bytes(reject_dispatcher_response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+    let reject_dispatcher_payload: Value = serde_json::from_slice(&reject_dispatcher_body).unwrap();
+    let reject_thread_id = reject_dispatcher_payload["thread"]["id"]
+        .as_str()
+        .expect("reject dispatcher thread id should be present")
+        .to_string();
+
+    {
+        let mut threads = harness.state.dispatcher_threads.write().await;
+        let thread = threads
+            .get_mut(&reject_thread_id)
+            .expect("dispatcher thread should exist");
+        thread.status = SessionStatus::NeedsInput;
+        thread.activity = Some("waiting_input".to_string());
+        thread.summary = Some("Plan ready for approval".to_string());
+        thread
+            .metadata
+            .insert("summary".to_string(), "Plan ready for approval".to_string());
+        thread.metadata.insert(
+            "acpPlanApprovalState".to_string(),
+            "approval_required".to_string(),
+        );
+        thread
+            .metadata
+            .insert("parserState".to_string(), "approval_required".to_string());
+    }
+
+    let reject_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/projects/demo/dispatcher/reject?threadId={}",
+                    reject_thread_id
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(reject_response.status(), StatusCode::OK);
+
+    let rejected_thread = wait_for_condition_with_timeout(
+        "reject action persisted",
+        std::time::Duration::from_secs(3),
+        || {
+            let state = harness.state.clone();
+            let thread_id = reject_thread_id.clone();
+            async move {
+                let threads = state.dispatcher_threads.read().await;
+                let thread = threads.get(&thread_id).cloned()?;
+                let rejected = thread
+                    .conversation
+                    .iter()
+                    .any(|entry| entry.kind == "user_message" && entry.text == "reject");
+                rejected.then_some(thread)
+            }
+        },
+    )
+    .await;
+    assert_eq!(
+        rejected_thread
+            .metadata
+            .get("acpPlanApprovalState")
+            .map(String::as_str),
+        Some("approval_required")
+    );
+}
+
+#[tokio::test]
+async fn dispatcher_approval_routes_reject_threads_without_pending_plan_review() {
+    let harness = TestHarness::new("dispatcher-approval-route-guard", "direct").await;
+    let app = build_app(harness.state.clone());
+
+    let dispatcher_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/projects/demo/dispatcher")
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "forceNew": true }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(dispatcher_response.status(), StatusCode::CREATED);
+    let dispatcher_body = axum::body::to_bytes(dispatcher_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let dispatcher_payload: Value = serde_json::from_slice(&dispatcher_body).unwrap();
+    let thread_id = dispatcher_payload["thread"]["id"]
+        .as_str()
+        .expect("dispatcher thread id should be present")
+        .to_string();
+
+    let approve_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/projects/demo/dispatcher/approve?threadId={}",
+                    thread_id
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(approve_response.status(), StatusCode::CONFLICT);
 }
 
 #[tokio::test]

--- a/docs/openclaw-integration-contract.md
+++ b/docs/openclaw-integration-contract.md
@@ -153,6 +153,17 @@ If no dispatcher exists and `threadId` is **not** set, Conductor may **create** 
 
 **Response:** `{ "ok": true, "threadId": "<dispatcher session id>" }`
 
+### Approve or reject a pending plan
+
+These routes are the explicit approval contract for dispatcher plan-only turns. Use them instead of sending magic plain-text `approve` / `reject` messages from the client.
+
+| Method | Path |
+|--------|------|
+| `POST` | `/api/projects/{projectId}/dispatcher/approve?threadId=&bridgeId=` |
+| `POST` | `/api/projects/{projectId}/dispatcher/reject?threadId=&bridgeId=` |
+
+**Response:** `{ "ok": true, "threadId": "<dispatcher session id>" }`
+
 ### Interrupt
 
 `POST /api/projects/{projectId}/dispatcher/interrupt?threadId=&bridgeId=`

--- a/docs/openclaw-integration-contract.md
+++ b/docs/openclaw-integration-contract.md
@@ -164,6 +164,9 @@ These routes are the explicit approval contract for dispatcher plan-only turns. 
 
 **Response:** `{ "ok": true, "threadId": "<dispatcher session id>" }`
 
+`404` if the dispatcher thread cannot be resolved for the project/query scope.
+`409` if the dispatcher exists but is not currently waiting for plan approval.
+
 ### Interrupt
 
 `POST /api/projects/{projectId}/dispatcher/interrupt?threadId=&bridgeId=`

--- a/packages/web/src/app/api/projects/[id]/dispatcher/approve/route.ts
+++ b/packages/web/src/app/api/projects/[id]/dispatcher/approve/route.ts
@@ -1,0 +1,8 @@
+import { guardedProxyParamRoute } from "@/lib/proxyRoutes";
+
+export const dynamic = "force-dynamic";
+
+export const POST = guardedProxyParamRoute(
+  ({ id }) => `/api/projects/${encodeURIComponent(id ?? "")}/dispatcher/approve`,
+  { role: "operator", requireActionGuard: true, bridgeAware: true },
+);

--- a/packages/web/src/app/api/projects/[id]/dispatcher/reject/route.ts
+++ b/packages/web/src/app/api/projects/[id]/dispatcher/reject/route.ts
@@ -1,0 +1,8 @@
+import { guardedProxyParamRoute } from "@/lib/proxyRoutes";
+
+export const dynamic = "force-dynamic";
+
+export const POST = guardedProxyParamRoute(
+  ({ id }) => `/api/projects/${encodeURIComponent(id ?? "")}/dispatcher/reject`,
+  { role: "operator", requireActionGuard: true, bridgeAware: true },
+);

--- a/packages/web/src/components/dispatcher/DispatcherPane.tsx
+++ b/packages/web/src/components/dispatcher/DispatcherPane.tsx
@@ -455,6 +455,8 @@ export function DispatcherPane({
           feed: `/api/projects/${encodeURIComponent(projectId)}/dispatcher/feed?limit=120&${threadQuery}`,
           stream: `/api/projects/${encodeURIComponent(projectId)}/dispatcher/feed/stream?limit=120&${threadQuery}`,
           send: `/api/projects/${encodeURIComponent(projectId)}/dispatcher/send?${threadQuery}`,
+          approve: `/api/projects/${encodeURIComponent(projectId)}/dispatcher/approve?${threadQuery}`,
+          reject: `/api/projects/${encodeURIComponent(projectId)}/dispatcher/reject?${threadQuery}`,
           interrupt: `/api/projects/${encodeURIComponent(projectId)}/dispatcher/interrupt?${threadQuery}`,
           integration: `/api/projects/${encodeURIComponent(projectId)}/dispatcher/integration?${threadQuery}`,
         }}

--- a/packages/web/src/components/dispatcher/DispatcherSessionPane.tsx
+++ b/packages/web/src/components/dispatcher/DispatcherSessionPane.tsx
@@ -75,6 +75,8 @@ type DispatcherSessionPaneApiPaths = {
   stream: string;
   send: string;
   interrupt?: string | null;
+  approve?: string | null;
+  reject?: string | null;
   repositories?: string;
   /** PATCH OpenClaw (or other orchestrator) thread/session binding */
   integration?: string;
@@ -940,9 +942,13 @@ function shouldShowDispatcherApprovalBanner(
   entries: SessionFeedEntry[],
   approvalState: string | null,
   sessionStatus: string | null,
+  parserState: SessionParserState | null,
 ): boolean {
   if (approvalState !== DISPATCHER_APPROVAL_REQUIRED) {
     return false;
+  }
+  if (parserState?.kind === DISPATCHER_APPROVAL_REQUIRED) {
+    return true;
   }
   if (sessionStatus?.trim().toLowerCase() !== "needs_input") {
     return false;
@@ -1044,6 +1050,8 @@ export function DispatcherSessionPane({
     stream: apiPaths.stream,
     send: apiPaths.send,
     interrupt: apiPaths.interrupt ?? null,
+    approve: apiPaths.approve ?? null,
+    reject: apiPaths.reject ?? null,
     repositories: apiPaths.repositories ?? "/api/repositories",
   }), [apiPaths]);
 
@@ -1070,8 +1078,13 @@ export function DispatcherSessionPane({
   const isDispatcher = session.metadata.sessionKind === "project_dispatcher";
   const approvalState = payload.approvalState ?? session.metadata.acpPlanApprovalState ?? null;
   const awaitingApproval = useMemo(
-    () => isDispatcher && shouldShowDispatcherApprovalBanner(payload.entries, approvalState, payload.sessionStatus ?? session.status),
-    [approvalState, isDispatcher, payload.entries, payload.sessionStatus, session.status],
+    () => isDispatcher && shouldShowDispatcherApprovalBanner(
+      payload.entries,
+      approvalState,
+      payload.sessionStatus ?? session.status,
+      payload.parserState,
+    ),
+    [approvalState, isDispatcher, payload.entries, payload.parserState, payload.sessionStatus, session.status],
   );
   const showInterruptAction = Boolean(sessionApiPaths.interrupt)
     && INTERRUPTIBLE_SESSION_STATUSES.has(normalizedStatusLabel);
@@ -1477,8 +1490,29 @@ export function DispatcherSessionPane({
   }, [composerValue, sendMessage]);
 
   const handleApprovalAction = useCallback(async (action: "approve" | "reject") => {
-    await sendMessage(action);
-  }, [sendMessage]);
+    const approvalPath = action === "approve" ? sessionApiPaths.approve : sessionApiPaths.reject;
+    if (!approvalPath) {
+      await sendMessage(action);
+      return;
+    }
+
+    setSending(true);
+    setSendError(null);
+    try {
+      const response = await fetch(withBridgeQuery(approvalPath, bridgeId), {
+        method: "POST",
+      });
+      const payload = asRecord(await response.json().catch(() => null));
+      if (!response.ok) {
+        throw new Error(readString(payload.error) ?? `Failed to ${action} plan (${response.status})`);
+      }
+      setComposerValue("");
+    } catch (err) {
+      setSendError(err instanceof Error ? err.message : `Failed to ${action} plan`);
+    } finally {
+      setSending(false);
+    }
+  }, [bridgeId, sendMessage, sessionApiPaths.approve, sessionApiPaths.reject]);
 
   const handleAgentChange = useCallback(async (nextAgent: string) => {
     if (!repository || savingAgent || nextAgent === repository.agent) {


### PR DESCRIPTION
## Summary

Hardens the dispatcher control plane and the headless executor runtime path so dispatcher approval turns fail closed, dispatcher feeds stay conversation-driven, and headless agent subprocesses no longer share Conductor's process group.

## User-Facing Release Notes

- Fixed dispatcher approval and reject actions so they only run when a plan is actually waiting for review.
- Improved dispatcher chat feeds so they stop leaking runtime transport noise and keep approval state stable after reloads.
- Fixed headless agent launches so child runtimes no longer share Conductor's process group, preventing agent exits from killing the main Conductor service.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Plugin addition / modification
- [ ] Documentation update
- [ ] Refactor / chore

## Testing

- cargo test -p conductor-executors
- cargo clippy -p conductor-executors --all-targets -- -D warnings
- cargo build --bin conductor
- cargo clippy -p conductor-server --all-targets -- -D warnings
- cargo test -p conductor-server
- bun run --cwd packages/web typecheck
- bun run --cwd packages/web test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit dispatcher plan approve/reject endpoints and integrated frontend support (approve/reject actions and approval banner).

* **Improvements**
  * Executor output handling now consistently sanitizes/parses stderr like stdout and drops empty output lines.

* **Chores**
  * Spawned child processes are isolated into separate process groups for improved robustness.

* **Documentation**
  * HTTP contract updated with approve/reject endpoint details.

* **Tests**
  * Added coverage for dispatcher approval flows and related unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->