### PR TITLE
fix: restore public signup access

### DIFF
--- a/packages/web/src/app/sign-up/[[...sign-up]]/SignUpExperience.tsx
+++ b/packages/web/src/app/sign-up/[[...sign-up]]/SignUpExperience.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { SignUp } from "@clerk/nextjs";
+
+type SignUpExperienceProps = {
+  redirectTarget: string;
+};
+
+const SIGN_UP_APPEARANCE = {
+  variables: {
+    colorPrimary: "#d4d4d8",
+    colorBackground: "transparent",
+    colorInputBackground: "#18181b",
+    colorInputText: "#fafafa",
+    colorText: "#fafafa",
+    colorTextSecondary: "#a1a1aa",
+    colorNeutral: "#3f3f46",
+    colorDanger: "#d25151",
+    fontFamily: "var(--font-sans), system-ui, sans-serif",
+    borderRadius: "0.375rem",
+  },
+  layout: {
+    socialButtonsVariant: "blockButton",
+    socialButtonsPlacement: "top",
+  },
+  elements: {
+    rootBox: "w-full",
+    cardBox: "w-full",
+    card: "w-full border-0 bg-transparent p-0 shadow-none",
+    main: "gap-5",
+    header: "hidden",
+    headerTitle: "hidden",
+    headerSubtitle: "hidden",
+    formFieldInput:
+      "min-h-12 rounded-[var(--radius-md)] border border-[var(--border-soft)] bg-[var(--bg-shell)] px-4 text-[var(--text-strong)] shadow-none placeholder:text-[var(--text-faint)]",
+    formButtonPrimary:
+      "min-h-11 rounded-[var(--radius-md)] border border-[var(--border-soft)] bg-[var(--bg-muted)] text-[var(--text-strong)] shadow-none transition hover:bg-[var(--bg-panel-2)]",
+    socialButtonsBlockButton:
+      "min-h-12 rounded-[var(--radius-md)] border border-[var(--border-soft)] bg-white text-[#111111] shadow-none transition hover:bg-[#f4f4f5]",
+    socialButtonsBlockButtonText: "font-semibold text-[#111111]",
+    dividerText: "text-[11px] uppercase tracking-[0.24em] text-[var(--text-muted)]",
+    dividerLine: "bg-[var(--border-soft)]",
+    footerActionText: "text-[13px] text-[var(--text-muted)]",
+    footerActionLink: "font-semibold text-[var(--text-strong)] transition hover:text-[var(--accent-hover)]",
+    identityPreviewText: "text-[var(--text-strong)]",
+    identityPreviewEditButton: "text-[var(--text-muted)] transition hover:text-[var(--text-strong)]",
+    formFieldSuccessText: "text-emerald-400",
+    formFieldErrorText: "text-rose-400",
+    alertText: "text-rose-300",
+  },
+} as const;
+
+export function SignUpExperience({ redirectTarget }: SignUpExperienceProps) {
+  return (
+    <div className="conductor-auth-form">
+      <SignUp
+        routing="path"
+        path="/sign-up"
+        appearance={SIGN_UP_APPEARANCE}
+        oauthFlow="auto"
+        forceRedirectUrl={redirectTarget}
+        fallbackRedirectUrl={redirectTarget}
+        signInForceRedirectUrl={redirectTarget}
+        signInFallbackRedirectUrl={redirectTarget}
+      />
+    </div>
+  );
+}

