### PR TITLE
fix: replace dead onboarding support links

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ On Windows PowerShell:
 
 The hosted dashboard is **not** a cloud IDE. Your repos, terminals, and agents stay on the paired machine.
 
+If you only forward a local dashboard port from a remote VM, Conductor will still treat that as remote access and block it unless you add an identity layer. For remote use, either pair the machine with `https://app.conductross.com` or put your self-hosted dashboard behind Clerk or Cloudflare Access.
+
 ## What Conductor actually is
 
 Conductor sits between your repos and the coding CLIs you already use.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -49,6 +49,8 @@ On Windows PowerShell:
 
 The hosted dashboard is not a cloud IDE. Your repos, terminals, and agents stay on the paired machine.
 
+If you only forward a local dashboard port from a remote VM, Conductor will still treat that as remote access and block it unless you add an identity layer. For remote use, either pair the machine with `https://app.conductross.com` or put your self-hosted dashboard behind Clerk or Cloudflare Access.
+
 ## Install globally
 
 ```bash

--- a/packages/web/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/packages/web/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,8 +1,7 @@
 import { headers } from "next/headers";
 import Link from "next/link";
 import { redirect } from "next/navigation";
-import { Check, HardDrive, ShieldCheck, Workflow } from "lucide-react";
-import { DiscordMark } from "@/components/DiscordMark";
+import { Check, HardDrive, LifeBuoy, ShieldCheck, Workflow } from "lucide-react";
 import { SignInExperience } from "./SignInExperience";
 import { PublicPageShell, PublicPanel, PublicSection } from "@/components/public/PublicPageShell";
 import { Button } from "@/components/ui/Button";
@@ -18,6 +17,7 @@ import {
   resolveRequestBaseUrl,
   resolveRequestHostname,
 } from "@/lib/clerkConfig";
+import { CONDUCTOR_SUPPORT_DISCUSSIONS_URL } from "@/lib/supportLinks";
 
 const LOCAL_RUNTIME_POINTS = [
   "Repositories remain on the paired laptop.",
@@ -109,9 +109,9 @@ export default async function SignInPage({ searchParams }: SignInPageProps) {
               <Link href="https://conductross.com">Read the product story</Link>
             </Button>
             <Button asChild variant="outline" size="lg">
-              <a href="https://discord.gg/sA4QCWNR" target="_blank" rel="noopener noreferrer">
-                <DiscordMark className="mr-2 h-4 w-4" />
-                Join Discord
+              <a href={CONDUCTOR_SUPPORT_DISCUSSIONS_URL} target="_blank" rel="noopener noreferrer">
+                <LifeBuoy className="mr-2 h-4 w-4" />
+                Open support
               </a>
             </Button>
           </div>
@@ -123,7 +123,9 @@ export default async function SignInPage({ searchParams }: SignInPageProps) {
           <p className="mt-3 text-sm leading-6 text-[var(--text-muted)]">
             Use Google or any other provider you enable in Clerk. Email stays available if you keep it enabled.
             After sign-in, Clerk returns you to the dashboard or active bridge claim flow inside the same local
-            workflow.
+            workflow. If you are coming from a remote VM, use the hosted paired-device flow here or put your
+            self-hosted dashboard behind Clerk or Cloudflare Access. Plain forwarded local dashboard ports are
+            intentionally blocked.
           </p>
 
           <div className="mt-6">

--- a/packages/web/src/app/unlock/page.tsx
+++ b/packages/web/src/app/unlock/page.tsx
@@ -1,10 +1,15 @@
-import { DiscordMark } from "@/components/DiscordMark";
+import { LifeBuoy } from "lucide-react";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { PublicPageShell, PublicPanel, PublicSection } from "@/components/public/PublicPageShell";
 import { allowsLocalUnauthenticatedAccess, isLoopbackHost } from "@/lib/accessControl";
 import { resolveRequestHostname } from "@/lib/clerkConfig";
 import { sanitizeRedirectTarget } from "@/lib/redirectTarget";
+import {
+  CONDUCTOR_APP_URL,
+  CONDUCTOR_SUPPORT_DISCUSSIONS_URL,
+  getRemoteAccessSupportMessage,
+} from "@/lib/supportLinks";
 
 function getErrorMessage(code: string | null | undefined): string | null {
   if (code === "invalid") return "That access request is invalid.";
@@ -24,6 +29,7 @@ export default async function UnlockPage({ searchParams }: UnlockPageProps) {
   const errorValue = Array.isArray(rawError) ? rawError[0] : rawError;
   const nextPath = sanitizeRedirectTarget(nextValue);
   const errorMessage = getErrorMessage(errorValue);
+  const remoteAccessHelp = getRemoteAccessSupportMessage(errorValue);
   const headerStore = await headers();
   const requestHost = resolveRequestHostname(headerStore);
 
@@ -38,7 +44,7 @@ export default async function UnlockPage({ searchParams }: UnlockPageProps) {
           <PublicSection
             eyebrow="Dashboard Access"
             title="Authentication Required"
-            description="Open Conductor from a local session, or use a protected dashboard URL backed by a verified identity provider such as Cloudflare Access or Clerk."
+            description="Open Conductor from a local session, use the hosted paired-device flow at app.conductross.com, or put your self-hosted dashboard behind Cloudflare Access or Clerk."
           />
 
           {errorMessage ? (
@@ -47,20 +53,36 @@ export default async function UnlockPage({ searchParams }: UnlockPageProps) {
             </p>
           ) : null}
 
+          {remoteAccessHelp ? (
+            <p className="mt-4 rounded-[var(--radius-md)] border border-[var(--border-soft)] bg-[var(--bg-shell)] px-3 py-2 text-sm leading-6 text-[var(--text-muted)]">
+              {remoteAccessHelp}
+            </p>
+          ) : null}
+
           {nextPath !== "/" ? (
             <p className="mt-6 text-sm leading-6 text-[var(--text-muted)]">
               Requested path: <code>{nextPath}</code>
             </p>
           ) : null}
-          <a
-            href="https://discord.gg/sA4QCWNR"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="mt-6 inline-flex items-center gap-2 rounded-[var(--radius-md)] border border-[var(--border-soft)] px-4 py-2 text-sm font-medium text-[var(--text-muted)] transition hover:border-[var(--border-default)] hover:text-[var(--text-normal)]"
-          >
-            <DiscordMark className="h-4 w-4" />
-            Join Community
-          </a>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <a
+              href={CONDUCTOR_APP_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-[var(--radius-md)] border border-[var(--border-default)] bg-[var(--accent-primary)] px-4 py-2 text-sm font-medium text-white transition hover:opacity-90"
+            >
+              Open hosted app
+            </a>
+            <a
+              href={CONDUCTOR_SUPPORT_DISCUSSIONS_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-[var(--radius-md)] border border-[var(--border-soft)] px-4 py-2 text-sm font-medium text-[var(--text-muted)] transition hover:border-[var(--border-default)] hover:text-[var(--text-normal)]"
+            >
+              <LifeBuoy className="h-4 w-4" />
+              Open support
+            </a>
+          </div>
         </PublicPanel>
       </div>
     </PublicPageShell>

--- a/packages/web/src/components/layout/TopBar.tsx
+++ b/packages/web/src/components/layout/TopBar.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { memo, type ReactNode } from "react";
-import { Settings } from "lucide-react";
-import { DiscordMark } from "@/components/DiscordMark";
+import { LifeBuoy, Settings } from "lucide-react";
+import { CONDUCTOR_SUPPORT_DISCUSSIONS_URL } from "@/lib/supportLinks";
 
 interface TopBarProps {
   title?: string;
@@ -25,14 +25,14 @@ export const TopBar = memo(function TopBar({ title, onOpenPreferences, rightCont
           </div>
         ) : null}
         <a
-          href="https://discord.gg/sA4QCWNR"
+          href={CONDUCTOR_SUPPORT_DISCUSSIONS_URL}
           target="_blank"
           rel="noopener noreferrer"
           className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-[4px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] hover:text-[var(--vk-text-normal)]"
-          aria-label="Join Discord community"
-          title="Community"
+          aria-label="Open Conductor support"
+          title="Support"
         >
-          <DiscordMark className="h-4 w-4" />
+          <LifeBuoy className="h-4 w-4" />
         </a>
         {onOpenPreferences ? (
           <button

--- a/packages/web/src/lib/supportLinks.test.ts
+++ b/packages/web/src/lib/supportLinks.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  CONDUCTOR_APP_URL,
+  CONDUCTOR_ISSUES_URL,
+  CONDUCTOR_SUPPORT_DISCUSSIONS_URL,
+  getRemoteAccessSupportMessage,
+} from "./supportLinks";
+
+test("support links point to live conductor support surfaces", () => {
+  assert.equal(CONDUCTOR_APP_URL, "https://app.conductross.com");
+  assert.equal(CONDUCTOR_SUPPORT_DISCUSSIONS_URL, "https://github.com/charannyk06/conductor-oss/discussions");
+  assert.equal(CONDUCTOR_ISSUES_URL, "https://github.com/charannyk06/conductor-oss/issues");
+});
+
+test("getRemoteAccessSupportMessage explains why raw port forwarding is blocked", () => {
+  const message = getRemoteAccessSupportMessage("unavailable");
+
+  assert.ok(message);
+  assert.match(message, /port forwarding/i);
+  assert.match(message, /remote access/i);
+  assert.match(message, /app\.conductross\.com/i);
+  assert.match(message, /Cloudflare Access or Clerk/i);
+});
+
+test("getRemoteAccessSupportMessage only adds extra guidance for unavailable access paths", () => {
+  assert.equal(getRemoteAccessSupportMessage("invalid"), null);
+  assert.equal(getRemoteAccessSupportMessage(undefined), null);
+});

--- a/packages/web/src/lib/supportLinks.ts
+++ b/packages/web/src/lib/supportLinks.ts
@@ -1,0 +1,11 @@
+export const CONDUCTOR_APP_URL = "https://app.conductross.com";
+export const CONDUCTOR_SUPPORT_DISCUSSIONS_URL = "https://github.com/charannyk06/conductor-oss/discussions";
+export const CONDUCTOR_ISSUES_URL = "https://github.com/charannyk06/conductor-oss/issues";
+
+export function getRemoteAccessSupportMessage(code: string | null | undefined): string | null {
+  if (code !== "unavailable") {
+    return null;
+  }
+
+  return "If you opened a raw forwarded dashboard URL from another machine, that is expected. Plain port forwarding still counts as remote access. Use the hosted paired-device flow at app.conductross.com, or put your self-hosted dashboard behind Cloudflare Access or Clerk.";
+}


### PR DESCRIPTION
## User-Facing Release Notes
- Broken community links on the sign-in and unlock screens now route to live GitHub Discussions instead of a dead Discord invite.
- The unlock flow now tells remote users to use app.conductross.com or protect a self-hosted dashboard with Clerk or Cloudflare Access instead of raw port forwarding.
- README and CLI docs now explain why plain forwarded dashboard ports are blocked for remote access.

## Type of Change
- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [x] Documentation Update
- [ ] Refactor / Chore

## Testing
- bun run --cwd packages/web test -- supportLinks.test.ts
- bun run --cwd packages/web typecheck
- bun run typecheck


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README files with clarification on remote access behavior: plainly forwarded local dashboard ports are intentionally blocked.

* **New Features**
  * Added guidance on authentication and sign-in pages for users accessing from remote VMs.
  * Transitioned support channel from Discord community to dedicated support discussions page.
  * Enhanced remote access support messaging to help users resolve authentication issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->