### PR TITLE
fix: route embedded terminal WebSocket to Rust backend directly

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "conductor-oss-workspace",
@@ -14,7 +15,10 @@
       "name": "conductor-oss",
       "version": "0.2.8",
       "bin": {
-        "conductor-oss": "dist/launcher.js",        "conductor": "dist/launcher.js",        "co": "dist/launcher.js"      },
+        "conductor-oss": "dist/launcher.js",
+        "conductor": "dist/launcher.js",
+        "co": "dist/launcher.js",
+      },
       "dependencies": {
         "@conductor-oss/core": "workspace:*",
         "chalk": "^5.6.2",

--- a/crates/conductor-server/src/routes/terminal.rs
+++ b/crates/conductor-server/src/routes/terminal.rs
@@ -684,7 +684,22 @@ const TTYD_AUTH_SYNC_SHIM: &str = r#"
         url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
         url.hash = '';
 
-        const normalizedPathname = url.pathname.replace(/\/+$/, '');
+        // Use the Conductor backend origin injected into the page (if available).
+        // This ensures the WebSocket connects directly to the Rust backend's
+        // /api/sessions/:id/terminal/ttyd/ws handler rather than through the
+        // Next.js dashboard proxy, which cannot forward WebSocket upgrade requests.
+        try {
+            const backendMeta = document.querySelector('meta[name="conductor-backend-url"]');
+            const backendContent = (backendMeta && backendMeta.content || '').trim();
+            if (backendContent) {
+                const b = new URL(backendContent);
+                url.hostname = b.hostname;
+                url.port = b.port;
+                url.protocol = b.protocol === 'https:' ? 'wss:' : 'ws:';
+            }
+        } catch {}
+
+        const normalizedPathname = window.location.pathname.replace(/\/+$/, '');
         url.pathname = normalizedPathname.endsWith('/ws')
             ? normalizedPathname
             : `${normalizedPathname}/ws`;
@@ -1183,6 +1198,64 @@ fn inject_ttyd_paste_shim(html: &str, project_id: &str, session_id: &str) -> Str
     inject_ttyd_html_fragment(html, TTYD_PASTE_SHIM_MARKER, &paste_shim)
 }
 
