### PR TITLE
fix: bridge updater npm prefix handling

### DIFF
--- a/bridge-cmd/backend/backend.go
+++ b/bridge-cmd/backend/backend.go
@@ -382,11 +382,16 @@ func inferCliUpdateEnv(binaryPath string) []string {
 	currentVersion := strings.TrimSpace(os.Getenv("CONDUCTOR_CLI_VERSION"))
 	installMode := strings.TrimSpace(os.Getenv("CONDUCTOR_CLI_INSTALL_MODE"))
 
+	globalPrefix := strings.TrimSpace(os.Getenv("CONDUCTOR_CLI_GLOBAL_PREFIX"))
+
 	manifestName, manifestVersion, manifestPackageRoot := inferCliPackageManifest(binaryPath)
 	if manifestName != "" && manifestVersion != "" {
 		packageName = manifestName
 		currentVersion = manifestVersion
 		installMode = inferCliInstallMode(manifestPackageRoot)
+		if globalPrefix == "" && installMode == "global-npm" {
+			globalPrefix = inferNpmGlobalPrefix(manifestPackageRoot)
+		}
 	}
 
 	if packageName == "" {
@@ -398,15 +403,27 @@ func inferCliUpdateEnv(binaryPath string) []string {
 	if installMode == "" {
 		installMode = inferCliInstallModeFromBinary(binaryPath)
 	}
+	if globalPrefix == "" && installMode == "global-npm" {
+		for _, packageRoot := range inferCliPackageRootCandidates(binaryPath) {
+			if candidate := inferNpmGlobalPrefix(packageRoot); candidate != "" {
+				globalPrefix = candidate
+				break
+			}
+		}
+	}
 	if packageName == "" || currentVersion == "" {
 		return nil
 	}
 
-	return []string{
+	env := []string{
 		"CONDUCTOR_CLI_PACKAGE_NAME=" + packageName,
 		"CONDUCTOR_CLI_VERSION=" + currentVersion,
 		"CONDUCTOR_CLI_INSTALL_MODE=" + installMode,
 	}
+	if globalPrefix != "" {
+		env = append(env, "CONDUCTOR_CLI_GLOBAL_PREFIX="+globalPrefix)
+	}
+	return env
 }
 
 func inferCliPackageManifest(binaryPath string) (string, string, string) {
@@ -600,9 +617,7 @@ func inferCliInstallMode(packageRoot string) string {
 		}
 	}
 
-	if strings.Contains(normalizedRoot, "/.conductor/npm/") ||
-		strings.Contains(normalizedRoot, "/lib/node_modules/") ||
-		strings.Contains(normalizedRoot, "/node_modules/") {
+	if inferNpmGlobalPrefix(packageRoot) != "" {
 		return "global-npm"
 	}
 
@@ -611,6 +626,24 @@ func inferCliInstallMode(packageRoot string) string {
 	}
 
 	return "unknown"
+}
+
+func inferNpmGlobalPrefix(packageRoot string) string {
+	if !isConductorPackageName(filepath.Base(packageRoot)) {
+		return ""
+	}
+
+	nodeModulesDir := filepath.Dir(packageRoot)
+	if filepath.Base(nodeModulesDir) != "node_modules" {
+		return ""
+	}
+
+	libDir := filepath.Dir(nodeModulesDir)
+	if filepath.Base(libDir) != "lib" {
+		return ""
+	}
+
+	return filepath.Clean(filepath.Dir(libDir))
 }
 
 func normalizeFsPath(value string) string {

--- a/bridge-cmd/backend/backend_test.go
+++ b/bridge-cmd/backend/backend_test.go
@@ -152,6 +152,7 @@ func TestInferCliUpdateEnvFallsBackToSymlinkedDotBinPackageMetadataWhenEnvMissin
 	t.Setenv("CONDUCTOR_CLI_PACKAGE_NAME", "")
 	t.Setenv("CONDUCTOR_CLI_VERSION", "")
 	t.Setenv("CONDUCTOR_CLI_INSTALL_MODE", "")
+	t.Setenv("CONDUCTOR_CLI_GLOBAL_PREFIX", "")
 
 	packageRoot := filepath.Join(tempDir, "project", "node_modules", "conductor-oss")
 	binaryPath := filepath.Join(packageRoot, "bin", "conductor")
@@ -191,6 +192,7 @@ func TestInferCliUpdateEnvFallsBackToBunPackageMetadataWhenEnvMissing(t *testing
 	t.Setenv("CONDUCTOR_CLI_PACKAGE_NAME", "")
 	t.Setenv("CONDUCTOR_CLI_VERSION", "")
 	t.Setenv("CONDUCTOR_CLI_INSTALL_MODE", "")
+	t.Setenv("CONDUCTOR_CLI_GLOBAL_PREFIX", "")
 
 	workspace := filepath.Join(tempDir, ".bun", "install", "global", "node_modules", "conductor-oss")
 	if err := os.MkdirAll(workspace, 0o755); err != nil {
@@ -229,6 +231,7 @@ func TestInferCliUpdateEnvFallsBackToGlobalBinPackageMetadataWhenEnvMissing(t *t
 	t.Setenv("CONDUCTOR_CLI_PACKAGE_NAME", "")
 	t.Setenv("CONDUCTOR_CLI_VERSION", "")
 	t.Setenv("CONDUCTOR_CLI_INSTALL_MODE", "")
+	t.Setenv("CONDUCTOR_CLI_GLOBAL_PREFIX", "")
 
 	workspace := filepath.Join(tempDir, "usr", "local", "lib", "node_modules", "conductor-oss")
 	if err := os.MkdirAll(workspace, 0o755); err != nil {
@@ -252,9 +255,40 @@ func TestInferCliUpdateEnvFallsBackToGlobalBinPackageMetadataWhenEnvMissing(t *t
 		"CONDUCTOR_CLI_PACKAGE_NAME=conductor-oss",
 		"CONDUCTOR_CLI_VERSION=5.6.7",
 		"CONDUCTOR_CLI_INSTALL_MODE=global-npm",
+		"CONDUCTOR_CLI_GLOBAL_PREFIX=" + filepath.Join(tempDir, "usr", "local"),
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("expected launch env to contain %q, got %v", want, gotEnv)
 		}
+	}
+}
+
+func TestInferNpmGlobalPrefixIgnoresNestedNativePackage(t *testing.T) {
+	nativePackageRoot := filepath.Join(
+		"Users",
+		"test",
+		".conductor",
+		"npm",
+		"lib",
+		"node_modules",
+		"conductor-oss",
+		"node_modules",
+		"conductor-oss-native-darwin-universal",
+	)
+	if got := inferNpmGlobalPrefix(nativePackageRoot); got != "" {
+		t.Fatalf("expected no npm global prefix for nested native package, got %q", got)
+	}
+	if got := inferCliInstallMode(nativePackageRoot); got != "unknown" {
+		t.Fatalf("expected nested native package install mode unknown, got %q", got)
+	}
+}
+
+func TestInferNpmGlobalPrefixIgnoresLocalProjectNodeModules(t *testing.T) {
+	packageRoot := filepath.Join("Users", "test", "project", "node_modules", "conductor-oss")
+	if got := inferNpmGlobalPrefix(packageRoot); got != "" {
+		t.Fatalf("expected no npm global prefix for local project package, got %q", got)
+	}
+	if got := inferCliInstallMode(packageRoot); got != "unknown" {
+		t.Fatalf("expected local project package install mode unknown, got %q", got)
 	}
 }

--- a/crates/conductor-server/src/state/app_update.rs
+++ b/crates/conductor-server/src/state/app_update.rs
@@ -17,6 +17,7 @@ use crate::state::AppState;
 const APP_UPDATE_CHECK_TTL_SECS: i64 = 5 * 60;
 const APP_UPDATE_BACKGROUND_INTERVAL_SECS: u64 = 30 * 60;
 const APP_UPDATE_LOG_TAIL_LIMIT: usize = 6000;
+const APP_UPDATE_NPM_RETRY_DELAYS_SECS: [u64; 2] = [5, 20];
 const NPM_PUBLIC_REGISTRY: &str = "https://registry.npmjs.org";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -379,10 +380,7 @@ fn infer_cli_install_mode(current_exe: &Path, package_root: &Path) -> AppInstall
         return AppInstallMode::GlobalBun;
     }
 
-    if normalized_root.contains("/.conductor/npm/")
-        || normalized_root.contains("/lib/node_modules/")
-        || normalized_root.contains("/node_modules/")
-    {
+    if infer_npm_global_prefix(package_root).is_some() {
         return AppInstallMode::GlobalNpm;
     }
 
@@ -394,19 +392,22 @@ fn infer_cli_install_mode(current_exe: &Path, package_root: &Path) -> AppInstall
 }
 
 fn infer_npm_global_prefix(package_root: &Path) -> Option<String> {
+    let package_dir = package_root.file_name().and_then(|value| value.to_str())?;
+    if !is_conductor_package_name(package_dir) {
+        return None;
+    }
+
     let node_modules = package_root.parent()?;
     if node_modules.file_name().and_then(|value| value.to_str()) != Some("node_modules") {
         return None;
     }
 
     let parent = node_modules.parent()?;
-    let prefix = if parent.file_name().and_then(|value| value.to_str()) == Some("lib") {
-        parent.parent()?
-    } else {
-        parent
-    };
+    if parent.file_name().and_then(|value| value.to_str()) != Some("lib") {
+        return None;
+    }
 
-    Some(normalize_fs_path(prefix))
+    Some(normalize_fs_path(parent.parent()?))
 }
 
 fn infer_bun_root() -> Option<PathBuf> {
@@ -573,7 +574,7 @@ fn build_update_command(
                 .map(|value| format!(" --prefix {}", shell_quote(value)))
                 .unwrap_or_default();
             Some(format!(
-                "npm install -g{prefix_fragment} --registry={NPM_PUBLIC_REGISTRY} {package_spec}"
+                "npm install -g{prefix_fragment} --prefer-online --registry={NPM_PUBLIC_REGISTRY} {package_spec}"
             ))
         }
         AppInstallMode::GlobalPnpm => Some(format!(
@@ -605,6 +606,7 @@ fn resolve_update_invocation(
                 args.push("--prefix".to_string());
                 args.push(prefix.to_string());
             }
+            args.push("--prefer-online".to_string());
             args.push(format!("--registry={NPM_PUBLIC_REGISTRY}"));
             args.push(package_spec.clone());
             let display_command = build_update_command(
@@ -615,7 +617,7 @@ fn resolve_update_invocation(
                 Some(target_version),
             )
             .unwrap_or_else(|| {
-                format!("npm install -g --registry={NPM_PUBLIC_REGISTRY} {package_spec}")
+                format!("npm install -g --prefer-online --registry={NPM_PUBLIC_REGISTRY} {package_spec}")
             });
             Some(("npm", args, display_command))
         }
@@ -643,6 +645,78 @@ fn trim_log_tail(value: &str) -> String {
         return value.to_string();
     }
     value[value.len() - APP_UPDATE_LOG_TAIL_LIMIT..].to_string()
+}
+
+fn command_output_text(output: &std::process::Output) -> String {
+    format!(
+        "{}{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        if output.stdout.is_empty() || output.stderr.is_empty() {
+            ""
+        } else {
+            "\n"
+        },
+        String::from_utf8_lossy(&output.stderr),
+    )
+    .trim()
+    .to_string()
+}
+
+fn should_retry_npm_update(output: &std::process::Output) -> bool {
+    if output.status.success() {
+        return false;
+    }
+
+    let normalized = command_output_text(output).to_lowercase();
+    normalized.contains("npm error code etarget")
+        || normalized.contains("no matching version found")
+        || normalized.contains("notarget")
+        || normalized.contains("eai_again")
+        || normalized.contains("etimedout")
+        || normalized.contains("socket timeout")
+}
+
+async fn run_update_command_with_retries(
+    command: &str,
+    args: &[String],
+) -> (std::io::Result<std::process::Output>, String) {
+    let mut retry_logs = String::new();
+
+    for (attempt_index, retry_delay_secs) in APP_UPDATE_NPM_RETRY_DELAYS_SECS
+        .into_iter()
+        .map(Some)
+        .chain(std::iter::once(None))
+        .enumerate()
+    {
+        let result = Command::new(command)
+            .args(args)
+            .env("NO_COLOR", "1")
+            .env("NPM_CONFIG_REGISTRY", NPM_PUBLIC_REGISTRY)
+            .env("npm_config_registry", NPM_PUBLIC_REGISTRY)
+            .output()
+            .await;
+
+        match result {
+            Ok(output)
+                if command == "npm"
+                    && should_retry_npm_update(&output)
+                    && retry_delay_secs.is_some() =>
+            {
+                if !retry_logs.is_empty() {
+                    retry_logs.push_str("\n\n");
+                }
+                retry_logs.push_str(&format!(
+                    "Attempt {} failed:\n{}",
+                    attempt_index + 1,
+                    command_output_text(&output)
+                ));
+                sleep(Duration::from_secs(retry_delay_secs.unwrap_or_default())).await;
+            }
+            other => return (other, retry_logs),
+        }
+    }
+
+    unreachable!("update retry loop always returns from the final attempt")
 }
 
 fn parse_version(value: &str) -> Option<ParsedVersion> {
@@ -898,13 +972,7 @@ impl AppState {
 
         let state = Arc::clone(self);
         tokio::spawn(async move {
-            let result = Command::new(command)
-                .args(&args)
-                .env("NO_COLOR", "1")
-                .env("NPM_CONFIG_REGISTRY", NPM_PUBLIC_REGISTRY)
-                .env("npm_config_registry", NPM_PUBLIC_REGISTRY)
-                .output()
-                .await;
+            let (result, retry_logs) = run_update_command_with_retries(command, &args).await;
 
             let finished_at = Utc::now().to_rfc3339();
             let next_snapshot = {
@@ -929,16 +997,12 @@ impl AppState {
                         runtime.status.logs_tail = None;
                     }
                     Ok(output) => {
-                        let combined_output = format!(
-                            "{}{}{}",
-                            String::from_utf8_lossy(&output.stdout),
-                            if output.stdout.is_empty() || output.stderr.is_empty() {
-                                ""
-                            } else {
-                                "\n"
-                            },
-                            String::from_utf8_lossy(&output.stderr),
-                        );
+                        let mut combined_output = retry_logs;
+                        let final_output = command_output_text(&output);
+                        if !combined_output.is_empty() && !final_output.is_empty() {
+                            combined_output.push_str("\n\nFinal attempt failed:\n");
+                        }
+                        combined_output.push_str(&final_output);
                         runtime.status.job_status = AppUpdateJobStatus::Failed;
                         runtime.status.job_message = Some(format!(
                             "{display_command} exited with code {}.",
@@ -1118,7 +1182,7 @@ mod tests {
         assert_eq!(
             build_update_command(AppInstallMode::GlobalNpm, "conductor-oss", None, None, None),
             Some(
-                "npm install -g --registry=https://registry.npmjs.org conductor-oss@latest"
+                "npm install -g --prefer-online --registry=https://registry.npmjs.org conductor-oss@latest"
                     .to_string()
             )
         );
@@ -1131,7 +1195,7 @@ mod tests {
                 Some("0.60.7"),
             ),
             Some(
-                "npm install -g --prefix '/Users/test/.conductor/npm' --registry=https://registry.npmjs.org conductor-oss@0.60.7"
+                "npm install -g --prefix '/Users/test/.conductor/npm' --prefer-online --registry=https://registry.npmjs.org conductor-oss@0.60.7"
                     .to_string()
             )
         );
@@ -1151,6 +1215,44 @@ mod tests {
     }
 
     #[test]
+    fn infer_npm_global_prefix_ignores_local_project_node_modules() {
+        let package_root = Path::new("/Users/test/project/node_modules/conductor-oss");
+        assert_eq!(infer_npm_global_prefix(package_root), None);
+        assert_eq!(
+            infer_cli_install_mode(&package_root.join("bin/conductor"), package_root),
+            AppInstallMode::Unknown,
+        );
+    }
+
+    #[test]
+    fn infer_npm_global_prefix_ignores_nested_native_package() {
+        let native_package_root = Path::new(
+            "/Users/test/.conductor/npm/lib/node_modules/conductor-oss/node_modules/conductor-oss-native-darwin-universal",
+        );
+        assert_eq!(infer_npm_global_prefix(native_package_root), None);
+        assert_eq!(
+            infer_cli_install_mode(
+                &native_package_root.join("bin/conductor"),
+                native_package_root,
+            ),
+            AppInstallMode::Unknown,
+        );
+    }
+
+    #[test]
+    fn infer_cli_install_mode_detects_conductor_npm_package_root() {
+        let package_root = Path::new("/Users/test/.conductor/npm/lib/node_modules/conductor-oss");
+        assert_eq!(
+            infer_cli_install_mode(
+                &package_root
+                    .join("node_modules/conductor-oss-native-darwin-universal/bin/conductor"),
+                package_root
+            ),
+            AppInstallMode::GlobalNpm,
+        );
+    }
+
+    #[test]
     fn build_update_command_quotes_prefixes_with_spaces() {
         assert_eq!(
             build_update_command(
@@ -1161,7 +1263,7 @@ mod tests {
                 Some("0.60.7"),
             ),
             Some(
-                "npm install -g --prefix '/Users/John Smith/.conductor/npm' --registry=https://registry.npmjs.org conductor-oss@0.60.7"
+                "npm install -g --prefix '/Users/John Smith/.conductor/npm' --prefer-online --registry=https://registry.npmjs.org conductor-oss@0.60.7"
                     .to_string()
             )
         );
@@ -1185,13 +1287,14 @@ mod tests {
                 "-g".to_string(),
                 "--prefix".to_string(),
                 "/Users/test/.conductor/npm".to_string(),
+                "--prefer-online".to_string(),
                 "--registry=https://registry.npmjs.org".to_string(),
                 "conductor-oss@0.60.7".to_string(),
             ]
         );
         assert_eq!(
             display_command,
-            "npm install -g --prefix '/Users/test/.conductor/npm' --registry=https://registry.npmjs.org conductor-oss@0.60.7"
+            "npm install -g --prefix '/Users/test/.conductor/npm' --prefer-online --registry=https://registry.npmjs.org conductor-oss@0.60.7"
         );
     }
 

--- a/packages/cli/src/__tests__/start.test.ts
+++ b/packages/cli/src/__tests__/start.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import {
+  inferNpmGlobalPrefixFromPackageRoot,
   isLoopbackHost,
   quoteWindowsCliArg,
   resolveDashboardPackageManager,
@@ -28,6 +29,27 @@ test("resolveLocalDashboardAuthEnv enables loopback packaged dashboards unless o
   assert.deepEqual(resolveLocalDashboardAuthEnv("127.0.0.1", {
     CONDUCTOR_ALLOW_LOCAL_UNAUTHENTICATED: "false",
   }), {});
+});
+
+test("inferNpmGlobalPrefixFromPackageRoot derives npm prefixes from package roots", () => {
+  assert.equal(
+    inferNpmGlobalPrefixFromPackageRoot("/Users/test/.conductor/npm/lib/node_modules/conductor-oss"),
+    "/Users/test/.conductor/npm",
+  );
+  assert.equal(
+    inferNpmGlobalPrefixFromPackageRoot("/Users/test/project/node_modules/conductor-oss"),
+    null,
+  );
+  assert.equal(
+    inferNpmGlobalPrefixFromPackageRoot(
+      "/Users/test/.conductor/npm/lib/node_modules/conductor-oss/node_modules/conductor-oss-native-darwin-universal",
+    ),
+    null,
+  );
+  assert.equal(
+    inferNpmGlobalPrefixFromPackageRoot("/Users/test/conductor-oss/packages/cli"),
+    null,
+  );
 });
 
 test("resolveRustBackendLaunch prefers the newest repo-local Rust binary over bundled fallbacks", () => {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -40,6 +40,7 @@ type CliUpdateContext = {
   packageName: string;
   version: string;
   installMode: CliInstallMode;
+  globalPrefix?: string;
 };
 
 type DashboardPackageManager = "bun" | "pnpm";
@@ -117,6 +118,25 @@ function resolveBunGlobalNodeModulesDir(): string {
   return join(bunInstallRoot, "install", "global", "node_modules");
 }
 
+export function inferNpmGlobalPrefixFromPackageRoot(packageRoot: string): string | null {
+  const packageName = basename(packageRoot).toLowerCase();
+  if (packageName !== "conductor" && packageName !== "conductor-oss") {
+    return null;
+  }
+
+  const nodeModulesDir = dirname(packageRoot);
+  if (basename(nodeModulesDir) !== "node_modules") {
+    return null;
+  }
+
+  const parentDir = dirname(nodeModulesDir);
+  if (basename(parentDir) === "lib") {
+    return dirname(parentDir);
+  }
+
+  return null;
+}
+
 function hasWorkspaceLockfile(packageRoot: string): boolean {
   const workspaceRoot = join(packageRoot, "..", "..");
   return existsSync(join(workspaceRoot, "bun.lock"))
@@ -185,7 +205,7 @@ function dashboardBuildHint(packageManager: DashboardPackageManager): string {
     : "bun run --cwd packages/web build";
 }
 
-function resolveCliUpdateContext(): CliUpdateContext {
+export function resolveCliUpdateContext(): CliUpdateContext {
   const packageJsonUrl = new URL("../../package.json", import.meta.url);
   const packageRoot = dirname(fileURLToPath(packageJsonUrl));
   let packageName = "conductor-oss";
@@ -225,6 +245,22 @@ function resolveCliUpdateContext(): CliUpdateContext {
     return { packageName, version, installMode: "global-pnpm" };
   }
 
+  const inferredNpmGlobalPrefix = inferNpmGlobalPrefixFromPackageRoot(packageRoot);
+  if (inferredNpmGlobalPrefix) {
+    const inferredNpmGlobalDirs = [
+      join(inferredNpmGlobalPrefix, "lib", "node_modules"),
+      join(inferredNpmGlobalPrefix, "node_modules"),
+    ];
+    if (inferredNpmGlobalDirs.some((dir) => isPathInside(packageRoot, dir))) {
+      return {
+        packageName,
+        version,
+        installMode: "global-npm",
+        globalPrefix: inferredNpmGlobalPrefix,
+      };
+    }
+  }
+
   const npmGlobalPrefix = readCommandStdout("npm", ["prefix", "-g"]);
   if (npmGlobalPrefix) {
     const npmGlobalDirs = [
@@ -232,7 +268,7 @@ function resolveCliUpdateContext(): CliUpdateContext {
       join(npmGlobalPrefix, "node_modules"),
     ];
     if (npmGlobalDirs.some((dir) => existsSync(dir) && isPathInside(packageRoot, dir))) {
-      return { packageName, version, installMode: "global-npm" };
+      return { packageName, version, installMode: "global-npm", globalPrefix: npmGlobalPrefix };
     }
   }
 
@@ -1030,6 +1066,9 @@ export function registerStart(program: Command): void {
                   CONDUCTOR_CLI_PACKAGE_NAME: cliUpdateContext.packageName,
                   CONDUCTOR_CLI_VERSION: cliUpdateContext.version,
                   CONDUCTOR_CLI_INSTALL_MODE: cliUpdateContext.installMode,
+                  ...(cliUpdateContext.globalPrefix
+                    ? { CONDUCTOR_CLI_GLOBAL_PREFIX: cliUpdateContext.globalPrefix }
+                    : {}),
                   ...(cliRerunCommand
                     ? { CONDUCTOR_CLI_RERUN_COMMAND: cliRerunCommand }
                     : {}),
@@ -1179,6 +1218,9 @@ export function registerStart(program: Command): void {
                 CONDUCTOR_CLI_PACKAGE_NAME: cliUpdateContext.packageName,
                 CONDUCTOR_CLI_VERSION: cliUpdateContext.version,
                 CONDUCTOR_CLI_INSTALL_MODE: cliUpdateContext.installMode,
+                ...(cliUpdateContext.globalPrefix
+                  ? { CONDUCTOR_CLI_GLOBAL_PREFIX: cliUpdateContext.globalPrefix }
+                  : {}),
                 ...(cliRerunCommand
                   ? { CONDUCTOR_CLI_RERUN_COMMAND: cliRerunCommand }
                   : {}),


### PR DESCRIPTION
## Summary

Fixes the bridge app update path so npm global installs use the correct install prefix instead of relying on the process default. Also hardens package-root detection so nested native packages and local project dependencies are not treated as the updatable CLI package.

## User-Facing Release Notes

- Bridge devices can now install Conductor updates more reliably when Conductor was installed through the bridge-managed npm prefix.
- Update failures caused by transient npm registry misses are retried before the UI reports failure.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Plugin addition / modification
- [ ] Documentation update
- [ ] Refactor / chore

## Checklist

- [x] `pnpm build` passes with no errors
- [x] `pnpm typecheck` passes with no errors
- [x] No `any` types introduced without justification
- [x] New plugins implement the appropriate `PluginModule` interface
- [x] No secrets or credentials committed
- [x] User-facing release notes are filled in plain English or marked internal-only
- [x] PR title follows conventional commits (`feat:`, `fix:`, `chore:`, etc.)

## Testing

```bash
cargo fmt --check && cargo test -p conductor-server state::app_update::tests --lib
bun run --cwd packages/cli test && bun run --cwd packages/cli typecheck
bun run --cwd packages/cli build
cd bridge-cmd && go test ./backend
```

## Screenshots / Demo

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection of global npm installations with stricter validation logic
  * Added automatic retry mechanism for transient npm command failures with exponential backoff

* **Improvements**
  * Enhanced error messages to display retry attempt details when npm updates fail

<!-- end of auto-generated comment: release notes by coderabbit.ai -->