--- a/packages/web/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/packages/web/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,0 +1,184 @@
+import { headers } from "next/headers";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { Check, HardDrive, LifeBuoy, ShieldCheck, Workflow } from "lucide-react";
+import { SignUpExperience } from "./SignUpExperience";
+import { PublicPageShell, PublicPanel, PublicSection } from "@/components/public/PublicPageShell";
+import { Button } from "@/components/ui/Button";
+import {
+  getDefaultPostSignInRedirectTarget,
+  getDashboardAccess,
+  requiresPairedDeviceScope,
+  resolvePostSignInRedirectTarget,
+} from "@/lib/auth";
+import {
+  type ClerkConfigurationReason,
+  resolveClerkConfiguration,
+  resolveRequestBaseUrl,
+  resolveRequestHostname,
+} from "@/lib/clerkConfig";
+import { CONDUCTOR_SUPPORT_DISCUSSIONS_URL } from "@/lib/supportLinks";
+
+const LOCAL_RUNTIME_POINTS = [
+  "Repositories remain on the paired laptop.",
+  "Agent credentials remain on the paired laptop.",
+  "Terminal output streams from the local native PTY runtime.",
+] as const;
+
+const OPERATOR_POINTS = [
+  "Create your dashboard account.",
+  "Pick the paired machine you trust.",
+  "Launch and review work without moving the runtime.",
+] as const;
+
+type SignUpPageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+function firstQueryValue(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) {
+    return value[0]?.trim() || null;
+  }
+  return value?.trim() || null;
+}
+
+function SignUpUnavailable({ reason = null }: { reason?: ClerkConfigurationReason | null }) {
+  return (
+    <div className="rounded-[var(--radius-md)] border border-[var(--status-error)]/30 bg-[color:color-mix(in_srgb,var(--status-error)_10%,transparent)] p-5 text-left">
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[var(--text-muted)]">Sign Up Unavailable</p>
+      <h2 className="mt-3 text-xl font-semibold text-[var(--text-strong)]">
+        {reason === "production-origin-mismatch" ? "This preview deployment cannot use the production Clerk instance." : "Authentication is not configured."}
+      </h2>
+      {reason === "production-origin-mismatch" ? (
+        <p className="mt-3 text-sm leading-6 text-[var(--text-muted)]">
+          Clerk only allows production keys on <code className="rounded bg-[var(--bg-shell)] px-1.5 py-0.5 text-[13px] text-[var(--text-strong)]">conductross.com</code> and its
+          subdomains. Use the Clerk development instance for the Vercel preview environment, or move
+          previews onto a <code className="rounded bg-[var(--bg-shell)] px-1.5 py-0.5 text-[13px] text-[var(--text-strong)]">*.conductross.com</code> hostname, then redeploy.
+        </p>
+      ) : (
+        <p className="mt-3 text-sm leading-6 text-[var(--text-muted)]">
+          Add{" "}
+          <code className="rounded bg-[var(--bg-shell)] px-1.5 py-0.5 text-[13px] text-[var(--text-strong)]">
+            NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+          </code>{" "}
+          to render the Clerk sign-up surface. Add{" "}
+          <code className="rounded bg-[var(--bg-shell)] px-1.5 py-0.5 text-[13px] text-[var(--text-strong)]">
+            CLERK_SECRET_KEY
+          </code>{" "}
+          for server-side session checks after sign-up.
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default async function SignUpPage({ searchParams }: SignUpPageProps) {
+  const resolvedSearchParams = searchParams ? await searchParams : {};
+  const headerStore = await headers();
+  const hostname = resolveRequestHostname(headerStore);
+  const baseUrl = resolveRequestBaseUrl(headerStore);
+  const access = await getDashboardAccess();
+  const defaultRedirectTarget = getDefaultPostSignInRedirectTarget(requiresPairedDeviceScope(access));
+  const redirectTarget = resolvePostSignInRedirectTarget(
+    firstQueryValue(resolvedSearchParams.redirect_url),
+    baseUrl,
+    defaultRedirectTarget,
+  );
+
+  if (access.ok && access.authenticated) {
+    redirect(redirectTarget);
+  }
+
+  const clerkConfiguration = resolveClerkConfiguration(hostname, baseUrl);
+
+  return (
+    <PublicPageShell>
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_400px] lg:items-start">
+        <PublicSection
+          eyebrow="Local-First Access"
+          title="Create the account that unlocks your paired runtime."
+          description="Conductor keeps repositories, terminals, and agent credentials on the paired machine while the dashboard handles launch, review, and session control."
+          className="max-w-2xl"
+        >
+          <div className="flex items-center gap-2 text-sm text-[var(--text-normal)]">
+            <ShieldCheck className="h-4 w-4 text-[var(--status-ready)]" />
+            Production auth with paired-device execution
+          </div>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Button asChild variant="primary" size="lg">
+              <Link href="https://conductross.com">Read the product story</Link>
+            </Button>
+            <Button asChild variant="outline" size="lg">
+              <a href={CONDUCTOR_SUPPORT_DISCUSSIONS_URL} target="_blank" rel="noopener noreferrer">
+                <LifeBuoy className="mr-2 h-4 w-4" />
+                Open support
+              </a>
+            </Button>
+          </div>
+        </PublicSection>
+
+        <PublicPanel className="p-6 sm:p-7">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[var(--text-muted)]">Sign up</p>
+          <h2 className="mt-3 text-2xl font-semibold text-[var(--text-strong)]">Create your paired-runtime account</h2>
+          <p className="mt-3 text-sm leading-6 text-[var(--text-muted)]">
+            Create the dashboard account you will use to reach your paired machine. After sign-up, Clerk returns you
+            to the dashboard or active bridge claim flow inside the same local workflow. If you are coming from a
+            remote VM, use the hosted paired-device flow here or put your self-hosted dashboard behind Clerk or
+            Cloudflare Access. Plain forwarded local dashboard ports are intentionally blocked.
+          </p>
+
+          <div className="mt-6">
+            {clerkConfiguration.enabled && clerkConfiguration.publishableKey ? (
+              <SignUpExperience redirectTarget={redirectTarget} />
+            ) : (
+              <SignUpUnavailable reason={clerkConfiguration.reason} />
+            )}
+          </div>
+        </PublicPanel>
+      </div>
+
+      <div className="mt-10 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        <PublicPanel className="p-5">
+          <div className="flex items-center gap-2 text-[var(--text-normal)]">
+            <HardDrive className="h-4 w-4 text-[var(--status-ready)]" />
+            <p className="text-sm font-semibold">What stays local</p>
+          </div>
+          <ul className="mt-4 space-y-3 text-sm leading-6 text-[var(--text-muted)]">
+            {LOCAL_RUNTIME_POINTS.map((item) => (
+              <li key={item} className="flex items-start gap-2">
+                <Check className="mt-1 h-3.5 w-3.5 shrink-0 text-[var(--status-ready)]" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </PublicPanel>
+
+        <PublicPanel className="p-5">
+          <div className="flex items-center gap-2 text-[var(--text-normal)]">
+            <Workflow className="h-4 w-4 text-[var(--status-working)]" />
+            <p className="text-sm font-semibold">How it works</p>
+          </div>
+          <ul className="mt-4 space-y-3 text-sm leading-6 text-[var(--text-muted)]">
+            {OPERATOR_POINTS.map((item) => (
+              <li key={item} className="flex items-start gap-2">
+                <Check className="mt-1 h-3.5 w-3.5 shrink-0 text-[var(--status-working)]" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </PublicPanel>
+
+        <PublicPanel className="p-5 md:col-span-2 xl:col-span-1">
+          <div className="flex items-center gap-2 text-[var(--text-normal)]">
+            <ShieldCheck className="h-4 w-4 text-[var(--status-ready)]" />
+            <p className="text-sm font-semibold">What Conductor does not do</p>
+          </div>
+          <p className="mt-4 text-sm leading-6 text-[var(--text-muted)]">
+            No cloud repo clone. No hosted shell. No credential proxy. Conductor orchestrates the machine you
+            pair and leaves the runtime where it already lives.
+          </p>
+        </PublicPanel>
+      </div>
+    </PublicPageShell>
+  );
+}

--- a/packages/web/src/lib/auth.test.ts
+++ b/packages/web/src/lib/auth.test.ts
@@ -196,9 +196,11 @@ test("resolvePostSignInRedirectTarget preserves bridge device redirects", () => 
   );
 });
 
-test("resolvePostSignInRedirectTarget avoids sending users back into sign-in", () => {
+test("resolvePostSignInRedirectTarget avoids sending users back into auth screens", () => {
   assert.equal(resolvePostSignInRedirectTarget("/sign-in"), "/");
   assert.equal(resolvePostSignInRedirectTarget("/sign-in/sso-callback"), "/");
+  assert.equal(resolvePostSignInRedirectTarget("/sign-up"), "/");
+  assert.equal(resolvePostSignInRedirectTarget("/sign-up/verify-email-address"), "/");
   assert.equal(resolvePostSignInRedirectTarget("https://evil.example.com"), "/");
 });
 

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -511,7 +511,7 @@ async function resolveClerkAccess(
       };
     }
 
-    const requireApproval = (process.env.CONDUCTOR_REQUIRE_APPROVAL ?? "true") === "true";
+    const requireApproval = (process.env.CONDUCTOR_REQUIRE_APPROVAL ?? "false").trim().toLowerCase() === "true";
     const adminEmails = legacyRoleEnvFallback().adminEmails;
     if (requireApproval && !adminEmails.includes(normalizedEmail) && !isApproved(user)) {
       return {

--- a/packages/web/src/lib/authRedirect.ts
+++ b/packages/web/src/lib/authRedirect.ts
@@ -3,15 +3,21 @@ import { sanitizeRedirectTarget } from "@/lib/redirectTarget";
 const DEFAULT_POST_SIGN_IN_REDIRECT = "/";
 const DEFAULT_PAIRED_DEVICE_POST_SIGN_IN_REDIRECT = "/bridge/connect";
 
-function normalizeDefaultRedirectTarget(candidate?: string | null): string {
-  const nextPath = sanitizeRedirectTarget(candidate ?? DEFAULT_POST_SIGN_IN_REDIRECT);
-
-  if (
-    nextPath === "/sign-in"
+function isAuthSurfacePath(nextPath: string): boolean {
+  return nextPath === "/sign-in"
     || nextPath === "/sign-in/"
     || nextPath.startsWith("/sign-in?")
     || nextPath.startsWith("/sign-in/")
-  ) {
+    || nextPath === "/sign-up"
+    || nextPath === "/sign-up/"
+    || nextPath.startsWith("/sign-up?")
+    || nextPath.startsWith("/sign-up/");
+}
+
+function normalizeDefaultRedirectTarget(candidate?: string | null): string {
+  const nextPath = sanitizeRedirectTarget(candidate ?? DEFAULT_POST_SIGN_IN_REDIRECT);
+
+  if (isAuthSurfacePath(nextPath)) {
     return DEFAULT_POST_SIGN_IN_REDIRECT;
   }
 
@@ -65,12 +71,7 @@ export function resolvePostSignInRedirectTarget(
   const resolvedDefaultRedirectTarget = normalizeDefaultRedirectTarget(defaultRedirectTarget);
   const nextPath = resolveRelativeRedirectTarget(candidate, requestBaseUrl, resolvedDefaultRedirectTarget);
 
-  if (
-    nextPath === "/sign-in"
-    || nextPath === "/sign-in/"
-    || nextPath.startsWith("/sign-in?")
-    || nextPath.startsWith("/sign-in/")
-  ) {
+  if (isAuthSurfacePath(nextPath)) {
     return resolvedDefaultRedirectTarget;
   }
 


### PR DESCRIPTION
## Summary

Restore the public hosted sign-up surface, keep auth redirects out of `/sign-in` and `/sign-up`, and stop requiring manual approval unless `CONDUCTOR_REQUIRE_APPROVAL=true` is explicitly configured.

## User-Facing Release Notes

- New users can create a Conductor dashboard account at `/sign-up` instead of landing on a 404 page.
- Hosted auth now returns users to the dashboard or bridge pairing flow instead of bouncing them back into auth screens.
- Public dashboard deployments no longer require manual approval unless the approval flag is explicitly turned on.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Testing

- `bun run --cwd packages/web test src/lib/auth.test.ts`
- `bun run --cwd packages/web typecheck`
- `bun run --cwd packages/web build`
- `bun run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a sign-up page with customizable redirect targets, styling configuration, and fallback messaging when services are unavailable.

* **Improvements**
  * Extended authentication redirect logic to properly handle both sign-in and sign-up paths, preventing unintended redirect loops.
  * Modified default approval requirement setting from enabled to disabled, allowing immediate access without manual review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->