### PR TITLE
fix: repair dispatcher Letta support and chat feed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2258,9 +2258,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/crates/conductor-executors/src/agents/gemini.rs
+++ b/crates/conductor-executors/src/agents/gemini.rs
@@ -8,7 +8,7 @@ use tokio::process::Command;
 
 use super::discover_binary;
 use crate::executor::{wrap_parsed_output, Executor, ExecutorHandle, ExecutorOutput, SpawnOptions};
-use crate::process::spawn_process;
+use crate::process::{spawn_process, spawn_process_no_stdin};
 
 /// Gemini CLI executor.
 #[derive(Clone)]
@@ -55,7 +55,11 @@ impl Executor for GeminiExecutor {
 
     async fn spawn(&self, options: SpawnOptions) -> Result<ExecutorHandle> {
         let args = self.build_args(&options);
-        let handle = spawn_process(&self.binary, &args, &options.cwd, &options.env).await?;
+        let handle = if options.interactive {
+            spawn_process(&self.binary, &args, &options.cwd, &options.env).await?
+        } else {
+            spawn_process_no_stdin(&self.binary, &args, &options.cwd, &options.env).await?
+        };
         let output_rx = wrap_parsed_output(self.clone(), handle.output_rx);
 
         Ok(ExecutorHandle::new(

--- a/crates/conductor-executors/src/agents/letta.rs
+++ b/crates/conductor-executors/src/agents/letta.rs
@@ -91,6 +91,11 @@ impl Executor for LettaExecutor {
                 args.push(model.to_string());
             }
 
+            if options.skip_permissions {
+                args.push("--permission-mode".to_string());
+                args.push("bypassPermissions".to_string());
+            }
+
             if let Some(id) = options
                 .resume_target
                 .as_deref()
@@ -117,6 +122,11 @@ impl Executor for LettaExecutor {
             args.push(model.to_string());
         }
 
+        if options.skip_permissions {
+            args.push("--permission-mode".to_string());
+            args.push("bypassPermissions".to_string());
+        }
+
         args.push("-p".to_string());
         args.push(options.prompt.clone());
 
@@ -137,11 +147,27 @@ impl Executor for LettaExecutor {
     fn parse_output(&self, line: &str) -> ExecutorOutput {
         let trimmed = line.trim();
         if trimmed.is_empty() {
-            ExecutorOutput::Stdout(String::new())
-        } else {
-            ExecutorOutput::Stdout(trimmed.to_string())
+            return ExecutorOutput::Stdout(String::new());
         }
+
+        if is_letta_auth_prompt(trimmed) {
+            return ExecutorOutput::NeedsInput(
+                "Letta login required. Run `letta` or `letta connect` in a terminal, then retry the session."
+                    .to_string(),
+            );
+        }
+
+        ExecutorOutput::Stdout(trimmed.to_string())
     }
+}
+
+fn is_letta_auth_prompt(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    lower.contains("missing letta_api_key")
+        || lower.contains("letta cloud oauth")
+        || lower.contains("authenticate")
+        || lower.contains("run 'letta' in interactive mode")
+        || lower.contains("run `letta` in interactive mode")
 }
 
 #[cfg(test)]
@@ -175,6 +201,47 @@ mod tests {
         assert!(args.contains(&"sonnet".to_string()));
         assert!(args.contains(&"--conversation".to_string()));
         assert!(args.contains(&"conv-1".to_string()));
+    }
+
+    #[test]
+    fn auth_prompt_is_reported_as_needs_input() {
+        let executor = LettaExecutor::new(PathBuf::from("/usr/bin/letta"));
+        match executor.parse_output("Missing LETTA_API_KEY") {
+            ExecutorOutput::NeedsInput(message) => {
+                assert!(message.contains("Letta login required"));
+            }
+            other => panic!("expected NeedsInput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn permission_bypass_maps_to_letta_permission_mode() {
+        let executor = LettaExecutor::new(PathBuf::from("/usr/bin/letta"));
+        let mut options = SpawnOptions {
+            cwd: PathBuf::from("."),
+            prompt: "Ship the feature".to_string(),
+            model: None,
+            reasoning_effort: None,
+            skip_permissions: true,
+            extra_args: Vec::new(),
+            env: HashMap::new(),
+            branch: None,
+            timeout: None,
+            interactive: false,
+            structured_output: false,
+            resume_target: None,
+        };
+
+        let headless_args = executor.build_args(&options);
+        assert!(headless_args
+            .windows(2)
+            .any(|w| w[0] == "--permission-mode" && w[1] == "bypassPermissions"));
+
+        options.interactive = true;
+        let interactive_args = executor.build_args(&options);
+        assert!(interactive_args
+            .windows(2)
+            .any(|w| w[0] == "--permission-mode" && w[1] == "bypassPermissions"));
     }
 
     #[test]

--- a/crates/conductor-server/src/routes/dispatcher.rs
+++ b/crates/conductor-server/src/routes/dispatcher.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::{self as stream, StreamExt};
+use url::form_urlencoded;
 
 use crate::dispatcher_task_lifecycle::{
     create_dispatcher_task, handoff_dispatcher_task, update_dispatcher_task,
@@ -118,16 +119,18 @@ fn error(status: StatusCode, message: impl Into<String>) -> ApiResponse {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct DispatcherQuery {
+    #[serde(alias = "bridge_id")]
     bridge_id: Option<String>,
+    #[serde(alias = "thread_id")]
     thread_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 struct FeedQuery {
     limit: Option<usize>,
-    #[serde(rename = "bridgeId")]
+    #[serde(rename = "bridgeId", alias = "bridge_id")]
     bridge_id: Option<String>,
-    #[serde(rename = "threadId")]
+    #[serde(rename = "threadId", alias = "thread_id")]
     thread_id: Option<String>,
 }
 
@@ -263,6 +266,15 @@ fn binding_query_lookup(query: &DispatcherBindingQuery) -> DispatcherBindingLook
     }
 }
 
+fn dispatcher_thread_query(thread_id: &str, bridge_id: Option<&str>) -> String {
+    let mut serializer = form_urlencoded::Serializer::new(String::new());
+    serializer.append_pair("threadId", thread_id);
+    if let Some(bridge_id) = bridge_id {
+        serializer.append_pair("bridgeId", bridge_id);
+    }
+    serializer.finish()
+}
+
 async fn serialize_dispatcher_binding(
     state: &Arc<AppState>,
     project_id: &str,
@@ -275,14 +287,10 @@ async fn serialize_dispatcher_binding(
         },
         None => Value::Null,
     };
-    let dispatcher_query = binding.dispatcher_thread_id.as_deref().map(|thread_id| {
-        let mut query = format!("threadId={thread_id}");
-        if let Some(bridge_id) = binding.bridge_id.as_deref() {
-            query.push_str("&bridgeId=");
-            query.push_str(bridge_id);
-        }
-        query
-    });
+    let dispatcher_query = binding
+        .dispatcher_thread_id
+        .as_deref()
+        .map(|thread_id| dispatcher_thread_query(thread_id, binding.bridge_id.as_deref()));
     let base_path = format!("/api/projects/{project_id}/dispatcher");
     let tasks_endpoint = dispatcher_query
         .as_ref()
@@ -1295,6 +1303,26 @@ mod tests {
         assert_eq!(trimmed_query_value(None), None);
         assert_eq!(trimmed_query_value(Some("   ")), None);
         assert_eq!(trimmed_query_value(Some(" thread-1 ")), Some("thread-1"));
+    }
+
+    #[test]
+    fn dispatcher_query_accepts_frontend_camel_case_scope() {
+        let query: super::DispatcherQuery = serde_json::from_value(serde_json::json!({
+            "threadId": "dispatcher-1",
+            "bridgeId": "bridge-1"
+        }))
+        .expect("camelCase dispatcher query should deserialize");
+
+        assert_eq!(query.thread_id.as_deref(), Some("dispatcher-1"));
+        assert_eq!(query.bridge_id.as_deref(), Some("bridge-1"));
+    }
+
+    #[test]
+    fn dispatcher_thread_query_url_encodes_scope() {
+        assert_eq!(
+            super::dispatcher_thread_query("thread/1", Some("bridge id")),
+            "threadId=thread%2F1&bridgeId=bridge+id"
+        );
     }
 
     #[test]

--- a/crates/conductor-server/src/state/acp_dispatcher.rs
+++ b/crates/conductor-server/src/state/acp_dispatcher.rs
@@ -270,7 +270,7 @@ impl DispatcherTurnRequest {
     }
 }
 
-const DISPATCHER_IMPLEMENTATION_AGENT_OPTIONS: [DispatcherSelectOption; 4] = [
+const DISPATCHER_IMPLEMENTATION_AGENT_OPTIONS: [DispatcherSelectOption; 6] = [
     DispatcherSelectOption {
         value: "codex",
         name: "Codex",
@@ -287,15 +287,26 @@ const DISPATCHER_IMPLEMENTATION_AGENT_OPTIONS: [DispatcherSelectOption; 4] = [
         description: "Route implementation work to Gemini sessions.",
     },
     DispatcherSelectOption {
+        value: "cursor-cli",
+        name: "Cursor CLI",
+        description: "Route implementation work to Cursor CLI sessions.",
+    },
+    DispatcherSelectOption {
         value: "openclaw",
         name: "OpenClaw",
         description: "Route work through an OpenClaw gateway-backed runtime.",
+    },
+    DispatcherSelectOption {
+        value: "letta",
+        name: "Letta Code",
+        description: "Route implementation work to Letta Code sessions.",
     },
 ];
 
 const DISPATCHER_OPENCLAW_MODEL_OPTIONS: [DispatcherSelectOption; 0] = [];
 const DISPATCHER_OPENCLAW_REASONING_OPTIONS: [DispatcherSelectOption; 0] = [];
 const DISPATCHER_CURSOR_MODEL_OPTIONS: [DispatcherSelectOption; 0] = [];
+const DISPATCHER_LETTA_MODEL_OPTIONS: [DispatcherSelectOption; 0] = [];
 
 const DISPATCHER_CODEX_MODEL_OPTIONS: [DispatcherSelectOption; 8] = [
     DispatcherSelectOption {
@@ -1370,6 +1381,29 @@ fn normalize_loaded_dispatcher_thread(
     changed
 }
 
+fn canonical_dispatcher_agent(value: &str) -> Option<String> {
+    match AgentKind::parse(value) {
+        AgentKind::Codex
+        | AgentKind::ClaudeCode
+        | AgentKind::Gemini
+        | AgentKind::OpenClaw
+        | AgentKind::Letta => Some(AgentKind::parse(value).to_string()),
+        _ => None,
+    }
+}
+
+fn canonical_implementation_agent(value: &str) -> Option<String> {
+    match AgentKind::parse(value) {
+        AgentKind::Codex
+        | AgentKind::ClaudeCode
+        | AgentKind::Gemini
+        | AgentKind::OpenClaw
+        | AgentKind::CursorCli
+        | AgentKind::Letta => Some(AgentKind::parse(value).to_string()),
+        _ => None,
+    }
+}
+
 fn default_implementation_agent(
     requested_agent: Option<&str>,
     project: &ProjectConfig,
@@ -1378,18 +1412,21 @@ fn default_implementation_agent(
     let candidate = requested_agent
         .or(project.agent.as_deref())
         .unwrap_or(default_agent);
-    match candidate.trim() {
-        "codex" | "claude-code" | "gemini" | "openclaw" | "cursor-cli" => {
-            candidate.trim().to_string()
-        }
-        _ => "codex".to_string(),
-    }
+    canonical_implementation_agent(candidate).unwrap_or_else(|| "codex".to_string())
 }
 
 fn normalize_optional_string(value: Option<String>) -> Option<String> {
     value
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
+}
+
+fn normalize_dispatcher_agent(value: Option<String>) -> Option<String> {
+    normalize_optional_string(value).and_then(|value| canonical_dispatcher_agent(&value))
+}
+
+fn normalize_implementation_agent(value: Option<String>) -> Option<String> {
+    normalize_optional_string(value).and_then(|value| canonical_implementation_agent(&value))
 }
 
 pub(crate) fn dispatcher_implementation_agent_options() -> &'static [DispatcherSelectOption] {
@@ -1399,11 +1436,15 @@ pub(crate) fn dispatcher_implementation_agent_options() -> &'static [DispatcherS
 pub(crate) fn dispatcher_implementation_model_options(
     agent: &str,
 ) -> &'static [DispatcherSelectOption] {
-    match agent.trim() {
+    match canonical_implementation_agent(agent)
+        .unwrap_or_else(|| "codex".to_string())
+        .as_str()
+    {
         "claude-code" => &DISPATCHER_CLAUDE_MODEL_OPTIONS,
         "gemini" => &DISPATCHER_GEMINI_MODEL_OPTIONS,
         "openclaw" => &DISPATCHER_OPENCLAW_MODEL_OPTIONS,
         "cursor-cli" => &DISPATCHER_CURSOR_MODEL_OPTIONS,
+        "letta" => &DISPATCHER_LETTA_MODEL_OPTIONS,
         _ => &DISPATCHER_CODEX_MODEL_OPTIONS,
     }
 }
@@ -1411,9 +1452,13 @@ pub(crate) fn dispatcher_implementation_model_options(
 pub(crate) fn dispatcher_implementation_reasoning_options(
     agent: &str,
 ) -> &'static [DispatcherSelectOption] {
-    match agent.trim() {
+    match canonical_implementation_agent(agent)
+        .unwrap_or_else(|| "codex".to_string())
+        .as_str()
+    {
         "gemini" => &[],
         "openclaw" => &DISPATCHER_OPENCLAW_REASONING_OPTIONS,
+        "letta" => &[],
         "claude-code" => &DISPATCHER_DEFAULT_REASONING_OPTIONS,
         _ => &DISPATCHER_CODEX_REASONING_OPTIONS,
     }
@@ -1428,11 +1473,14 @@ pub(crate) fn dispatcher_default_implementation_model(agent: &str) -> Option<&'s
 pub(crate) fn dispatcher_default_implementation_reasoning_effort(
     agent: &str,
 ) -> Option<&'static str> {
-    match agent.trim() {
+    match canonical_implementation_agent(agent)
+        .unwrap_or_else(|| "codex".to_string())
+        .as_str()
+    {
         "claude-code" => Some("medium"),
         "codex" => Some("high"),
         "cursor-cli" => Some("medium"),
-        "openclaw" => None,
+        "openclaw" | "letta" => None,
         _ => None,
     }
 }
@@ -1588,7 +1636,10 @@ fn dispatcher_model_supported_for_agent(agent: &str, model: &str) -> bool {
     }
 
     let normalized = trimmed.to_ascii_lowercase();
-    match agent.trim() {
+    match canonical_implementation_agent(agent)
+        .unwrap_or_else(|| "codex".to_string())
+        .as_str()
+    {
         "claude-code" => {
             matches!(normalized.as_str(), "opus" | "sonnet" | "haiku")
                 || normalized.starts_with("claude-")
@@ -1597,6 +1648,10 @@ fn dispatcher_model_supported_for_agent(agent: &str, model: &str) -> bool {
         "cursor-cli" => {
             // Cursor model IDs are runtime-discovered (e.g. auto, gpt-5.4-medium,
             // claude-4.6-opus-max-thinking) and not statically enumerated here.
+            true
+        }
+        "letta" => {
+            // Letta Code accepts provider-specific model IDs through --model.
             true
         }
         _ => {
@@ -1614,7 +1669,7 @@ fn dispatcher_reasoning_supported_for_agent(
     model: Option<&str>,
     reasoning_effort: &str,
 ) -> bool {
-    if agent.trim() == "codex" {
+    if canonical_implementation_agent(agent).as_deref() == Some("codex") {
         if let Some(model) = model.map(str::trim).filter(|value| !value.is_empty()) {
             if let Some(supported) = codex_runtime_reasoning_supported(model, reasoning_effort) {
                 return supported;
@@ -1688,12 +1743,7 @@ fn apply_dispatcher_implementation_preferences(
     let previous_agent = dispatcher_preferred_implementation_agent(thread);
     let next_agent = implementation_agent
         .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(|value| match value {
-            "codex" | "claude-code" | "gemini" | "openclaw" | "cursor-cli" => value.to_string(),
-            _ => "codex".to_string(),
-        })
+        .and_then(canonical_implementation_agent)
         .unwrap_or_else(|| previous_agent.clone());
     let agent_changed = next_agent != previous_agent
         || thread
@@ -2558,11 +2608,12 @@ impl AppState {
             .cloned()
             .with_context(|| format!("Unknown project: {project_id}"))?;
         let default_agent =
-            normalize_optional_string(Some(config.preferences.coding_agent.clone()))
+            normalize_implementation_agent(Some(config.preferences.coding_agent.clone()))
                 .unwrap_or_else(|| "codex".to_string());
-        let agent = normalize_optional_string(dispatcher_agent)
-            .or_else(|| normalize_optional_string(project.agent.clone()))
-            .unwrap_or_else(|| default_agent.clone());
+        let agent = normalize_dispatcher_agent(dispatcher_agent)
+            .or_else(|| normalize_dispatcher_agent(project.agent.clone()))
+            .or_else(|| canonical_dispatcher_agent(&default_agent))
+            .unwrap_or_else(|| "codex".to_string());
         if !force_new {
             if let Some(existing) = self
                 .latest_project_dispatcher_thread(
@@ -2648,7 +2699,7 @@ impl AppState {
             ACP_APPROVAL_STATE_METADATA_KEY.to_string(),
             ACP_APPROVAL_GRANTED.to_string(),
         );
-        let selected_implementation_agent = normalize_optional_string(implementation_agent)
+        let selected_implementation_agent = normalize_implementation_agent(implementation_agent)
             .unwrap_or_else(|| {
                 default_implementation_agent(Some(agent.as_str()), &project, &default_agent)
             });
@@ -2727,21 +2778,19 @@ impl AppState {
             openclaw_config,
         } = patch;
 
-        let current_dispatcher_agent = thread.agent.trim().to_ascii_lowercase();
-        let target_dispatcher_agent = dispatcher_agent
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(|value| value.to_ascii_lowercase())
-            .unwrap_or_else(|| current_dispatcher_agent.clone());
-        if !matches!(
-            target_dispatcher_agent.as_str(),
-            "codex" | "claude-code" | "gemini" | "openclaw"
-        ) {
-            return Err(anyhow!(
-                "Unsupported dispatcher agent `{target_dispatcher_agent}`. Expected codex, claude-code, gemini, or openclaw"
-            ));
-        }
+        let current_dispatcher_agent = canonical_dispatcher_agent(&thread.agent)
+            .unwrap_or_else(|| thread.agent.trim().to_ascii_lowercase());
+        let requested_dispatcher_agent = normalize_optional_string(dispatcher_agent.clone())
+            .map(|value| {
+                canonical_dispatcher_agent(&value).ok_or_else(|| {
+                    anyhow!(
+                        "Unsupported dispatcher agent `{value}`. Expected codex, claude-code, gemini, openclaw, or letta"
+                    )
+                })
+            })
+            .transpose()?;
+        let target_dispatcher_agent =
+            requested_dispatcher_agent.unwrap_or_else(|| current_dispatcher_agent.clone());
 
         let requested_dispatcher_model = dispatcher_model
             .as_deref()
@@ -2789,20 +2838,19 @@ impl AppState {
             })
         });
 
-        let target_implementation_agent = implementation_agent
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(str::to_string)
-            .unwrap_or_else(|| dispatcher_preferred_implementation_agent(&thread));
-        if !matches!(
-            target_implementation_agent.as_str(),
-            "codex" | "claude-code" | "gemini" | "openclaw" | "cursor-cli"
-        ) {
-            return Err(anyhow!(
-                "Unsupported implementation agent `{target_implementation_agent}`. Expected codex, claude-code, gemini, openclaw, or cursor-cli"
-            ));
-        }
+        let requested_implementation_agent = normalize_optional_string(implementation_agent.clone())
+            .map(|value| {
+                canonical_implementation_agent(&value).ok_or_else(|| {
+                    anyhow!(
+                        "Unsupported implementation agent `{value}`. Expected codex, claude-code, gemini, openclaw, cursor-cli, or letta"
+                    )
+                })
+            })
+            .transpose()?;
+        let target_implementation_agent = requested_implementation_agent.unwrap_or_else(|| {
+            canonical_implementation_agent(&dispatcher_preferred_implementation_agent(&thread))
+                .unwrap_or_else(|| "codex".to_string())
+        });
         let target_implementation_model = resolve_dispatcher_implementation_model(
             &thread,
             &target_implementation_agent,
@@ -3067,6 +3115,9 @@ impl AppState {
                     "codex".to_string(),
                     "claude-code".to_string(),
                     "gemini".to_string(),
+                    "cursor-cli".to_string(),
+                    "openclaw".to_string(),
+                    "letta".to_string(),
                 ],
                 durable_notes: Vec::new(),
                 recent_task_refs: Vec::new(),
@@ -3231,6 +3282,9 @@ impl AppState {
                     "codex".to_string(),
                     "claude-code".to_string(),
                     "gemini".to_string(),
+                    "cursor-cli".to_string(),
+                    "openclaw".to_string(),
+                    "letta".to_string(),
                 ],
                 durable_notes: Vec::new(),
                 recent_task_refs: Vec::new(),
@@ -3511,13 +3565,22 @@ impl AppState {
         };
         let resume_target = dispatcher_resume_target(thread, &executor.kind());
 
-        let prompt = self
+        let runtime_prompt = self
             .dispatcher_prompt_with_context(
                 thread,
                 &merge_dispatcher_prompt_with_user(&thread.prompt, initial_message),
                 attachments,
             )
             .await;
+        let send_initial_prompt_after_runtime_attach = !use_headless_turns
+            && executor.supports_direct_terminal_ui()
+            && !executor.accepts_prompt_on_launch_when_interactive()
+            && !runtime_prompt.trim().is_empty();
+        let launch_prompt = if send_initial_prompt_after_runtime_attach {
+            String::new()
+        } else {
+            runtime_prompt.clone()
+        };
         let handle = executor
             .spawn(SpawnOptions {
                 cwd: PathBuf::from(
@@ -3528,7 +3591,7 @@ impl AppState {
                         .or_else(|| thread.workspace_path.clone())
                         .unwrap_or_else(|| ".".to_string()),
                 ),
-                prompt,
+                prompt: launch_prompt,
                 model,
                 reasoning_effort,
                 skip_permissions: true,
@@ -3574,6 +3637,12 @@ impl AppState {
             runtime_handle.runtime_id.clone(),
             output_rx,
         );
+        if send_initial_prompt_after_runtime_attach {
+            runtime_handle
+                .input_tx
+                .send(ExecutorInput::Text(runtime_prompt))
+                .await?;
+        }
         Ok(())
     }
 
@@ -4161,7 +4230,9 @@ mod tests {
         types::AgentKind,
     };
     use conductor_db::Database;
-    use conductor_executors::executor::{Executor, ExecutorHandle, ExecutorOutput, SpawnOptions};
+    use conductor_executors::executor::{
+        Executor, ExecutorHandle, ExecutorInput, ExecutorOutput, SpawnOptions,
+    };
     use serde_json::json;
     use std::collections::{BTreeMap, HashMap};
     use std::fs;
@@ -4177,6 +4248,76 @@ mod tests {
     struct DelayedHeadlessExecutor {
         assistant_text: String,
         delay: Duration,
+    }
+
+    #[derive(Clone)]
+    struct PromptAfterAttachExecutor {
+        observed_input_tx: mpsc::UnboundedSender<String>,
+    }
+
+    #[async_trait]
+    impl Executor for PromptAfterAttachExecutor {
+        fn kind(&self) -> AgentKind {
+            AgentKind::Letta
+        }
+
+        fn name(&self) -> &str {
+            "PromptAfterAttachExecutor"
+        }
+
+        fn binary_path(&self) -> &Path {
+            Path::new("/tmp/prompt-after-attach-executor")
+        }
+
+        async fn is_available(&self) -> bool {
+            true
+        }
+
+        async fn version(&self) -> Result<String> {
+            Ok("test".to_string())
+        }
+
+        fn supports_direct_terminal_ui(&self) -> bool {
+            true
+        }
+
+        fn accepts_prompt_on_launch_when_interactive(&self) -> bool {
+            false
+        }
+
+        async fn spawn(&self, options: SpawnOptions) -> Result<ExecutorHandle> {
+            assert_eq!(options.prompt, "");
+            assert!(options.interactive);
+            let (output_tx, output_rx) = mpsc::channel(8);
+            let (input_tx, mut input_rx) = mpsc::channel(4);
+            let (kill_tx, _kill_rx) = oneshot::channel();
+            let observed_input_tx = self.observed_input_tx.clone();
+
+            tokio::spawn(async move {
+                if let Some(ExecutorInput::Text(text)) = input_rx.recv().await {
+                    let _ = observed_input_tx.send(text);
+                    let _ = output_tx
+                        .send(ExecutorOutput::Completed { exit_code: 0 })
+                        .await;
+                }
+            });
+
+            Ok(ExecutorHandle::new(
+                4343,
+                AgentKind::Letta,
+                output_rx,
+                input_tx,
+                kill_tx,
+            ))
+        }
+
+        fn build_args(&self, _options: &SpawnOptions) -> Vec<String> {
+            Vec::new()
+        }
+
+        fn parse_output(&self, line: &str) -> ExecutorOutput {
+            ExecutorOutput::Stdout(line.to_string())
+        }
     }
 
     #[async_trait]
@@ -5026,6 +5167,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn interactive_prompt_after_attach_dispatcher_receives_first_turn() {
+        let (root, state) = build_test_state("acp-prompt-after-attach").await;
+        let thread = state
+            .create_project_dispatcher_thread(
+                "demo",
+                CreateDispatcherThreadOptions {
+                    dispatcher_agent: Some("letta".to_string()),
+                    implementation_agent: Some("letta".to_string()),
+                    ..CreateDispatcherThreadOptions::default()
+                },
+            )
+            .await
+            .expect("dispatcher thread should be created");
+        let (observed_input_tx, mut observed_input_rx) = mpsc::unbounded_channel();
+        state.executors.write().await.insert(
+            AgentKind::Letta,
+            Arc::new(PromptAfterAttachExecutor { observed_input_tx }),
+        );
+
+        state
+            .send_to_dispatcher_thread(
+                &thread.id,
+                DispatcherTurnRequest::plain(
+                    "Ship through Letta".to_string(),
+                    Vec::new(),
+                    None,
+                    None,
+                    "chat",
+                ),
+            )
+            .await
+            .expect("dispatcher send should succeed");
+
+        let prompt = timeout(Duration::from_secs(3), observed_input_rx.recv())
+            .await
+            .expect("interactive prompt should be sent after runtime attach")
+            .expect("interactive prompt channel should remain open");
+        assert!(prompt.contains("Ship through Letta"));
+        assert!(prompt.to_ascii_lowercase().contains("letta"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
     async fn runtime_events_refresh_session_memory_artifacts() {
         let (root, state) = build_test_state("acp-runtime-memory-sync").await;
         let thread = state
@@ -5113,6 +5298,28 @@ mod tests {
         assert_eq!(
             updated.metadata.get("reasoningEffort").map(String::as_str),
             Some("high")
+        );
+
+        let updated = state
+            .update_dispatcher_preferences(
+                &thread.id,
+                DispatcherPreferencesPatch {
+                    dispatcher_agent: Some("letta-code".to_string()),
+                    implementation_agent: Some("letta-code".to_string()),
+                    openclaw_config: OpenClawDispatcherConfigPatch::default(),
+                    ..DispatcherPreferencesPatch::default()
+                },
+            )
+            .await
+            .expect("dispatcher preferences should accept letta aliases");
+
+        assert_eq!(updated.agent, "letta");
+        assert_eq!(
+            updated
+                .metadata
+                .get(ACP_IMPLEMENTATION_AGENT_METADATA_KEY)
+                .map(String::as_str),
+            Some("letta")
         );
 
         let _ = fs::remove_dir_all(root);

--- a/crates/conductor-server/src/state/acp_dispatcher.rs
+++ b/crates/conductor-server/src/state/acp_dispatcher.rs
@@ -1484,7 +1484,7 @@ fn home_dir() -> Option<PathBuf> {
 fn dispatcher_uses_headless_turns(agent_kind: &AgentKind) -> bool {
     matches!(
         agent_kind,
-        AgentKind::Codex | AgentKind::QwenCode | AgentKind::OpenClaw
+        AgentKind::Codex | AgentKind::QwenCode | AgentKind::Gemini | AgentKind::OpenClaw
     )
 }
 
@@ -4376,10 +4376,14 @@ mod tests {
     fn dispatcher_runtime_mode_selection_matches_agent_capabilities() {
         assert!(dispatcher_uses_headless_turns(&AgentKind::Codex));
         assert!(dispatcher_uses_headless_turns(&AgentKind::QwenCode));
+        assert!(dispatcher_uses_headless_turns(&AgentKind::Gemini));
         assert!(!dispatcher_uses_headless_turns(&AgentKind::ClaudeCode));
 
         assert!(dispatcher_supports_interactive_structured_output(
             &AgentKind::ClaudeCode
+        ));
+        assert!(dispatcher_supports_interactive_structured_output(
+            &AgentKind::Gemini
         ));
         assert!(dispatcher_supports_interactive_structured_output(
             &AgentKind::GithubCopilot

--- a/packages/web/src/components/dispatcher/DispatcherPreferenceChips.tsx
+++ b/packages/web/src/components/dispatcher/DispatcherPreferenceChips.tsx
@@ -17,7 +17,7 @@ import { getKnownAgent } from "@/lib/knownAgents";
 import type { RuntimeAgentModelCatalog } from "@/lib/runtimeAgentModelsShared";
 import { formatCurrentModelLabel } from "@/lib/sessionModelCatalog";
 
-const DISPATCHER_AGENT_OPTIONS = ["codex", "claude-code", "gemini", "cursor-cli", "openclaw"] as const;
+const DISPATCHER_AGENT_OPTIONS = ["codex", "claude-code", "gemini", "cursor-cli", "openclaw", "letta"] as const;
 
 function formatReasoningLabel(value: string): string {
   if (value === "xhigh") {

--- a/packages/web/src/components/dispatcher/DispatcherSessionPane.test.ts
+++ b/packages/web/src/components/dispatcher/DispatcherSessionPane.test.ts
@@ -49,8 +49,8 @@ test("applyFeedDelta patch appends textDelta onto the existing entry text", () =
     entries: [makeEntry("entry-1", "hello", true)],
   };
 
-  const next = applyFeedDelta(current, {
-    type: "patch",
+  const delta = {
+    type: "patch" as const,
     entryId: "entry-1",
     entry: makeEntry("entry-1", "hello world", true),
     textDelta: " world",
@@ -64,8 +64,14 @@ test("applyFeedDelta patch appends textDelta onto the existing entry text", () =
     source: "stream",
     error: null,
     integration: null,
-  });
+  };
+
+  const next = applyFeedDelta(current, delta);
 
   assert.equal(next.entries.length, 1);
   assert.equal(next.entries[0]?.text, "hello world");
+
+  const replayed = applyFeedDelta(next, delta);
+  assert.equal(replayed.entries.length, 1);
+  assert.equal(replayed.entries[0]?.text, "hello world");
 });

--- a/packages/web/src/components/dispatcher/DispatcherSessionPane.tsx
+++ b/packages/web/src/components/dispatcher/DispatcherSessionPane.tsx
@@ -1011,6 +1011,7 @@ export function DispatcherSessionPane({
   const streamConnectCountRef = useRef(0);
   const streamReconnectCountRef = useRef(0);
   const streamFallbackReloadCountRef = useRef(0);
+  const streamConnectGenerationRef = useRef(0);
   const deltaAppendCountRef = useRef(0);
   const deltaPatchCountRef = useRef(0);
   const deltaReplaceCountRef = useRef(0);
@@ -1036,6 +1037,7 @@ export function DispatcherSessionPane({
     streamConnectCountRef.current = 0;
     streamReconnectCountRef.current = 0;
     streamFallbackReloadCountRef.current = 0;
+    streamConnectGenerationRef.current += 1;
     deltaAppendCountRef.current = 0;
     deltaPatchCountRef.current = 0;
     deltaReplaceCountRef.current = 0;
@@ -1124,9 +1126,12 @@ export function DispatcherSessionPane({
     }
   }, [bridgeId, hideRepositoryControls, session.projectId, sessionApiPaths.repositories]);
 
-  const loadFeed = useCallback(async () => {
+  const loadFeed = useCallback(async (options: { showLoading?: boolean } = {}) => {
+    const showLoading = options.showLoading ?? true;
     loadFeedCountRef.current += 1;
-    setLoading(true);
+    if (showLoading) {
+      setLoading(true);
+    }
     setLoadingError(null);
     try {
       const response = await fetch(withBridgeQuery(sessionApiPaths.feed, bridgeId), { cache: "no-store" });
@@ -1144,7 +1149,9 @@ export function DispatcherSessionPane({
       loadFeedFailureCountRef.current += 1;
       setLoadingError(error instanceof Error ? error.message : "Failed to load session feed");
     } finally {
-      setLoading(false);
+      if (showLoading) {
+        setLoading(false);
+      }
     }
   }, [bridgeId, sessionApiPaths.feed]);
 
@@ -1253,6 +1260,9 @@ export function DispatcherSessionPane({
       if (cancelled) {
         return;
       }
+      const myGeneration = streamConnectGenerationRef.current + 1;
+      streamConnectGenerationRef.current = myGeneration;
+      const isCurrentConnection = () => !cancelled && streamConnectGenerationRef.current === myGeneration;
       streamAbortRef.current?.abort();
       const ac = new AbortController();
       streamAbortRef.current = ac;
@@ -1263,28 +1273,29 @@ export function DispatcherSessionPane({
           cache: "no-store",
           signal: ac.signal,
         });
+        if (!isCurrentConnection()) {
+          return;
+        }
         if (!res.ok || !res.body) {
-          if (!cancelled) {
-            streamFallbackReloadCountRef.current += 1;
-            void loadFeed();
-            scheduleReconnect();
-          }
+          streamFallbackReloadCountRef.current += 1;
+          void loadFeed();
+          scheduleReconnect();
           return;
         }
         reconnectAttempt = 0;
         for await (const frame of iterateSseFrames(res.body, ac.signal)) {
-          if (cancelled) {
+          if (!isCurrentConnection()) {
             return;
           }
           applySseData(frame.data);
         }
-        if (!cancelled) {
+        if (isCurrentConnection()) {
           streamFallbackReloadCountRef.current += 1;
           void loadFeed();
           scheduleReconnect();
         }
       } catch {
-        if (!cancelled && !ac.signal.aborted) {
+        if (isCurrentConnection() && !ac.signal.aborted) {
           streamFallbackReloadCountRef.current += 1;
           void loadFeed();
           scheduleReconnect();
@@ -1296,6 +1307,7 @@ export function DispatcherSessionPane({
 
     return () => {
       cancelled = true;
+      streamConnectGenerationRef.current += 1;
       clearReconnect();
       streamAbortRef.current?.abort();
     };
@@ -1469,6 +1481,7 @@ export function DispatcherSessionPane({
       if (!response.ok) {
         throw new Error(readString(asRecord(body).error) ?? `Failed to send message (${response.status})`);
       }
+      void loadFeed({ showLoading: false });
       return true;
     } catch (error) {
       setSendError(error instanceof Error ? error.message : "Failed to send message");
@@ -1476,7 +1489,7 @@ export function DispatcherSessionPane({
     } finally {
       setSending(false);
     }
-  }, [bridgeId, sending, sessionApiPaths.send]);
+  }, [bridgeId, loadFeed, sending, sessionApiPaths.send]);
 
   const handleSend = useCallback(async () => {
     const message = composerValue.trim();
@@ -1507,12 +1520,13 @@ export function DispatcherSessionPane({
         throw new Error(readString(payload.error) ?? `Failed to ${action} plan (${response.status})`);
       }
       setComposerValue("");
+      void loadFeed({ showLoading: false });
     } catch (err) {
       setSendError(err instanceof Error ? err.message : `Failed to ${action} plan`);
     } finally {
       setSending(false);
     }
-  }, [bridgeId, sendMessage, sessionApiPaths.approve, sessionApiPaths.reject]);
+  }, [bridgeId, loadFeed, sendMessage, sessionApiPaths.approve, sessionApiPaths.reject]);
 
   const handleAgentChange = useCallback(async (nextAgent: string) => {
     if (!repository || savingAgent || nextAgent === repository.agent) {
@@ -1564,12 +1578,13 @@ export function DispatcherSessionPane({
       if (!response.ok) {
         throw new Error(readString(asRecord(body).error) ?? `Failed to interrupt session (${response.status})`);
       }
+      void loadFeed({ showLoading: false });
     } catch (error) {
       setSendError(error instanceof Error ? error.message : "Failed to interrupt session");
     } finally {
       setSending(false);
     }
-  }, [bridgeId, sessionApiPaths.interrupt]);
+  }, [bridgeId, loadFeed, sessionApiPaths.interrupt]);
 
   return (
     <aside className={cn(

--- a/packages/web/src/components/dispatcher/dispatcherFeedState.ts
+++ b/packages/web/src/components/dispatcher/dispatcherFeedState.ts
@@ -177,6 +177,7 @@ export function applyFeedDelta(current: SessionFeedPayload, delta: FeedDeltaEven
     if (
       delta.textDelta !== null
       && nextEntry.text.startsWith(existing.text)
+      && existing.text.length + delta.textDelta.length === nextEntry.text.length
     ) {
       entries[patchIndex] = {
         ...nextEntry,


### PR DESCRIPTION
## Summary

Fixes dispatcher chat send/feed reliability and adds Letta Code as a supported dispatcher and implementation agent. Also normalizes agent aliases, sends initial prompts correctly for interactive direct-terminal runtimes, and keeps dispatcher query handling compatible with both frontend camelCase and legacy snake_case params.

## User-Facing Release Notes

- Dispatcher chat now reliably reflects sent messages and live feed updates without stale stream state or duplicate streamed text.
- Letta Code can now be selected for dispatcher and implementation work after Letta CLI authentication is configured.
- Cursor CLI is restored as an implementation-agent choice in dispatcher preferences.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Plugin addition / modification
- [ ] Documentation update
- [ ] Refactor / chore

## Testing

- `cargo fmt --all`
- `cargo test -p conductor-executors letta -- --nocapture`
- `cargo test -p conductor-server dispatcher -- --nocapture`
- `bun run --cwd packages/web test`
- `bun run --cwd packages/web typecheck`
- `cargo check --workspace`
- Verified local dispatcher send/feed path against `http://127.0.0.1:4749` with a PONG health-check turn.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Letta is now available as a dispatcher coding agent option
  * Enhanced authentication handling with permission mode overrides
  * Improved prompt handling for interactive executor modes

* **Improvements**
  * Session stability enhanced through stale operation filtering to prevent race conditions
  * Feed updates now refresh without interrupting UI state
  * Better parameter flexibility for dispatcher requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->