### PR TITLE
fix: harden dispatcher headless runtime stability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
+ "toml",
  "tracing",
  "url",
  "uuid",
@@ -2354,6 +2355,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2966,6 +2976,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -3778,6 +3829,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ clap = { version = "4.0", features = ["derive"] }
 glob = "0.3"
 which = "7"
 regex = "1"
+toml = "0.8"
 
 # Crypto (for webhook HMAC, auth)
 hmac = "0.12"

--- a/crates/conductor-executors/Cargo.toml
+++ b/crates/conductor-executors/Cargo.toml
@@ -15,6 +15,7 @@ tokio = { workspace = true }
 async-trait = { workspace = true }
 which = { workspace = true }
 regex = { workspace = true }
+toml = { workspace = true }
 portable-pty = { workspace = true }
 base64 = { workspace = true }
 futures-util = { workspace = true }

--- a/crates/conductor-executors/src/agents/codex.rs
+++ b/crates/conductor-executors/src/agents/codex.rs
@@ -5,10 +5,14 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tokio::process::Command;
+use tokio::sync::mpsc;
+use uuid::Uuid;
 
 use super::discover_binary;
 use crate::executor::{wrap_parsed_output, Executor, ExecutorHandle, ExecutorOutput, SpawnOptions};
-use crate::process::{spawn_process, spawn_process_no_stdin};
+use crate::process::{
+    spawn_process, spawn_process_no_stdin_with_clean_env, spawn_process_with_env_removals,
+};
 
 /// OpenAI Codex CLI executor.
 #[derive(Clone)]
@@ -16,9 +20,331 @@ pub struct CodexExecutor {
     binary: PathBuf,
 }
 