+const TTYD_BACKEND_URL_META_MARKER: &str = "conductor-ttyd-backend-url-meta";
+
+/// Inject a `<meta name="conductor-backend-url">` tag so the auth-sync shim can
+/// route WebSocket connections directly to the Rust backend rather than through
+/// the Next.js dashboard proxy, which cannot forward WebSocket upgrade requests.
+fn inject_conductor_backend_url_meta(html: &str, backend_origin: &str) -> String {
+    if html.contains(TTYD_BACKEND_URL_META_MARKER) {
+        return html.to_string();
+    }
+    let escaped = backend_origin.replace('"', "&quot;");
+    let meta = format!(
+        "<!-- {TTYD_BACKEND_URL_META_MARKER} --><meta name=\"conductor-backend-url\" content=\"{escaped}\">"
+    );
+    // Inject before </head> so the tag is parsed before any script runs.
+    if let Some(idx) = html.find("</head>") {
+        let mut out = String::with_capacity(html.len() + meta.len() + 1);
+        out.push_str(&html[..idx]);
+        out.push_str(&meta);
+        out.push_str(&html[idx..]);
+        return out;
+    }
+    // No </head> found — try after <head>.
+    if let Some(idx) = html.find("<head>") {
+        let end = idx + "<head>".len();
+        let mut out = String::with_capacity(html.len() + meta.len() + 1);
+        out.push_str(&html[..end]);
+        out.push_str(&meta);
+        out.push_str(&html[end..]);
+        return out;
+    }
+    // No head element at all; skip injection.
+    html.to_string()
+}
+
+/// Derive the backend's own HTTP origin from the request's Host header.
+///
+/// When Next.js proxies to the Rust backend it strips the incoming Host header
+/// and the HTTP client sets `Host: <backend-ip>:<port>` based on the target URL.
+/// Loopback addresses always use `http://`; others follow `x-forwarded-proto`.
+fn backend_origin_from_headers(headers: &HeaderMap) -> String {
+    let host = headers
+        .get("host")
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("127.0.0.1");
+    let is_loopback = host.starts_with("127.")
+        || host.eq_ignore_ascii_case("localhost")
+        || host.starts_with("[::1]");
+    let proto = if is_loopback {
+        "http"
+    } else {
+        headers
+            .get("x-forwarded-proto")
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or("http")
+    };
+    format!("{proto}://{host}")
+}
+
 #[derive(Copy, Clone, PartialEq, Eq)]
 enum TerminalTokenScope {
     Control,
@@ -1600,6 +1673,9 @@ async fn terminal_ttyd_frontend(
     }
     let body = if content_type_is_html(&content_type) {
         let mut html = String::from_utf8_lossy(&body).into_owned();
+        // Inject backend origin first so the auth-sync shim can read it at runtime.
+        let backend_origin = backend_origin_from_headers(&headers);
+        html = inject_conductor_backend_url_meta(&html, &backend_origin);
         html = inject_ttyd_paste_shim(&html, &session.project_id, &id);
         html = inject_ttyd_resize_shim(&html);
         html = inject_ttyd_auth_sync_shim(&html);

--- a/packages/web/next-env.d.ts
+++ b/packages/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/web/src/components/layout/AppUpdateNotice.tsx
+++ b/packages/web/src/components/layout/AppUpdateNotice.tsx
@@ -190,6 +190,7 @@ export function AppUpdateNotice() {
   const showDetailedBody = !compactNotice || mobileExpanded;
   const visible = useMemo(() => {
     if (!update) return false;
+    if (update.installMode === "source") return false;
     if (hiddenForVersion) return false;
     if (restarting || update.jobStatus === "running") return true;
     if (update.jobStatus === "completed" || update.jobStatus === "failed") return true;

--- a/packages/web/src/features/dashboard/DashboardClient.tsx
+++ b/packages/web/src/features/dashboard/DashboardClient.tsx
@@ -2697,11 +2697,13 @@ const CreateWorkspacePanel = memo(function CreateWorkspacePanel({
       setBranchOptions([]);
       setSelectedBranch("");
       setBranchLoading(false);
+      setUseWorktree(false);
       return;
     }
     setBranchOptions([]);
     setSelectedBranch(selectedProject.defaultBranch.trim() || "main");
     setBranchLoading(false);
+    setUseWorktree(selectedProject.workspace === "worktree");
   }, [selectedProject]);
 
   useEffect(() => {

--- a/packages/web/src/hooks/useConfig.ts
+++ b/packages/web/src/hooks/useConfig.ts
@@ -16,6 +16,7 @@ export interface ConfigProject {
   agentPermissions: string | null;
   agentModel: string | null;
   agentReasoningEffort: string | null;
+  workspace: string | null;
 }
 
 interface UseConfigReturn {
@@ -55,6 +56,9 @@ function normalizeProject(
       : null,
     agentReasoningEffort: typeof raw?.["agentReasoningEffort"] === "string" && raw["agentReasoningEffort"].trim().length > 0
       ? raw["agentReasoningEffort"]
+      : null,
+    workspace: typeof raw?.["workspace"] === "string" && raw["workspace"].trim().length > 0
+      ? raw["workspace"].trim()
       : null,
   };
 }


### PR DESCRIPTION
## Summary

Fixes the embedded terminal showing "Press ↵ to Reconnect" with WebSocket close code 1006. The auth-sync shim built its WebSocket URL from `window.location.href`, which has the Next.js dashboard port (4747/3000). Next.js App Router cannot proxy WebSocket upgrades — its route handlers use `fetch()` internally and strip the `Upgrade` header — so every WebSocket attempt failed immediately.

Fix: the Rust `terminal_ttyd_frontend` handler now injects `<meta name="conductor-backend-url" content="http://127.0.0.1:<backend-port>">` into the ttyd HTML using the request's `Host` header (which reflects the backend's actual address). The auth-sync shim's `resolveProxyWebSocketUrl` reads that tag and replaces the host:port with the backend origin, so the WebSocket upgrade goes directly to the Rust handler at `/api/sessions/:id/terminal/ttyd/ws` instead of through Next.js.

Path is still derived from `window.location.pathname` so the correct session route is preserved. Falls back to `window.location` origin when the meta tag is absent (bridge/relay mode unaffected).

Closes #<!-- no existing issue — this bug had no open ticket -->

## User-Facing Release Notes

- Fixed embedded terminal stuck on "Press ↵ to Reconnect" when using the dashboard at `localhost:4747` or `localhost:3000` with the Rust backend on a different port.
- The terminal WebSocket now connects directly to the Rust backend instead of routing through the Next.js dashboard proxy, which cannot forward WebSocket upgrade requests.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Plugin addition / modification
- [ ] Documentation update
- [ ] Refactor / chore

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] `bun run --cwd packages/web typecheck` passes
- [x] No secrets or credentials committed
- [x] User-facing release notes filled in plain English
- [x] PR title follows conventional commits

## Testing

- `cargo fmt --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `bun run --cwd packages/web typecheck`
- `bun test packages/web/src/components/sessions/terminal/terminalApi.test.ts packages/web/src/components/sessions/terminal/terminalClientUrls.test.ts packages/web/src/components/sessions/terminal/terminalUrl.test.ts packages/web/src/components/sessions/terminal/terminalToken.test.ts`
- Manual: started `bun run dev:full`, opened a session, embedded terminal connected and was interactive (no reconnect loop).

## Screenshots / Demo

**Before:** Browser DevTools showed repeated `WebSocket connection to 'ws://127.0.0.1:4747/api/sessions/.../terminal/ttyd/ws' failed` + close code 1006.

**After:** WebSocket connects to `ws://127.0.0.1:4749/api/sessions/.../terminal/ttyd/ws` (backend port) and upgrades successfully. Terminal is interactive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal WebSocket connections now reliably connect directly to the backend, fixing failures when routing through the dashboard proxy.
  * Create Workspace panel now clears the worktree checkbox when no project is selected, preventing stale UI state.

* **Behavior Changes**
  * Update notice is suppressed for installations using "source" mode.

* **New Features**
  * Project entries now include an optional workspace field for improved workspace handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charannyk06/conductor-oss/pull/496)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->