### PR TITLE
Expose Pi runtime catalog in agents API

### DIFF
--- a/crates/conductor-server/src/routes/agents.rs
+++ b/crates/conductor-server/src/routes/agents.rs
@@ -370,7 +370,10 @@ fn agent_metadata(kind: &AgentKind) -> (&'static str, &'static str, &'static str
 // Runtime model catalog dispatch
 // ---------------------------------------------------------------------------
 
-async fn build_runtime_model_catalog_for_name(name: &str, binary_path: Option<&Path>) -> Value {
+pub(crate) async fn build_runtime_model_catalog_for_name(
+    name: &str,
+    binary_path: Option<&Path>,
+) -> Value {
     let normalized = normalize_agent_name(name);
     match normalized.as_str() {
         "claude-code" | "claude" => {

--- a/crates/conductor-server/src/routes/config.rs
+++ b/crates/conductor-server/src/routes/config.rs
@@ -1167,7 +1167,13 @@ async fn build_runtime_model_catalog(
                 .await
                 .unwrap_or(Value::Null)
         }
-        _ => Value::Null,
+        _ => {
+            crate::routes::agents::build_runtime_model_catalog_for_name(
+                &kind.to_string(),
+                Some(binary_path),
+            )
+            .await
+        }
     }
 }
 


### PR DESCRIPTION
## User-Facing Release Notes

- Pi's local model catalog now appears in the dashboard agents API after Pi is installed, including default model selection and model-specific reasoning options.

## Type of Change

- [ ] Breaking Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Performance Improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Testing

- `cargo test -p conductor-server routes::agents::tests --lib`
- `cargo check --workspace`
- `cargo build -p conductor-cli`
- Local smoke: started the Conductor backend from source with Pi installed and confirmed `/api/agents` reports Pi as ready with 41 models and default `openai/gpt-5.5`.