+fn build_codex_spawn_env(overrides: &HashMap<String, String>) -> HashMap<String, String> {
+    let mut env = HashMap::new();
+    for key in [
+        "HOME",
+        "USERPROFILE",
+        "HOMEDRIVE",
+        "HOMEPATH",
+        "APPDATA",
+        "LOCALAPPDATA",
+        "PATH",
+        "PATHEXT",
+        "SHELL",
+        "COMSPEC",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "USER",
+        "USERNAME",
+        "LOGNAME",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+        "TERM",
+        "COLORTERM",
+        "__CF_USER_TEXT_ENCODING",
+        "VIRTUAL_ENV",
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+        "REQUESTS_CA_BUNDLE",
+        "CURL_CA_BUNDLE",
+        "SSH_AUTH_SOCK",
+        "SYSTEMROOT",
+        "XPC_FLAGS",
+        "XPC_SERVICE_NAME",
+    ] {
+        if let Ok(value) = std::env::var(key) {
+            env.insert(key.to_string(), value);
+        }
+    }
+    env.extend(overrides.clone());
+    env
+}
+
+fn codex_clean_env_removals(allowed_env: &HashMap<String, String>) -> Vec<String> {
+    std::env::vars_os()
+        .filter_map(|(key, _)| key.into_string().ok())
+        .filter(|key| !allowed_env.contains_key(key))
+        .collect()
+}
+
+fn create_private_dir_all(path: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(path)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))?;
+    }
+
+    Ok(())
+}
+
+fn clone_or_link_file(source: &Path, destination: &Path) -> std::io::Result<()> {
+    std::fs::copy(source, destination)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        std::fs::set_permissions(destination, std::fs::Permissions::from_mode(0o600))?;
+    }
+
+    Ok(())
+}
+
+fn strip_mcp_servers_from_codex_config(config: &str) -> String {
+    let sanitized = toml::from_str::<toml::Value>(config)
+        .ok()
+        .and_then(|mut value| {
+            value.as_table_mut()?.remove("mcp_servers");
+            toml::to_string(&value).ok()
+        })
+        .unwrap_or_else(|| strip_mcp_servers_from_codex_config_fallback(config));
+
+    if config.ends_with('\n') && !sanitized.ends_with('\n') {
+        format!("{sanitized}\n")
+    } else {
+        sanitized
+    }
+}
+
+fn strip_mcp_servers_from_codex_config_fallback(config: &str) -> String {
+    let mut sanitized = Vec::new();
+    let mut skipping_mcp_section = false;
+
+    for line in config.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            let table_name = trimmed.trim_matches(|ch| ch == '[' || ch == ']');
+            skipping_mcp_section =
+                table_name == "mcp_servers" || table_name.starts_with("mcp_servers.");
+            if skipping_mcp_section {
+                continue;
+            }
+        }
+
+        if !skipping_mcp_section {
+            sanitized.push(line);
+        }
+    }
+
+    let mut sanitized_config = sanitized.join("\n");
+    if config.ends_with('\n') {
+        sanitized_config.push('\n');
+    }
+
+    sanitized_config
+}
+
+fn seed_isolated_codex_home(source_home: &Path, target_home: &Path) -> std::io::Result<()> {
+    let source_codex_dir = source_home.join(".codex");
+    let target_codex_dir = target_home.join(".codex");
+    create_private_dir_all(target_home)?;
+    create_private_dir_all(&target_codex_dir)?;
+
+    let source_auth = source_codex_dir.join("auth.json");
+    if source_auth.is_file() {
+        clone_or_link_file(&source_auth, &target_codex_dir.join("auth.json"))?;
+    }
+
+    let source_version = source_codex_dir.join("version.json");
+    if source_version.is_file() {
+        std::fs::copy(&source_version, target_codex_dir.join("version.json"))?;
+    }
+
+    let source_config = source_codex_dir.join("config.toml");
+    if source_config.is_file() {
+        let config = std::fs::read_to_string(&source_config)?;
+        let sanitized = strip_mcp_servers_from_codex_config(&config);
+        std::fs::write(target_codex_dir.join("config.toml"), sanitized)?;
+    }
+
+    Ok(())
+}
+
+fn next_headless_codex_home_path(source_home: &Path) -> PathBuf {
+    source_home
+        .join(".conductor")
+        .join("codex-headless")
+        .join(Uuid::new_v4().to_string())
+}
+
+fn resolve_home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+fn apply_headless_codex_env(
+    env: &mut HashMap<String, String>,
+    headless_home: &Path,
+) -> std::io::Result<()> {
+    env.insert(
+        "HOME".to_string(),
+        headless_home.to_string_lossy().to_string(),
+    );
+
+    #[cfg(windows)]
+    {
+        let roaming = headless_home.join("AppData").join("Roaming");
+        let local = headless_home.join("AppData").join("Local");
+        create_private_dir_all(&roaming)?;
+        create_private_dir_all(&local)?;
+        env.insert(
+            "USERPROFILE".to_string(),
+            headless_home.to_string_lossy().to_string(),
+        );
+        env.insert("APPDATA".to_string(), roaming.to_string_lossy().to_string());
+        env.insert(
+            "LOCALAPPDATA".to_string(),
+            local.to_string_lossy().to_string(),
+        );
+    }
+
+    Ok(())
+}
+
+fn prepare_headless_codex_home() -> std::io::Result<Option<PathBuf>> {
+    let Some(source_home) = resolve_home_dir() else {
+        return Ok(None);
+    };
+
+    let target_home = next_headless_codex_home_path(&source_home);
+    seed_isolated_codex_home(&source_home, &target_home)?;
+    Ok(Some(target_home))
+}
+
+fn wrap_codex_output_with_home_cleanup(
+    headless_home: Option<PathBuf>,
+    mut output_rx: mpsc::Receiver<ExecutorOutput>,
+) -> mpsc::Receiver<ExecutorOutput> {
+    let (cleanup_tx, cleanup_rx) = mpsc::channel(1024);
+
+    tokio::spawn(async move {
+        while let Some(event) = output_rx.recv().await {
+            if cleanup_tx.send(event).await.is_err() {
+                break;
+            }
+        }
+
+        if let Some(headless_home) = headless_home {
+            let _ = tokio::fs::remove_dir_all(headless_home).await;
+        }
+    });
+
+    cleanup_rx
+}
+
+fn codex_target_triple() -> Option<&'static str> {
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("linux", "x86_64") => Some("x86_64-unknown-linux-musl"),
+        ("linux", "aarch64") | ("linux", "arm64") => Some("aarch64-unknown-linux-musl"),
+        ("macos", "x86_64") => Some("x86_64-apple-darwin"),
+        ("macos", "aarch64") | ("macos", "arm64") => Some("aarch64-apple-darwin"),
+        ("windows", "x86_64") => Some("x86_64-pc-windows-msvc"),
+        ("windows", "aarch64") | ("windows", "arm64") => Some("aarch64-pc-windows-msvc"),
+        _ => None,
+    }
+}
+
+fn codex_platform_package(target_triple: &str) -> Option<&'static str> {
+    match target_triple {
+        "x86_64-unknown-linux-musl" => Some("@openai/codex-linux-x64"),
+        "aarch64-unknown-linux-musl" => Some("@openai/codex-linux-arm64"),
+        "x86_64-apple-darwin" => Some("@openai/codex-darwin-x64"),
+        "aarch64-apple-darwin" => Some("@openai/codex-darwin-arm64"),
+        "x86_64-pc-windows-msvc" => Some("@openai/codex-win32-x64"),
+        "aarch64-pc-windows-msvc" => Some("@openai/codex-win32-arm64"),
+        _ => None,
+    }
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        if let Ok(metadata) = std::fs::metadata(path) {
+            return metadata.permissions().mode() & 0o111 != 0;
+        }
+        false
+    }
+
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+fn resolve_native_codex_binary(binary: &Path) -> PathBuf {
+    let canonical = std::fs::canonicalize(binary).unwrap_or_else(|_| binary.to_path_buf());
+    let is_node_wrapper = canonical
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.eq_ignore_ascii_case("js"))
+        .unwrap_or(false)
+        && canonical
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(|name| name.eq_ignore_ascii_case("codex.js"))
+            .unwrap_or(false);
+
+    if !is_node_wrapper {
+        return canonical;
+    }
+
+    let Some(target_triple) = codex_target_triple() else {
+        return canonical;
+    };
+    let binary_name = if cfg!(windows) { "codex.exe" } else { "codex" };
+    let Some(package_root) = canonical.parent().and_then(Path::parent) else {
+        return canonical;
+    };
+
+    let local_candidate = package_root
+        .join("vendor")
+        .join(target_triple)
+        .join("codex")
+        .join(binary_name);
+    if is_executable_file(&local_candidate) {
+        return local_candidate;
+    }
+
+    let Some(platform_package) = codex_platform_package(target_triple) else {
+        return canonical;
+    };
+    let packaged_candidate = package_root
+        .join("node_modules")
+        .join(platform_package)
+        .join("vendor")
+        .join(target_triple)
+        .join("codex")
+        .join(binary_name);
+    if is_executable_file(&packaged_candidate) {
+        return packaged_candidate;
+    }
+
+    canonical
+}
+
 impl CodexExecutor {
     pub fn new(binary: PathBuf) -> Self {
-        Self { binary }
+        Self {
+            binary: resolve_native_codex_binary(&binary),
+        }
     }
 
     pub fn discover() -> Option<Self> {
@@ -55,13 +381,37 @@ impl Executor for CodexExecutor {
 
     async fn spawn(&self, options: SpawnOptions) -> Result<ExecutorHandle> {
         let args = self.build_args(&options);
-        let needs_stdin = options.structured_output && args.iter().any(|arg| arg == "-");
-        let handle = if options.structured_output && !needs_stdin {
-            spawn_process_no_stdin(&self.binary, &args, &options.cwd, &options.env).await?
+        let mut env = build_codex_spawn_env(&options.env);
+        let headless_home = if options.structured_output {
+            let headless_home = prepare_headless_codex_home()?;
+            if let Some(ref headless_home) = headless_home {
+                apply_headless_codex_env(&mut env, headless_home)?;
+            }
+            headless_home
         } else {
-            spawn_process(&self.binary, &args, &options.cwd, &options.env).await?
+            None
+        };
+        let needs_stdin = options.structured_output && args.iter().any(|arg| arg == "-");
+        let spawn_result = if options.structured_output && !needs_stdin {
+            spawn_process_no_stdin_with_clean_env(&self.binary, &args, &options.cwd, &env).await
+        } else if options.structured_output {
+            let env_remove = codex_clean_env_removals(&env);
+            spawn_process_with_env_removals(&self.binary, &args, &options.cwd, &env, &env_remove)
+                .await
+        } else {
+            spawn_process(&self.binary, &args, &options.cwd, &env).await
+        };
+        let handle = match spawn_result {
+            Ok(handle) => handle,
+            Err(error) => {
+                if let Some(headless_home) = headless_home.clone() {
+                    let _ = tokio::fs::remove_dir_all(headless_home).await;
+                }
+                return Err(error);
+            }
         };
         let output_rx = wrap_parsed_output(self.clone(), handle.output_rx);
+        let output_rx = wrap_codex_output_with_home_cleanup(headless_home, output_rx);
 
         Ok(ExecutorHandle::new(
             handle.pid,
@@ -539,7 +889,173 @@ fn extract_text(value: &Value) -> Option<String> {
 mod tests {
     use super::*;
     use crate::executor::Executor;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
     use tokio::time::{timeout, Duration};
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("conductor-codex-{prefix}-{nanos}"))
+    }
+
+    fn mark_executable(path: &Path) {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mut permissions = fs::metadata(path).expect("metadata").permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(path, permissions).expect("set executable bit");
+        }
+    }
+
+    #[test]
+    fn next_headless_codex_home_path_is_unique() {
+        let source_home = unique_temp_dir("headless-home-root");
+        let first = next_headless_codex_home_path(&source_home);
+        let second = next_headless_codex_home_path(&source_home);
+        assert_ne!(first, second);
+        assert!(first.to_string_lossy().contains("codex-headless"));
+        assert!(second.to_string_lossy().contains("codex-headless"));
+    }
+
+    #[test]
+    fn strip_mcp_servers_from_codex_config_preserves_non_mcp_settings() {
+        let config = concat!(
+            "model = \"gpt-5.4\"\n",
+            "approval_policy = \"never\"\n\n",
+            "[profiles.default]\n",
+            "model = \"gpt-5.4\"\n\n",
+            "[mcp_servers.memory]\n",
+            "command = \"npx\"\n\n",
+            "[tools]\n",
+            "web_search = true\n"
+        );
+
+        let sanitized = strip_mcp_servers_from_codex_config(config);
+        assert!(sanitized.contains("approval_policy = \"never\""));
+        assert!(sanitized.contains("[profiles.default]"));
+        assert!(sanitized.contains("[tools]"));
+        assert!(!sanitized.contains("mcp_servers"));
+    }
+
+    #[test]
+    fn strip_mcp_servers_from_codex_config_removes_dotted_keys() {
+        let config = concat!(
+            "model = \"gpt-5.4\"\n",
+            "mcp_servers.memory.command = \"npx\"\n",
+            "mcp_servers.memory.args = [\"-y\", \"demo\"]\n",
+            "approval_policy = \"never\"\n"
+        );
+
+        let sanitized = strip_mcp_servers_from_codex_config(config);
+        assert!(sanitized.contains("model = \"gpt-5.4\""));
+        assert!(sanitized.contains("approval_policy = \"never\""));
+        assert!(!sanitized.contains("mcp_servers"));
+    }
+
+    #[tokio::test]
+    async fn wrap_codex_output_with_home_cleanup_removes_headless_home() {
+        let temp_dir = unique_temp_dir("headless-cleanup");
+        fs::create_dir_all(&temp_dir).expect("create temp dir");
+
+        let (output_tx, output_rx) = mpsc::channel(4);
+        let mut wrapped = wrap_codex_output_with_home_cleanup(Some(temp_dir.clone()), output_rx);
+        output_tx
+            .send(ExecutorOutput::Completed { exit_code: 0 })
+            .await
+            .expect("send completion");
+        drop(output_tx);
+
+        assert!(matches!(
+            wrapped.recv().await,
+            Some(ExecutorOutput::Completed { exit_code: 0 })
+        ));
+        timeout(Duration::from_secs(2), async {
+            while temp_dir.exists() {
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .expect("cleanup should remove headless home");
+    }
+
+    #[test]
+    fn seed_isolated_codex_home_copies_auth_and_strips_mcp_config() {
+        let temp_dir = unique_temp_dir("isolated-home");
+        let source_home = temp_dir.join("source-home");
+        let target_home = temp_dir.join("target-home");
+        let source_codex_dir = source_home.join(".codex");
+        fs::create_dir_all(&source_codex_dir).expect("create source codex dir");
+        fs::write(source_codex_dir.join("auth.json"), b"{\"token\":\"ok\"}\n").expect("write auth");
+        fs::write(
+            source_codex_dir.join("config.toml"),
+            concat!(
+                "model = \"gpt-5.4\"\n",
+                "approval_policy = \"never\"\n\n",
+                "[mcp_servers.memory]\n",
+                "command = \"npx\"\n\n",
+                "[profiles.default]\n",
+                "model = \"gpt-5.4\"\n"
+            ),
+        )
+        .expect("write source config");
+
+        seed_isolated_codex_home(&source_home, &target_home).expect("seed isolated home");
+
+        let target_codex_dir = target_home.join(".codex");
+        assert!(target_codex_dir.join("auth.json").is_file());
+        #[cfg(unix)]
+        assert!(!fs::symlink_metadata(target_codex_dir.join("auth.json"))
+            .expect("auth metadata")
+            .file_type()
+            .is_symlink());
+        let config = fs::read_to_string(target_codex_dir.join("config.toml")).expect("read config");
+        assert!(config.contains("approval_policy = \"never\""));
+        assert!(config.contains("[profiles.default]"));
+        assert!(!config.contains("mcp_servers"));
+
+        fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[test]
+    fn new_resolves_native_binary_from_node_wrapper() {
+        let Some(target_triple) = codex_target_triple() else {
+            return;
+        };
+        let Some(platform_package) = codex_platform_package(target_triple) else {
+            return;
+        };
+
+        let temp_dir = unique_temp_dir("native-resolve");
+        let package_root = temp_dir.join("@openai").join("codex");
+        let wrapper_path = package_root.join("bin").join("codex.js");
+        let native_path = package_root
+            .join("node_modules")
+            .join(platform_package)
+            .join("vendor")
+            .join(target_triple)
+            .join("codex")
+            .join(if cfg!(windows) { "codex.exe" } else { "codex" });
+
+        fs::create_dir_all(wrapper_path.parent().expect("wrapper parent"))
+            .expect("create wrapper dir");
+        fs::create_dir_all(native_path.parent().expect("native parent"))
+            .expect("create native dir");
+        fs::write(&wrapper_path, b"#!/usr/bin/env node\n").expect("write wrapper");
+        fs::write(&native_path, b"#!/bin/sh\nexit 0\n").expect("write native binary");
+        mark_executable(&wrapper_path);
+        mark_executable(&native_path);
+
+        let executor = CodexExecutor::new(wrapper_path.clone());
+        let expected = fs::canonicalize(&native_path).expect("canonical native path");
+        assert_eq!(executor.binary_path(), expected.as_path());
+
+        fs::remove_dir_all(&temp_dir).ok();
+    }
 
     #[test]
     fn parse_started_mcp_tool_call_emits_structured_status() {

--- a/crates/conductor-executors/src/process.rs
+++ b/crates/conductor-executors/src/process.rs
@@ -7,9 +7,10 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::io::{Read, Write};
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tokio::io::{AsyncBufReadExt, BufReader as AsyncBufReader};
+use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 use tokio::sync::{mpsc, oneshot};
 
@@ -32,13 +33,147 @@ fn apply_tokio_command_env(
     cmd: &mut Command,
     env: &HashMap<String, String>,
     env_remove: &[String],
+    clear_existing: bool,
 ) {
+    if clear_existing {
+        cmd.env_clear();
+    }
     for key in env_remove {
         cmd.env_remove(key);
     }
     for (key, value) in env {
         cmd.env(key, value);
     }
+}
+
+#[cfg(unix)]
+fn mark_extra_fds_cloexec_in_child() -> std::io::Result<()> {
+    let max_fd = unsafe { libc::sysconf(libc::_SC_OPEN_MAX) };
+    let max_fd = if max_fd > 0 { max_fd as i32 } else { 1024 };
+    for fd in 3..max_fd {
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+        if flags == -1 {
+            let error = std::io::Error::last_os_error();
+            if error.raw_os_error() != Some(libc::EBADF) {
+                return Err(error);
+            }
+            continue;
+        }
+
+        let result = unsafe { libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC) };
+        if result == -1 {
+            return Err(std::io::Error::last_os_error());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn restore_default_signals_in_child() -> std::io::Result<()> {
+    for signal in [libc::SIGPIPE, libc::SIGXFSZ] {
+        let mut action = unsafe { std::mem::zeroed::<libc::sigaction>() };
+        action.sa_sigaction = libc::SIG_DFL;
+        let empty_result = unsafe { libc::sigemptyset(&mut action.sa_mask) };
+        if empty_result != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        action.sa_flags = 0;
+        let result = unsafe { libc::sigaction(signal, &action, std::ptr::null_mut()) };
+        if result != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn clear_signal_mask_in_child() -> std::io::Result<()> {
+    let mut set = unsafe { std::mem::zeroed::<libc::sigset_t>() };
+    let empty_result = unsafe { libc::sigemptyset(&mut set) };
+    if empty_result != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let mask_result = unsafe { libc::sigprocmask(libc::SIG_SETMASK, &set, std::ptr::null_mut()) };
+    if mask_result != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+const MAX_BUFFERED_PROCESS_OUTPUT_BYTES: usize = 8 * 1024 * 1024;
+
+async fn await_reader_task_with_timeout<T>(task: &mut tokio::task::JoinHandle<T>) {
+    if tokio::time::timeout(Duration::from_millis(250), &mut *task)
+        .await
+        .is_err()
+    {
+        task.abort();
+        let _ = task.await;
+    }
+}
+
+fn buffered_process_output_size(event: &ExecutorOutput) -> Option<usize> {
+    match event {
+        ExecutorOutput::Stdout(line) | ExecutorOutput::Stderr(line) => Some(line.len()),
+        _ => None,
+    }
+}
+
+fn signal_output_overflow(
+    tx: &mpsc::UnboundedSender<ExecutorOutput>,
+    output_overflowed: &AtomicBool,
+) {
+    if !output_overflowed.swap(true, Ordering::AcqRel) {
+        let _ = tx.send(ExecutorOutput::Stderr(format!(
+            "[conductor] process output exceeded {} bytes, dropping additional stdout/stderr",
+            MAX_BUFFERED_PROCESS_OUTPUT_BYTES
+        )));
+    }
+}
+
+fn queue_process_output(
+    tx: &mpsc::UnboundedSender<ExecutorOutput>,
+    buffered_bytes: &AtomicUsize,
+    output_overflowed: &AtomicBool,
+    event: ExecutorOutput,
+) -> bool {
+    if let Some(size) = buffered_process_output_size(&event) {
+        if output_overflowed.load(Ordering::Acquire) {
+            return true;
+        }
+        let previous = buffered_bytes.fetch_add(size, Ordering::AcqRel);
+        if previous + size > MAX_BUFFERED_PROCESS_OUTPUT_BYTES {
+            buffered_bytes.fetch_sub(size, Ordering::AcqRel);
+            signal_output_overflow(tx, output_overflowed);
+            return true;
+        }
+        if tx.send(event).is_err() {
+            buffered_bytes.fetch_sub(size, Ordering::AcqRel);
+            return false;
+        }
+        true
+    } else {
+        tx.send(event).is_ok()
+    }
+}
+
+fn forward_process_output(
+    mut source_rx: mpsc::UnboundedReceiver<ExecutorOutput>,
+    sink_tx: mpsc::Sender<ExecutorOutput>,
+    buffered_bytes: Arc<AtomicUsize>,
+) {
+    tokio::spawn(async move {
+        while let Some(event) = source_rx.recv().await {
+            let buffered_size = buffered_process_output_size(&event);
+            let send_result = sink_tx.send(event).await;
+            if let Some(size) = buffered_size {
+                buffered_bytes.fetch_sub(size, Ordering::AcqRel);
+            }
+            if send_result.is_err() {
+                break;
+            }
+        }
+    });
 }
 
 /// PTY dimensions configuration.
@@ -234,14 +369,24 @@ pub async fn spawn_process_with_pty_size_and_env_removals(
     let child = Arc::new(Mutex::new(child));
 
     let (output_tx, output_rx) = mpsc::channel::<ExecutorOutput>(1024);
+    let (raw_output_tx, raw_output_rx) = mpsc::unbounded_channel::<ExecutorOutput>();
+    let buffered_output_bytes = Arc::new(AtomicUsize::new(0));
+    let output_overflowed = Arc::new(AtomicBool::new(false));
+    forward_process_output(
+        raw_output_rx,
+        output_tx.clone(),
+        Arc::clone(&buffered_output_bytes),
+    );
     let (terminal_tx, terminal_rx) = mpsc::channel::<Vec<u8>>(256);
     let (input_tx, mut input_rx) = mpsc::channel::<ExecutorInput>(64);
     let (resize_tx, mut resize_rx) = mpsc::channel::<PtyDimensions>(8);
     let (kill_tx, kill_rx) = oneshot::channel::<()>();
 
-    let stdout_tx = output_tx.clone();
+    let stdout_tx = raw_output_tx.clone();
+    let stdout_buffered_bytes = Arc::clone(&buffered_output_bytes);
+    let stdout_output_overflowed = Arc::clone(&output_overflowed);
     let terminal_stream_tx = terminal_tx.clone();
-    tokio::task::spawn_blocking(move || {
+    let mut stdout_task = tokio::task::spawn_blocking(move || {
         let mut reader = reader;
         let mut pending = Vec::new();
         let mut buffer = [0_u8; 4096];
@@ -249,10 +394,12 @@ pub async fn spawn_process_with_pty_size_and_env_removals(
             match reader.read(&mut buffer) {
                 Ok(0) => {
                     if let Some(line) = flush_terminal_line_buffer(&mut pending) {
-                        if stdout_tx
-                            .blocking_send(ExecutorOutput::Stdout(line))
-                            .is_err()
-                        {
+                        if !queue_process_output(
+                            &stdout_tx,
+                            &stdout_buffered_bytes,
+                            &stdout_output_overflowed,
+                            ExecutorOutput::Stdout(line),
+                        ) {
                             break;
                         }
                     }
@@ -261,21 +408,36 @@ pub async fn spawn_process_with_pty_size_and_env_removals(
                 Ok(read) => {
                     let chunk = buffer[..read].to_vec();
                     let _ = terminal_stream_tx.blocking_send(chunk.clone());
+                    if stdout_output_overflowed.load(Ordering::Acquire) {
+                        continue;
+                    }
                     pending.extend_from_slice(&chunk);
+                    if pending.len() > MAX_BUFFERED_PROCESS_OUTPUT_BYTES {
+                        pending.clear();
+                        signal_output_overflow(&stdout_tx, &stdout_output_overflowed);
+                        continue;
+                    }
                     for line in drain_terminal_lines(&mut pending) {
-                        if stdout_tx
-                            .blocking_send(ExecutorOutput::Stdout(line))
-                            .is_err()
-                        {
+                        if !queue_process_output(
+                            &stdout_tx,
+                            &stdout_buffered_bytes,
+                            &stdout_output_overflowed,
+                            ExecutorOutput::Stdout(line),
+                        ) {
                             return;
                         }
                     }
                 }
                 Err(error) => {
-                    let _ = stdout_tx.blocking_send(ExecutorOutput::Failed {
-                        error: error.to_string(),
-                        exit_code: None,
-                    });
+                    let _ = queue_process_output(
+                        &stdout_tx,
+                        &stdout_buffered_bytes,
+                        &stdout_output_overflowed,
+                        ExecutorOutput::Failed {
+                            error: error.to_string(),
+                            exit_code: None,
+                        },
+                    );
                     break;
                 }
             }
@@ -328,7 +490,7 @@ pub async fn spawn_process_with_pty_size_and_env_removals(
         }
     });
 
-    let exit_tx = output_tx;
+    let exit_tx = raw_output_tx;
     let child_for_wait = Arc::clone(&child);
     let master_for_cleanup = Arc::clone(&master);
     tokio::spawn(async move {
@@ -352,14 +514,14 @@ pub async fn spawn_process_with_pty_size_and_env_removals(
                         let _ = child.kill();
                         let _ = child.wait();
                     }).await;
-                    // Drop the master handle to close PTY file descriptors.
                     if let Ok(mut guard) = master_for_cleanup.lock() {
                         guard.take();
                     }
+                    await_reader_task_with_timeout(&mut stdout_task).await;
                     let _ = exit_tx.send(ExecutorOutput::Failed {
                         error: "killed".to_string(),
                         exit_code: Some(-9),
-                    }).await;
+                    });
                 }
             }
             result = async move {
@@ -382,19 +544,19 @@ pub async fn spawn_process_with_pty_size_and_env_removals(
                     }
                 }
             } => {
-                // Drop the master handle on normal exit too.
                 if let Ok(mut guard) = master.lock() {
                     guard.take();
                 }
+                await_reader_task_with_timeout(&mut stdout_task).await;
                 match result {
                     Ok(code) => {
-                        let _ = exit_tx.send(ExecutorOutput::Completed { exit_code: code }).await;
+                        let _ = exit_tx.send(ExecutorOutput::Completed { exit_code: code });
                     }
                     Err(error) => {
                         let _ = exit_tx.send(ExecutorOutput::Failed {
                             error,
                             exit_code: None,
-                        }).await;
+                        });
                     }
                 }
             }
@@ -418,7 +580,18 @@ pub async fn spawn_process_no_stdin(
     cwd: &Path,
     env: &HashMap<String, String>,
 ) -> Result<ProcessHandle> {
-    spawn_process_no_stdin_with_env_removals(binary, args, cwd, env, &[]).await
+    spawn_process_no_stdin_with_env_options(binary, args, cwd, env, &[], false).await
+}
+
+/// Spawn a CLI process with stdout/stderr capture, stdin closed, and a clean
+/// environment built only from the provided variables.
+pub async fn spawn_process_no_stdin_with_clean_env(
+    binary: &Path,
+    args: &[String],
+    cwd: &Path,
+    env: &HashMap<String, String>,
+) -> Result<ProcessHandle> {
+    spawn_process_no_stdin_with_env_options(binary, args, cwd, env, &[], true).await
 }
 
 /// Spawn a CLI process with stdout/stderr capture, stdin closed, and explicit
@@ -430,6 +603,17 @@ pub async fn spawn_process_no_stdin_with_env_removals(
     env: &HashMap<String, String>,
     env_remove: &[String],
 ) -> Result<ProcessHandle> {
+    spawn_process_no_stdin_with_env_options(binary, args, cwd, env, env_remove, false).await
+}
+
+async fn spawn_process_no_stdin_with_env_options(
+    binary: &Path,
+    args: &[String],
+    cwd: &Path,
+    env: &HashMap<String, String>,
+    env_remove: &[String],
+    clear_existing_env: bool,
+) -> Result<ProcessHandle> {
     let mut cmd = Command::new(binary);
     cmd.args(args)
         .current_dir(cwd)
@@ -437,14 +621,15 @@ pub async fn spawn_process_no_stdin_with_env_removals(
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
 
-    apply_tokio_command_env(&mut cmd, env, env_remove);
+    apply_tokio_command_env(&mut cmd, env, env_remove, clear_existing_env);
 
     #[cfg(unix)]
     {
-        #[allow(unused_imports)]
-        use std::os::unix::process::CommandExt;
         unsafe {
             cmd.pre_exec(|| {
+                mark_extra_fds_cloexec_in_child()?;
+                clear_signal_mask_in_child()?;
+                restore_default_signals_in_child()?;
                 if libc::setpgid(0, 0) != 0 {
                     return Err(std::io::Error::last_os_error());
                 }
@@ -459,7 +644,7 @@ pub async fn spawn_process_no_stdin_with_env_removals(
         let result = unsafe { libc::setpgid(pid as libc::pid_t, pid as libc::pid_t) };
         if result != 0 {
             let error = std::io::Error::last_os_error();
-            if error.raw_os_error() != Some(libc::EACCES) {
+            if !matches!(error.raw_os_error(), Some(libc::EACCES | libc::EPERM)) {
                 return Err(error.into());
             }
         }
@@ -476,47 +661,149 @@ pub async fn spawn_process_no_stdin_with_env_removals(
         .ok_or_else(|| anyhow::anyhow!("stderr not piped"))?;
 
     let (output_tx, output_rx) = mpsc::channel::<ExecutorOutput>(1024);
-    // Input channel is intentionally created and receiver dropped — stdin is closed for
+    let (raw_output_tx, raw_output_rx) = mpsc::unbounded_channel::<ExecutorOutput>();
+    let buffered_output_bytes = Arc::new(AtomicUsize::new(0));
+    let output_overflowed = Arc::new(AtomicBool::new(false));
+    forward_process_output(
+        raw_output_rx,
+        output_tx.clone(),
+        Arc::clone(&buffered_output_bytes),
+    );
+    // Input channel is intentionally created and receiver dropped, stdin is closed for
     // this process variant. The sender is required by ProcessHandle's API contract.
     let (input_tx, _input_rx) = mpsc::channel::<ExecutorInput>(1);
     let (kill_tx, kill_rx) = oneshot::channel::<()>();
 
-    let stdout_tx = output_tx.clone();
-    tokio::spawn(async move {
-        let reader = AsyncBufReader::new(stdout);
-        let mut lines = reader.lines();
-        while let Ok(Some(line)) = lines.next_line().await {
-            if stdout_tx.send(ExecutorOutput::Stdout(line)).await.is_err() {
-                break;
+    let stdout_tx = raw_output_tx.clone();
+    let stdout_buffered_bytes = Arc::clone(&buffered_output_bytes);
+    let stdout_output_overflowed = Arc::clone(&output_overflowed);
+    let mut stdout_task = tokio::spawn(async move {
+        let mut reader = stdout;
+        let mut pending = Vec::new();
+        let mut buffer = [0_u8; 4096];
+        loop {
+            match reader.read(&mut buffer).await {
+                Ok(0) => {
+                    if stdout_output_overflowed.load(Ordering::Acquire) {
+                        break;
+                    }
+                    if let Some(line) = flush_terminal_line_buffer(&mut pending) {
+                        if !queue_process_output(
+                            &stdout_tx,
+                            &stdout_buffered_bytes,
+                            &stdout_output_overflowed,
+                            ExecutorOutput::Stdout(line),
+                        ) {
+                            break;
+                        }
+                    }
+                    break;
+                }
+                Ok(read) => {
+                    if stdout_output_overflowed.load(Ordering::Acquire) {
+                        continue;
+                    }
+                    pending.extend_from_slice(&buffer[..read]);
+                    if pending.len() > MAX_BUFFERED_PROCESS_OUTPUT_BYTES {
+                        pending.clear();
+                        signal_output_overflow(&stdout_tx, &stdout_output_overflowed);
+                        continue;
+                    }
+                    for line in drain_terminal_lines(&mut pending) {
+                        if !queue_process_output(
+                            &stdout_tx,
+                            &stdout_buffered_bytes,
+                            &stdout_output_overflowed,
+                            ExecutorOutput::Stdout(line),
+                        ) {
+                            return;
+                        }
+                    }
+                }
+                Err(_) => break,
             }
         }
     });
 
-    let stderr_tx = output_tx.clone();
-    tokio::spawn(async move {
-        let reader = AsyncBufReader::new(stderr);
-        let mut lines = reader.lines();
-        while let Ok(Some(line)) = lines.next_line().await {
-            if stderr_tx.send(ExecutorOutput::Stderr(line)).await.is_err() {
-                break;
+    let stderr_tx = raw_output_tx.clone();
+    let stderr_buffered_bytes = Arc::clone(&buffered_output_bytes);
+    let stderr_output_overflowed = Arc::clone(&output_overflowed);
+    let mut stderr_task = tokio::spawn(async move {
+        let mut reader = stderr;
+        let mut pending = Vec::new();
+        let mut buffer = [0_u8; 4096];
+        loop {
+            match reader.read(&mut buffer).await {
+                Ok(0) => {
+                    if stderr_output_overflowed.load(Ordering::Acquire) {
+                        break;
+                    }
+                    if let Some(line) = flush_terminal_line_buffer(&mut pending) {
+                        if !queue_process_output(
+                            &stderr_tx,
+                            &stderr_buffered_bytes,
+                            &stderr_output_overflowed,
+                            ExecutorOutput::Stderr(line),
+                        ) {
+                            break;
+                        }
+                    }
+                    break;
+                }
+                Ok(read) => {
+                    if stderr_output_overflowed.load(Ordering::Acquire) {
+                        continue;
+                    }
+                    pending.extend_from_slice(&buffer[..read]);
+                    if pending.len() > MAX_BUFFERED_PROCESS_OUTPUT_BYTES {
+                        pending.clear();
+                        signal_output_overflow(&stderr_tx, &stderr_output_overflowed);
+                        continue;
+                    }
+                    for line in drain_terminal_lines(&mut pending) {
+                        if !queue_process_output(
+                            &stderr_tx,
+                            &stderr_buffered_bytes,
+                            &stderr_output_overflowed,
+                            ExecutorOutput::Stderr(line),
+                        ) {
+                            return;
+                        }
+                    }
+                }
+                Err(_) => break,
             }
         }
     });
 
-    let exit_tx = output_tx;
+    let exit_tx = raw_output_tx;
     tokio::spawn(async move {
         tokio::select! {
-            status = child.wait() => {
+            status = async {
+                loop {
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                    match child.try_wait() {
+                        Ok(Some(status)) => break Ok(status),
+                        Ok(None) => continue,
+                        Err(error) => break Err(error),
+                    }
+                }
+            } => {
+                if status.is_ok() {
+                    let _ = child.wait().await;
+                }
+                await_reader_task_with_timeout(&mut stdout_task).await;
+                await_reader_task_with_timeout(&mut stderr_task).await;
                 match status {
                     Ok(s) => {
                         let code = s.code().unwrap_or(-1);
-                        let _ = exit_tx.send(ExecutorOutput::Completed { exit_code: code }).await;
+                        let _ = exit_tx.send(ExecutorOutput::Completed { exit_code: code });
                     }
                     Err(e) => {
                         let _ = exit_tx.send(ExecutorOutput::Failed {
                             error: e.to_string(),
                             exit_code: None,
-                        }).await;
+                        });
                     }
                 }
             }
@@ -530,18 +817,22 @@ pub async fn spawn_process_no_stdin_with_env_removals(
                         })
                         .await;
                         let _ = child.wait().await;
+                        await_reader_task_with_timeout(&mut stdout_task).await;
+                        await_reader_task_with_timeout(&mut stderr_task).await;
                         let _ = exit_tx.send(ExecutorOutput::Failed {
                             error: "killed".to_string(),
                             exit_code: Some(-15),
-                        }).await;
+                        });
                         return;
                     }
                     // SIGKILL fallback
                     let _ = child.kill().await;
+                    await_reader_task_with_timeout(&mut stdout_task).await;
+                    await_reader_task_with_timeout(&mut stderr_task).await;
                     let _ = exit_tx.send(ExecutorOutput::Failed {
                         error: "killed".to_string(),
                         exit_code: Some(-9),
-                    }).await;
+                    });
                 }
             }
         }
@@ -595,7 +886,10 @@ fn flush_terminal_line_buffer(buffer: &mut Vec<u8>) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_process_alive, spawn_process, spawn_process_no_stdin, ExecutorOutput};
+    use super::{
+        is_process_alive, spawn_process, spawn_process_no_stdin,
+        spawn_process_no_stdin_with_clean_env, ExecutorOutput,
+    };
     use std::collections::HashMap;
     use std::path::Path;
     use tokio::time::{timeout, Duration};
@@ -699,6 +993,327 @@ mod tests {
         assert!(
             terminated.is_ok(),
             "shell child should terminate with parent"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn spawn_process_no_stdin_with_clean_env_drops_parent_env_noise() {
+        let noisy_key = "CONDUCTOR_EXECUTORS_TEST_NOISY_ENV";
+        std::env::set_var(noisy_key, "should-not-leak");
+
+        let mut clean_env = HashMap::new();
+        clean_env.insert("TEST_ALLOWED".to_string(), "present".to_string());
+
+        let mut handle = spawn_process_no_stdin_with_clean_env(
+            Path::new("/usr/bin/python3"),
+            &[
+                "-c".to_string(),
+                format!(
+                    "import json, os; print(json.dumps({{'allowed': os.getenv('TEST_ALLOWED'), 'noisy': os.getenv('{noisy_key}')}}))"
+                ),
+            ],
+            Path::new("."),
+            &clean_env,
+        )
+        .await
+        .expect("headless process should spawn with clean env");
+
+        let first = timeout(Duration::from_secs(5), handle.output_rx.recv())
+            .await
+            .expect("timed out waiting for env report")
+            .expect("output channel closed before env report");
+        let second = timeout(Duration::from_secs(5), handle.output_rx.recv())
+            .await
+            .expect("timed out waiting for completion")
+            .expect("output channel closed before completion");
+
+        std::env::remove_var(noisy_key);
+
+        let ExecutorOutput::Stdout(env_json) = first else {
+            panic!("expected stdout env report, got {first:?}");
+        };
+        let env_report: serde_json::Value =
+            serde_json::from_str(&env_json).expect("env report should parse");
+
+        assert_eq!(
+            env_report.get("allowed").and_then(|value| value.as_str()),
+            Some("present")
+        );
+        assert!(
+            env_report.get("noisy").is_some_and(|value| value.is_null()),
+            "clean-env spawn should not inherit parent env noise: {env_report:?}"
+        );
+        assert!(
+            matches!(second, ExecutorOutput::Completed { exit_code: 0 }),
+            "expected completion after env report, got {second:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn spawn_process_no_stdin_with_clean_env_restores_sigpipe_default() {
+        use nix::libc;
+        use std::fs;
+        use std::process::Command as StdCommand;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be valid")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("conductor-sigpipe-{stamp}"));
+        fs::create_dir_all(&root).expect("temp dir should be created");
+        let source = root.join("sigpipe.c");
+        let binary = root.join("sigpipe-check");
+        fs::write(
+            &source,
+            r#"#include <signal.h>
+#include <stdio.h>
+int main(void) {
+    struct sigaction action;
+    if (sigaction(SIGPIPE, NULL, &action) != 0) {
+        return 2;
+    }
+    if (action.sa_handler == SIG_DFL) {
+        puts("{\"sigpipe\":\"SIG_DFL\"}");
+    } else if (action.sa_handler == SIG_IGN) {
+        puts("{\"sigpipe\":\"SIG_IGN\"}");
+    } else {
+        puts("{\"sigpipe\":\"OTHER\"}");
+    }
+    return 0;
+}
+"#,
+        )
+        .expect("source should be written");
+        let status = StdCommand::new("/usr/bin/cc")
+            .arg(&source)
+            .arg("-o")
+            .arg(&binary)
+            .status()
+            .expect("cc should launch");
+        assert!(status.success(), "cc should compile the sigpipe helper");
+
+        let previous = unsafe { libc::signal(libc::SIGPIPE, libc::SIG_IGN) };
+        assert_ne!(
+            previous,
+            libc::SIG_ERR,
+            "should set parent sigpipe disposition"
+        );
+
+        let mut clean_env = HashMap::new();
+        clean_env.insert("TEST_ALLOWED".to_string(), "present".to_string());
+
+        let mut handle =
+            spawn_process_no_stdin_with_clean_env(&binary, &[], Path::new("."), &clean_env)
+                .await
+                .expect("headless process should spawn with restored sigpipe");
+
+        let first = timeout(Duration::from_secs(5), handle.output_rx.recv())
+            .await
+            .expect("timed out waiting for sigpipe report")
+            .expect("output channel closed before sigpipe report");
+        let second = timeout(Duration::from_secs(5), handle.output_rx.recv())
+            .await
+            .expect("timed out waiting for completion")
+            .expect("output channel closed before completion");
+
+        let restored = unsafe { libc::signal(libc::SIGPIPE, previous) };
+        assert_ne!(
+            restored,
+            libc::SIG_ERR,
+            "should restore parent sigpipe disposition"
+        );
+
+        let ExecutorOutput::Stdout(sig_json) = first else {
+            panic!("expected stdout sigpipe report, got {first:?}");
+        };
+        let sig_report: serde_json::Value =
+            serde_json::from_str(&sig_json).expect("sigpipe report should parse");
+
+        assert_eq!(
+            sig_report.get("sigpipe").and_then(|value| value.as_str()),
+            Some("SIG_DFL")
+        );
+        assert!(
+            matches!(second, ExecutorOutput::Completed { exit_code: 0 }),
+            "expected completion after sigpipe report, got {second:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn spawn_process_no_stdin_closes_inherited_extra_fds() {
+        use nix::libc;
+        use std::fs::File;
+        use std::os::fd::AsRawFd;
+
+        let extra = File::open("/dev/null").expect("should open test file");
+        let extra_fd = extra.as_raw_fd();
+        let flags = unsafe { libc::fcntl(extra_fd, libc::F_GETFD) };
+        assert!(flags >= 0, "should read fd flags");
+        let cleared = unsafe { libc::fcntl(extra_fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) };
+        assert_eq!(cleared, 0, "should clear close-on-exec");
+
+        let mut handle = spawn_process_no_stdin(
+            Path::new("/bin/sh"),
+            &[
+                "-lc".to_string(),
+                "python3 -c 'import json, os; print(json.dumps(sorted(int(fd) for fd in os.listdir(\"/dev/fd\"))))'"
+                    .to_string(),
+            ],
+            Path::new("."),
+            &HashMap::new(),
+        )
+        .await
+        .expect("headless process should spawn");
+
+        let first = timeout(Duration::from_secs(5), handle.output_rx.recv())
+            .await
+            .expect("timed out waiting for fd list")
+            .expect("output channel closed before fd list");
+        let second = timeout(Duration::from_secs(5), handle.output_rx.recv())
+            .await
+            .expect("timed out waiting for completion")
+            .expect("output channel closed before completion");
+
+        let ExecutorOutput::Stdout(fd_json) = first else {
+            panic!("expected stdout fd list, got {first:?}");
+        };
+        let fds: Vec<i32> = serde_json::from_str(&fd_json).expect("fd list should parse");
+
+        assert!(
+            !fds.contains(&extra_fd),
+            "child inherited unexpected extra fd {extra_fd}: {fds:?}"
+        );
+        assert!(
+            matches!(second, ExecutorOutput::Completed { exit_code: 0 }),
+            "expected completion after fd list, got {second:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn spawn_process_no_stdin_reports_missing_binary_spawn_errors() {
+        let error = match spawn_process_no_stdin(
+            Path::new("/definitely/not/a/real/binary"),
+            &[],
+            Path::new("."),
+            &HashMap::new(),
+        )
+        .await
+        {
+            Ok(_) => panic!("missing binary should return spawn error"),
+            Err(error) => error,
+        };
+
+        let error_text = format!("{error:#}");
+        assert!(
+            error_text.contains("No such file") || error_text.contains("os error 2"),
+            "expected missing binary spawn error, got {error_text}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn spawn_process_no_stdin_completes_even_if_descendant_keeps_pipe_open() {
+        let mut handle = spawn_process_no_stdin(
+            Path::new("/bin/sh"),
+            &[
+                "-lc".to_string(),
+                "(sleep 2) & printf 'pipe kept open\\n'".to_string(),
+            ],
+            Path::new("."),
+            &HashMap::new(),
+        )
+        .await
+        .expect("headless process should spawn");
+
+        let first = timeout(Duration::from_secs(2), handle.output_rx.recv())
+            .await
+            .expect("timed out waiting for first event")
+            .expect("output channel closed before first event");
+        let second = timeout(Duration::from_millis(900), handle.output_rx.recv())
+            .await
+            .expect("completion should not wait for descendant-held pipe")
+            .expect("output channel closed before completion");
+
+        assert!(
+            matches!(first, ExecutorOutput::Stdout(ref line) if line == "pipe kept open"),
+            "expected stdout before completion, got {first:?}"
+        );
+        assert!(
+            matches!(second, ExecutorOutput::Completed { exit_code: 0 }),
+            "expected completion even with descendant-held pipe, got {second:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn spawn_process_no_stdin_preserves_trailing_stdout_before_completion() {
+        let mut handle = spawn_process_no_stdin(
+            Path::new("/bin/sh"),
+            &[
+                "-lc".to_string(),
+                "printf 'pipe trailing output'".to_string(),
+            ],
+            Path::new("."),
+            &HashMap::new(),
+        )
+        .await
+        .expect("headless process should spawn");
+
+        let first = timeout(Duration::from_secs(5), handle.output_rx.recv())
+            .await
+            .expect("timed out waiting for first event")
+            .expect("output channel closed before first event");
+        let second = timeout(Duration::from_secs(5), handle.output_rx.recv())
+            .await
+            .expect("timed out waiting for second event")
+            .expect("output channel closed before second event");
+
+        assert!(
+            matches!(first, ExecutorOutput::Stdout(ref line) if line == "pipe trailing output"),
+            "expected trailing stdout before completion, got {first:?}"
+        );
+        assert!(
+            matches!(second, ExecutorOutput::Completed { exit_code: 0 }),
+            "expected completion after stdout flush, got {second:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn spawn_process_preserves_trailing_stdout_before_completion() {
+        let mut handle = spawn_process(
+            Path::new("/bin/sh"),
+            &[
+                "-lc".to_string(),
+                "printf 'pty trailing output'".to_string(),
+            ],
+            Path::new("."),
+            &HashMap::new(),
+        )
+        .await
+        .expect("pty process should spawn");
+
+        let first = timeout(Duration::from_secs(5), handle.output_rx.recv())
+            .await
+            .expect("timed out waiting for first event")
+            .expect("output channel closed before first event");
+        let second = timeout(Duration::from_secs(5), handle.output_rx.recv())
+            .await
+            .expect("timed out waiting for second event")
+            .expect("output channel closed before second event");
+
+        assert!(
+            matches!(first, ExecutorOutput::Stdout(ref line) if line == "pty trailing output"),
+            "expected trailing stdout before completion, got {first:?}"
+        );
+        assert!(
+            matches!(second, ExecutorOutput::Completed { exit_code: 0 }),
+            "expected completion after stdout flush, got {second:?}"
         );
     }
 }

--- a/crates/conductor-server/src/state/acp_dispatcher.rs
+++ b/crates/conductor-server/src/state/acp_dispatcher.rs
@@ -1274,7 +1274,14 @@ fn append_dispatcher_context_sections(prompt: &str, sections: &[String]) -> Stri
     combined
 }
 
-fn normalize_loaded_dispatcher_thread(thread: &mut SessionRecord) -> bool {
+fn running_inside_dispatcher_mcp_server() -> bool {
+    std::env::var("CONDUCTOR_SESSION_KIND").ok().as_deref() == Some(ACP_SESSION_KIND)
+}
+
+fn normalize_loaded_dispatcher_thread(
+    thread: &mut SessionRecord,
+    terminate_loaded_pid: bool,
+) -> bool {
     let mut changed = false;
     if thread.metadata.get("sessionKind").map(String::as_str) != Some(ACP_SESSION_KIND) {
         thread
@@ -1302,26 +1309,32 @@ fn normalize_loaded_dispatcher_thread(thread: &mut SessionRecord) -> bool {
         changed = true;
     }
 
-    if let Some(pid) = thread.pid.filter(|pid| *pid > 1) {
-        if is_process_alive(pid) {
-            let _ = terminate_process(pid);
-        }
-        thread.pid = None;
-        changed = true;
-    }
+    let loaded_pid = thread.pid.filter(|pid| *pid > 1);
+    let live_pid = loaded_pid.filter(|pid| is_process_alive(*pid));
+    let should_reset_runtime_state = terminate_loaded_pid || live_pid.is_none();
 
-    if matches!(
-        thread.status,
-        SessionStatus::Working | SessionStatus::Queued | SessionStatus::Spawning
-    ) {
-        thread.status = SessionStatus::Idle;
-        thread.activity = Some("idle".to_string());
-        thread.summary = Some("Dispatcher ready for the next turn".to_string());
-        thread.metadata.insert(
-            "summary".to_string(),
-            "Dispatcher ready for the next turn".to_string(),
-        );
-        changed = true;
+    if should_reset_runtime_state {
+        if let Some(pid) = loaded_pid {
+            if terminate_loaded_pid && live_pid.is_some() {
+                let _ = terminate_process(pid);
+            }
+            thread.pid = None;
+            changed = true;
+        }
+
+        if matches!(
+            thread.status,
+            SessionStatus::Working | SessionStatus::Queued | SessionStatus::Spawning
+        ) {
+            thread.status = SessionStatus::Idle;
+            thread.activity = Some("idle".to_string());
+            thread.summary = Some("Dispatcher ready for the next turn".to_string());
+            thread.metadata.insert(
+                "summary".to_string(),
+                "Dispatcher ready for the next turn".to_string(),
+            );
+            changed = true;
+        }
     }
 
     if strip_dispatcher_context_attachments(thread) {
@@ -1877,6 +1890,13 @@ impl AppState {
     }
 
     pub(crate) async fn load_dispatchers_from_disk(&self) {
+        self.load_dispatchers_from_disk_with_pid_termination(
+            !running_inside_dispatcher_mcp_server(),
+        )
+        .await;
+    }
+
+    async fn load_dispatchers_from_disk_with_pid_termination(&self, terminate_loaded_pids: bool) {
         let root = self.dispatcher_store_dir();
         let entries = match tokio::fs::read_dir(&root).await {
             Ok(entries) => entries,
@@ -1891,7 +1911,8 @@ impl AppState {
             }
             if let Ok(content) = tokio::fs::read_to_string(&path).await {
                 if let Ok(mut session) = serde_json::from_str::<SessionRecord>(&content) {
-                    let changed = normalize_loaded_dispatcher_thread(&mut session);
+                    let changed =
+                        normalize_loaded_dispatcher_thread(&mut session, terminate_loaded_pids);
                     if changed {
                         if let Ok(updated) = serde_json::to_string_pretty(&session) {
                             let _ = tokio::fs::write(&path, updated).await;
@@ -3969,6 +3990,17 @@ impl AppState {
         self.persist_dispatcher_thread(&updated).await?;
         self.publish_dispatcher_update(thread_id).await;
 
+        if let Err(err) = self
+            .record_acp_dispatcher_turn(&updated, &message, &recorded_attachments)
+            .await
+        {
+            tracing::warn!(
+                session_id = %updated.id,
+                error = %err,
+                "failed to record ACP dispatcher turn"
+            );
+        }
+
         let runtime_prompt = self
             .dispatcher_prompt_with_context(&updated, &runtime_message, &effective_attachments)
             .await;
@@ -4015,17 +4047,6 @@ impl AppState {
                 reasoning_effort.or_else(|| updated.reasoning_effort.clone()),
             )
             .await?;
-        }
-
-        if let Err(err) = self
-            .record_acp_dispatcher_turn(&updated, &message, &recorded_attachments)
-            .await
-        {
-            tracing::warn!(
-                session_id = %updated.id,
-                error = %err,
-                "failed to record ACP dispatcher turn"
-            );
         }
         Ok(())
     }
@@ -4147,6 +4168,7 @@ mod tests {
     use std::path::Path;
     use std::sync::Arc;
     use std::time::Duration;
+    use tokio::process::Command;
     use tokio::sync::{mpsc, oneshot};
     use tokio::time::timeout;
     use uuid::Uuid;
@@ -4651,11 +4673,135 @@ mod tests {
             metadata: HashMap::new(),
         });
 
-        assert!(normalize_loaded_dispatcher_thread(&mut thread));
+        assert!(normalize_loaded_dispatcher_thread(&mut thread, false));
         assert_eq!(
             thread.conversation[0].attachments,
             vec!["notes/spec.md".to_string()]
         );
+    }
+
+    #[tokio::test]
+    async fn load_dispatchers_from_disk_preserves_live_pid_when_termination_disabled() {
+        let (root, state) = build_test_state("dispatcher-load-live-pid").await;
+        let mut child = Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("sleep child should spawn");
+        let pid = child.id().expect("sleep child should have pid");
+
+        let mut thread = SessionRecord::new(
+            "dispatcher-load-live-pid".to_string(),
+            "demo".to_string(),
+            None,
+            None,
+            Some(root.join("repo").to_string_lossy().to_string()),
+            "codex".to_string(),
+            None,
+            None,
+            "dispatcher prompt".to_string(),
+            None,
+        );
+        thread.status = SessionStatus::Working;
+        thread.activity = Some("working".to_string());
+        thread.pid = Some(pid);
+        thread
+            .metadata
+            .insert("sessionKind".to_string(), ACP_SESSION_KIND.to_string());
+        thread
+            .metadata
+            .insert("role".to_string(), "orchestrator".to_string());
+
+        let snapshot = state.dispatcher_snapshot_path(&thread.id);
+        fs::write(
+            &snapshot,
+            serde_json::to_string_pretty(&thread).expect("thread should serialize"),
+        )
+        .expect("dispatcher snapshot should persist");
+
+        state
+            .load_dispatchers_from_disk_with_pid_termination(false)
+            .await;
+
+        assert!(super::is_process_alive(pid));
+        let loaded = state
+            .get_dispatcher_thread(&thread.id)
+            .await
+            .expect("loaded thread should exist");
+        assert_eq!(loaded.pid, Some(pid));
+        assert_eq!(loaded.status, SessionStatus::Working);
+        assert_eq!(loaded.activity.as_deref(), Some("working"));
+        let persisted: SessionRecord = serde_json::from_str(
+            &fs::read_to_string(&snapshot).expect("dispatcher snapshot should still exist"),
+        )
+        .expect("snapshot should deserialize");
+        assert_eq!(persisted.pid, Some(pid));
+        assert_eq!(persisted.status, SessionStatus::Working);
+
+        let _ = child.kill().await;
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn load_dispatchers_from_disk_terminates_live_process_when_requested() {
+        let (root, state) = build_test_state("dispatcher-load-stale-pid").await;
+        let mut child = Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("sleep child should spawn");
+        let pid = child.id().expect("sleep child should have pid");
+
+        let mut thread = SessionRecord::new(
+            "dispatcher-load-stale-pid".to_string(),
+            "demo".to_string(),
+            None,
+            None,
+            Some(root.join("repo").to_string_lossy().to_string()),
+            "codex".to_string(),
+            None,
+            None,
+            "dispatcher prompt".to_string(),
+            None,
+        );
+        thread.status = SessionStatus::Working;
+        thread.activity = Some("working".to_string());
+        thread.pid = Some(pid);
+        thread
+            .metadata
+            .insert("sessionKind".to_string(), ACP_SESSION_KIND.to_string());
+        thread
+            .metadata
+            .insert("role".to_string(), "orchestrator".to_string());
+
+        let snapshot = state.dispatcher_snapshot_path(&thread.id);
+        fs::write(
+            &snapshot,
+            serde_json::to_string_pretty(&thread).expect("thread should serialize"),
+        )
+        .expect("dispatcher snapshot should persist");
+
+        state
+            .load_dispatchers_from_disk_with_pid_termination(true)
+            .await;
+
+        let status = timeout(Duration::from_secs(5), child.wait())
+            .await
+            .expect("stale child should terminate")
+            .expect("child wait should succeed");
+        assert!(
+            !status.success(),
+            "stale child should not exit cleanly after termination"
+        );
+
+        let loaded = state
+            .get_dispatcher_thread(&thread.id)
+            .await
+            .expect("loaded thread should exist");
+        assert_eq!(loaded.pid, None);
+        assert_eq!(loaded.status, SessionStatus::Idle);
+        assert_eq!(loaded.activity.as_deref(), Some("idle"));
+
+        let _ = child.kill().await;
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]
@@ -4686,7 +4832,7 @@ mod tests {
             ACP_APPROVAL_REQUIRED.to_string(),
         );
 
-        assert!(normalize_loaded_dispatcher_thread(&mut thread));
+        assert!(normalize_loaded_dispatcher_thread(&mut thread, false));
         assert_eq!(thread.status, SessionStatus::NeedsInput);
         assert_eq!(thread.activity.as_deref(), Some("waiting_input"));
         assert_eq!(
@@ -4730,7 +4876,7 @@ mod tests {
             ACP_APPROVAL_REQUIRED.to_string(),
         );
 
-        assert!(normalize_loaded_dispatcher_thread(&mut thread));
+        assert!(normalize_loaded_dispatcher_thread(&mut thread, false));
         assert_eq!(thread.status, SessionStatus::NeedsInput);
         assert_eq!(thread.activity.as_deref(), Some("waiting_input"));
         assert_eq!(


### PR DESCRIPTION
## Summary

Hardens the dispatcher headless runtime path so structured Codex sessions run in an isolated home, PTY and pipe readers drain safely without wedging completion, and dispatcher snapshot recovery preserves live runtimes while still resetting stale approval state.

## User-Facing Release Notes

- Fixed dispatcher chat runs getting stuck or reporting stale runtime state after headless Codex turns.
- Fixed headless dispatcher sessions inheriting stray local environment and terminal state.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Plugin addition / modification
- [ ] Documentation update
- [ ] Refactor / chore

## Testing

- `cargo test -p conductor-executors`
- `cargo test -p conductor-server normalize_loaded_dispatcher_thread_restores_pending_plan_reviews_to_needs_input -- --nocapture`
- `cargo test -p conductor-server normalize_loaded_dispatcher_thread_restores_working_plan_reviews_to_needs_input -- --nocapture`
- `cargo test -p conductor-server load_dispatchers_from_disk_preserves_live_pid_when_termination_disabled -- --nocapture`
- `cargo test -p conductor-server load_dispatchers_from_disk_terminates_live_process_when_requested -- --nocapture`
- `cargo test -p conductor-server headless_plan_only_dispatcher_turn_waits_for_explicit_approval -- --nocapture`
- `cargo test -p conductor-server headless_dispatcher_send_returns_before_runtime_finishes -- --nocapture`
- `cargo clippy -p conductor-executors -p conductor-server -- -D warnings`
- `bun run --cwd packages/web typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes & Improvements**
  * Enhanced process execution with improved environment isolation and variable management
  * Added output buffering limits to prevent resource exhaustion
  * Improved Codex execution reliability through native binary resolution
  * Strengthened dispatcher session management and lifecycle handling

* **Tests**
  * Added unit tests for process execution, environment handling, and dispatcher behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->