### PR TITLE
fix: harden config and notes surfaces

### DIFF
--- a/crates/conductor-relay/src/relay.rs
+++ b/crates/conductor-relay/src/relay.rs
@@ -2992,9 +2992,10 @@ fn generate_claim_token() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{LazyLock, Mutex as StdMutex};
+    use std::sync::LazyLock;
 
-    static RELAY_STATE_ENV_LOCK: LazyLock<StdMutex<()>> = LazyLock::new(|| StdMutex::new(()));
+    static RELAY_STATE_ENV_LOCK: LazyLock<tokio::sync::Mutex<()>> =
+        LazyLock::new(|| tokio::sync::Mutex::new(()));
     use axum::extract::ws::Message;
     use tokio::sync::mpsc;
 
@@ -3761,7 +3762,7 @@ mod tests {
 
     #[tokio::test]
     async fn persisted_device_state_round_trips() {
-        let _guard = RELAY_STATE_ENV_LOCK.lock().unwrap();
+        let _guard = RELAY_STATE_ENV_LOCK.lock().await;
         let path =
             std::env::temp_dir().join(format!("conductor-relay-state-{}.json", Uuid::new_v4()));
         unsafe {

--- a/crates/conductor-server/src/mcp.rs
+++ b/crates/conductor-server/src/mcp.rs
@@ -11,7 +11,7 @@ use crate::dispatcher_task_lifecycle::{
     DispatcherTaskUpdateInput,
 };
 use crate::routes::boards::{load_board_response, resolve_board_task_record, split_task_text};
-use crate::state::{AppState, SessionRecord, SpawnRequest};
+use crate::state::{repo_url_without_credentials, AppState, SessionRecord, SpawnRequest};
 
 const MCP_SERVER_NAME: &str = "conductor";
 const MCP_SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -208,7 +208,7 @@ impl McpBackend for AppStateMcpBackend {
             .map(|(id, project)| McpProjectSummary {
                 id,
                 name: project.name,
-                repo: project.repo,
+                repo: repo_url_without_credentials(project.repo.as_deref()),
                 path: project.path,
                 default_branch: project.default_branch,
                 agent: project.agent,

--- a/crates/conductor-server/src/routes/boards.rs
+++ b/crates/conductor-server/src/routes/boards.rs
@@ -16,7 +16,7 @@ use crate::dispatcher_task_lifecycle::{
     DispatcherTaskMutationContext, DispatcherTaskUpdateInput,
 };
 use crate::routes::config::resolve_access_identity;
-use crate::state::{resolve_board_file, AppState};
+use crate::state::{repo_url_without_credentials, resolve_board_file, AppState};
 use crate::task_context::ensure_task_brief;
 
 type ApiResponse = (StatusCode, Json<Value>);
@@ -567,7 +567,7 @@ pub(crate) async fn load_board_response(
 
     Ok(json!({
         "projectId": project_id,
-        "repository": project.repo.clone(),
+        "repository": repo_url_without_credentials(project.repo.as_deref()),
         "boardPath": board_path_display,
         "workspacePath": state.workspace_path.to_string_lossy().to_string(),
         "columns": columns,

--- a/crates/conductor-server/src/routes/project_notes.rs
+++ b/crates/conductor-server/src/routes/project_notes.rs
@@ -76,7 +76,6 @@ struct OpenProjectNoteBody {
 
 #[derive(Debug, Clone)]
 struct ProjectNotesContext {
-    workspace_root: PathBuf,
     project_root: PathBuf,
     project_workspace_root: Option<PathBuf>,
     board_path: Option<PathBuf>,
@@ -283,10 +282,18 @@ async fn resolve_project_notes_context(
     let notes_root = resolve_notes_root(
         &state.workspace_path,
         &config.preferences.markdown_editor_path,
-    );
+    )
+    .filter(|root| {
+        project_scoped_note_roots(
+            &project_root,
+            project_workspace_root.as_deref(),
+            board_parent.as_deref(),
+        )
+        .iter()
+        .any(|scoped_root| path_is_within_root(root, scoped_root, false))
+    });
 
     Ok(ProjectNotesContext {
-        workspace_root: state.workspace_path.clone(),
         project_root,
         project_workspace_root,
         board_path: Some(board_path),
@@ -583,18 +590,29 @@ fn path_within_allowed_note_roots(
 }
 
 fn allowed_note_roots(context: &ProjectNotesContext) -> Vec<PathBuf> {
-    let mut roots = Vec::new();
     if let Some(notes_root) = context.notes_root.as_ref() {
-        roots.push(notes_root.clone());
-    } else {
-        if let Some(project_workspace_root) = context.project_workspace_root.as_ref() {
-            roots.push(project_workspace_root.clone());
-        }
-        roots.push(context.project_root.clone());
-        if let Some(board_parent) = context.board_parent.as_ref() {
-            roots.push(board_parent.clone());
-        }
-        roots.push(context.workspace_root.clone());
+        return vec![notes_root.clone()];
+    }
+
+    project_scoped_note_roots(
+        &context.project_root,
+        context.project_workspace_root.as_deref(),
+        context.board_parent.as_deref(),
+    )
+}
+
+fn project_scoped_note_roots(
+    project_root: &Path,
+    project_workspace_root: Option<&Path>,
+    board_parent: Option<&Path>,
+) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Some(project_workspace_root) = project_workspace_root {
+        roots.push(project_workspace_root.to_path_buf());
+    }
+    roots.push(project_root.to_path_buf());
+    if let Some(board_parent) = board_parent {
+        roots.push(board_parent.to_path_buf());
     }
 
     let mut seen = HashSet::new();
@@ -1263,9 +1281,13 @@ fn resolve_wikilink_target(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_obsidian_open_uri, canonicalize_for_write_target, is_markdown_like,
-        markdown_source_label,
+        build_obsidian_open_uri, canonicalize_for_write_target, collect_indexed_note_files,
+        is_markdown_like, markdown_source_label, resolve_project_notes_context,
     };
+    use crate::state::AppState;
+    use conductor_core::config::{ConductorConfig, PreferencesConfig, ProjectConfig};
+    use conductor_db::Database;
+    use std::collections::BTreeMap;
     use std::fs;
 
     #[test]
@@ -1280,6 +1302,68 @@ mod tests {
         assert!(is_markdown_like(std::path::Path::new("notes/design.md")));
         assert!(is_markdown_like(std::path::Path::new("notes/summary.mdx")));
         assert!(!is_markdown_like(std::path::Path::new("notes/design.ts")));
+    }
+
+    #[tokio::test]
+    async fn project_notes_ignore_configured_root_from_another_project() {
+        let root = std::env::temp_dir().join(format!(
+            "conductor-project-notes-isolation-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let conductor_root = root.join("projects").join("conductor-oss");
+        let solar_root = root.join("projects").join("solar-copilot");
+        fs::create_dir_all(&conductor_root).unwrap();
+        fs::create_dir_all(&solar_root).unwrap();
+        fs::write(conductor_root.join("CONDUCTOR.md"), "# Conductor\n").unwrap();
+        fs::write(conductor_root.join("roadmap.md"), "# Roadmap\n").unwrap();
+        fs::write(solar_root.join("private-solar-note.md"), "# Solar\n").unwrap();
+
+        let config = ConductorConfig {
+            workspace: root.clone(),
+            preferences: PreferencesConfig {
+                markdown_editor: "obsidian".to_string(),
+                markdown_editor_path: solar_root.to_string_lossy().to_string(),
+                ..PreferencesConfig::default()
+            },
+            projects: BTreeMap::from([
+                (
+                    "conductor-oss".to_string(),
+                    ProjectConfig {
+                        path: conductor_root.to_string_lossy().to_string(),
+                        ..ProjectConfig::default()
+                    },
+                ),
+                (
+                    "solar-copilot".to_string(),
+                    ProjectConfig {
+                        path: solar_root.to_string_lossy().to_string(),
+                        ..ProjectConfig::default()
+                    },
+                ),
+            ]),
+            ..ConductorConfig::default()
+        };
+        let db = Database::in_memory()
+            .await
+            .expect("in-memory db should open");
+        let state = AppState::new(root.join("conductor.yaml"), config, db).await;
+
+        let context = resolve_project_notes_context(&state, "conductor-oss")
+            .await
+            .expect("project notes context should resolve");
+        assert_ne!(context.notes_root.as_deref(), Some(solar_root.as_path()));
+
+        let files = collect_indexed_note_files(&context);
+        let joined = files
+            .iter()
+            .filter_map(|file| file["path"].as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(joined.contains("roadmap.md"));
+        assert!(!joined.contains("private-solar-note.md"));
+        assert!(!joined.contains("solar-copilot"));
+
+        fs::remove_dir_all(&root).unwrap();
     }
 
     #[test]

--- a/crates/conductor-server/src/routes/project_notes.rs
+++ b/crates/conductor-server/src/routes/project_notes.rs
@@ -282,15 +282,32 @@ async fn resolve_project_notes_context(
     let notes_root = resolve_notes_root(
         &state.workspace_path,
         &config.preferences.markdown_editor_path,
-    )
-    .filter(|root| {
-        project_scoped_note_roots(
+    );
+    let notes_root = notes_root.and_then(|root| {
+        let scoped_roots = project_scoped_note_roots(
             &project_root,
             project_workspace_root.as_deref(),
             board_parent.as_deref(),
-        )
-        .iter()
-        .any(|scoped_root| path_is_within_root(root, scoped_root, false))
+        );
+        if scoped_roots
+            .iter()
+            .any(|scoped_root| path_is_within_root(&root, scoped_root, false))
+        {
+            Some(root)
+        } else {
+            let scoped_roots_display = scoped_roots
+                .iter()
+                .map(|scoped_root| scoped_root.to_string_lossy().to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            tracing::warn!(
+                project_id = trimmed_project_id,
+                configured_root = %root.display(),
+                scoped_roots = %scoped_roots_display,
+                "Ignoring markdown_editor_path because it falls outside the project-scoped note roots"
+            );
+            None
+        }
     });
 
     Ok(ProjectNotesContext {

--- a/crates/conductor-server/src/routes/projects.rs
+++ b/crates/conductor-server/src/routes/projects.rs
@@ -9,7 +9,7 @@ use std::path::Path as FsPath;
 use std::sync::Arc;
 use tokio::process::Command;
 
-use crate::state::{resolve_board_file, AppState};
+use crate::state::{redact_repo_url_credentials, resolve_board_file, AppState};
 use conductor_core::config::ProjectConfig;
 use conductor_core::support::{
     resolve_project_path, sync_project_local_config, sync_support_files_for_directory,
@@ -101,7 +101,7 @@ fn config_project_response(
     let name = project
         .name
         .clone()
-        .or_else(|| project.repo.clone())
+        .or_else(|| project.repo.as_deref().map(redact_repo_url_credentials))
         .unwrap_or_else(|| id.to_string());
     let board_dir = project.board_dir.as_deref().unwrap_or(id);
     let board_path = Some(resolve_board_file(

--- a/crates/conductor-server/src/routes/repositories.rs
+++ b/crates/conductor-server/src/routes/repositories.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use crate::state::AppState;
+use crate::state::{repo_url_without_credentials, AppState};
 
 type ApiResponse = (StatusCode, Json<Value>);
 
@@ -224,7 +224,7 @@ fn repository_payload(
     json!({
         "id": id,
         "displayName": project.name.clone().unwrap_or_else(|| id.to_string()),
-        "repo": project.repo.clone().unwrap_or_else(|| id.to_string()),
+        "repo": repo_url_without_credentials(project.repo.as_deref()).unwrap_or_else(|| id.to_string()),
         "path": resolved_path.to_string_lossy().to_string(),
         "agent": project.agent.clone().unwrap_or_else(|| default_agent.to_string()),
         "agentPermissions": project.agent_config.permissions.clone().unwrap_or_else(|| "skip".to_string()),

--- a/crates/conductor-server/src/routes/workspaces.rs
+++ b/crates/conductor-server/src/routes/workspaces.rs
@@ -15,7 +15,7 @@ use tokio::process::Command;
 use tracing::info;
 
 use crate::routes::filesystem::{allowed_browse_roots, expand_path, resolve_browse_path};
-use crate::state::AppState;
+use crate::state::{repo_url_without_credentials, AppState};
 
 type ApiResponse = (StatusCode, Json<Value>);
 
@@ -81,7 +81,7 @@ async fn list_workspaces(State(state): State<Arc<AppState>>) -> ApiResponse {
             json!({
                 "id": id,
                 "name": project.name.clone().unwrap_or_else(|| id.to_string()),
-                "repo": project.repo.clone(),
+                "repo": repo_url_without_credentials(project.repo.as_deref()),
                 "workspace": project.workspace.clone().unwrap_or_else(|| "worktree".to_string()),
                 "runtime": project.runtime.clone().unwrap_or_else(|| "ttyd".to_string()),
                 "path": resolve_path(&state.workspace_path, &project.path).to_string_lossy().to_string(),

--- a/crates/conductor-server/src/state/mod.rs
+++ b/crates/conductor-server/src/state/mod.rs
@@ -79,6 +79,7 @@ use terminal_hosts::TerminalHostRegistry;
 use tokio::fs::OpenOptions;
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt, SeekFrom};
 use tokio::sync::{broadcast, mpsc, oneshot, Mutex, Notify, RwLock};
+use url::Url;
 
 pub(crate) struct DevServerRecord {
     pub pid: u32,
@@ -118,6 +119,27 @@ const TERMINAL_CAPTURE_BUFFER_CAPACITY: usize = 64 * 1024;
 const TERMINAL_CAPTURE_FLUSH_INTERVAL: Duration = Duration::from_millis(32);
 const TERMINAL_CAPTURE_FORCE_FLUSH_BYTES: usize = 64 * 1024;
 const TERMINAL_RESTORE_PERSIST_INTERVAL: Duration = Duration::from_millis(250);
+
+pub(crate) fn repo_url_without_credentials(repo: Option<&str>) -> Option<String> {
+    repo.map(redact_repo_url_credentials)
+}
+
+pub(crate) fn redact_repo_url_credentials(repo: &str) -> String {
+    let trimmed = repo.trim();
+    let Ok(mut url) = Url::parse(trimmed) else {
+        return trimmed.to_string();
+    };
+
+    if matches!(url.scheme(), "http" | "https")
+        && (!url.username().is_empty() || url.password().is_some())
+    {
+        let _ = url.set_username("");
+        let _ = url.set_password(None);
+        return url.to_string();
+    }
+
+    trimmed.to_string()
+}
 const TERMINAL_RESTORE_FORCE_SEQUENCE_DELTA: u64 = 24;
 const TERMINAL_HOST_MAINTENANCE_INTERVAL: Duration = Duration::from_millis(500);
 const TERMINAL_HOST_IDLE_EVICTION_TTL: Duration = Duration::from_secs(45);
@@ -1315,7 +1337,7 @@ impl AppState {
                 let board_dir = project.board_dir.clone().unwrap_or_else(|| id.clone());
                 json!({
                     "id": id,
-                    "repo": project.repo,
+                    "repo": repo_url_without_credentials(project.repo.as_deref()),
                     "path": expand_path(&project.path, &workspace_path).to_string_lossy().to_string(),
                     "iconUrl": project.icon_url,
                     "boardDir": board_dir,
@@ -1348,6 +1370,74 @@ mod tests {
 
     fn contains_arg(args: &[String], needle: &str) -> bool {
         args.iter().any(|arg| arg.contains(needle))
+    }
+
+    #[tokio::test]
+    async fn config_projects_payload_redacts_repo_url_credentials() {
+        let root = std::env::temp_dir().join(format!("conductor-state-test-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&root).expect("test root should exist");
+        let github_host = "github.com";
+        let basic_repo = format!("https://{}@{github_host}/acme/basic.git", "user:password");
+        let token_prefix = "ghp_";
+        let token_value = format!("{token_prefix}{}", "exampletoken");
+        let token_repo = format!("https://{token_value}@{github_host}/acme/widgets.git");
+
+        let config = ConductorConfig {
+            workspace: root.clone(),
+            projects: BTreeMap::from([
+                (
+                    "basic".to_string(),
+                    ProjectConfig {
+                        repo: Some(basic_repo.clone()),
+                        path: "basic".to_string(),
+                        ..ProjectConfig::default()
+                    },
+                ),
+                (
+                    "pat".to_string(),
+                    ProjectConfig {
+                        repo: Some(token_repo.clone()),
+                        path: "widgets".to_string(),
+                        ..ProjectConfig::default()
+                    },
+                ),
+                (
+                    "ssh".to_string(),
+                    ProjectConfig {
+                        repo: Some("git@github.com:acme/safe.git".to_string()),
+                        path: "safe".to_string(),
+                        ..ProjectConfig::default()
+                    },
+                ),
+            ]),
+            ..ConductorConfig::default()
+        };
+        let config_path = root.join("conductor.yaml");
+        let db = Database::in_memory()
+            .await
+            .expect("in-memory db should open");
+        let state = AppState::new(config_path, config.clone(), db).await;
+
+        let payload = state.config_projects_payload(&config);
+        let projects = payload["projects"]
+            .as_array()
+            .expect("projects should be an array");
+        let repo_for = |id: &str| -> &str {
+            projects
+                .iter()
+                .find(|project| project["id"] == id)
+                .and_then(|project| project["repo"].as_str())
+                .expect("project repo should be present")
+        };
+
+        assert_eq!(repo_for("basic"), "https://github.com/acme/basic.git");
+        assert_eq!(repo_for("pat"), "https://github.com/acme/widgets.git");
+        assert_eq!(repo_for("ssh"), "git@github.com:acme/safe.git");
+        let payload_text = payload.to_string();
+        assert!(!payload_text.contains("password"));
+        assert!(!payload_text.contains(&token_value));
+
+        std::fs::remove_dir_all(&root).expect("test root should be removed");
     }
 
     #[tokio::test]

--- a/crates/conductor-server/src/state/mod.rs
+++ b/crates/conductor-server/src/state/mod.rs
@@ -130,9 +130,7 @@ pub(crate) fn redact_repo_url_credentials(repo: &str) -> String {
         return trimmed.to_string();
     };
 
-    if matches!(url.scheme(), "http" | "https")
-        && (!url.username().is_empty() || url.password().is_some())
-    {
+    if !url.username().is_empty() || url.password().is_some() {
         let _ = url.set_username("");
         let _ = url.set_password(None);
         return url.to_string();
@@ -1378,6 +1376,7 @@ mod tests {
         std::fs::create_dir_all(&root).expect("test root should exist");
         let github_host = "github.com";
         let basic_repo = format!("https://{}@{github_host}/acme/basic.git", "user:password");
+        let ssh_url_repo = format!("ssh://{}@{github_host}/acme/ssh.git", "user:password");
         let token_prefix = "ghp_";
         let token_value = format!("{token_prefix}{}", "exampletoken");
         let token_repo = format!("https://{token_value}@{github_host}/acme/widgets.git");
@@ -1409,6 +1408,14 @@ mod tests {
                         ..ProjectConfig::default()
                     },
                 ),
+                (
+                    "ssh-url".to_string(),
+                    ProjectConfig {
+                        repo: Some(ssh_url_repo.clone()),
+                        path: "ssh-url".to_string(),
+                        ..ProjectConfig::default()
+                    },
+                ),
             ]),
             ..ConductorConfig::default()
         };
@@ -1433,6 +1440,7 @@ mod tests {
         assert_eq!(repo_for("basic"), "https://github.com/acme/basic.git");
         assert_eq!(repo_for("pat"), "https://github.com/acme/widgets.git");
         assert_eq!(repo_for("ssh"), "git@github.com:acme/safe.git");
+        assert_eq!(repo_for("ssh-url"), "ssh://github.com/acme/ssh.git");
         let payload_text = payload.to_string();
         assert!(!payload_text.contains("password"));
         assert!(!payload_text.contains(&token_value));

--- a/packages/web/src/components/bridge/BridgeStatusPill.test.ts
+++ b/packages/web/src/components/bridge/BridgeStatusPill.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { bridgeStatusBadgeLabel } from "@/lib/bridgeStatusLabel";
+
+test("bridge status label distinguishes local dashboard from bridge availability", () => {
+  assert.equal(
+    bridgeStatusBadgeLabel({ relayConfigured: false, connectedDevices: 0, totalDevices: 0, loading: false }),
+    "Local backend",
+  );
+  assert.equal(
+    bridgeStatusBadgeLabel({ relayConfigured: true, connectedDevices: 0, totalDevices: 0, loading: false }),
+    "No bridge",
+  );
+  assert.equal(
+    bridgeStatusBadgeLabel({ relayConfigured: true, connectedDevices: 0, totalDevices: 2, loading: false }),
+    "Bridge offline",
+  );
+  assert.equal(
+    bridgeStatusBadgeLabel({ relayConfigured: true, connectedDevices: 1, totalDevices: 2, loading: false }),
+    "Online",
+  );
+});

--- a/packages/web/src/components/bridge/BridgeStatusPill.test.ts
+++ b/packages/web/src/components/bridge/BridgeStatusPill.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { bridgeStatusBadgeLabel } from "@/lib/bridgeStatusLabel";
+import { bridgeStatusBadgeLabel, bridgeStatusTone } from "@/lib/bridgeStatusLabel";
 
 test("bridge status label distinguishes local dashboard from bridge availability", () => {
   assert.equal(
@@ -18,5 +18,32 @@ test("bridge status label distinguishes local dashboard from bridge availability
   assert.equal(
     bridgeStatusBadgeLabel({ relayConfigured: true, connectedDevices: 1, totalDevices: 2, loading: false }),
     "Online",
+  );
+  assert.equal(
+    bridgeStatusBadgeLabel({ relayConfigured: true, connectedDevices: 0, totalDevices: 2, loading: true }),
+    "Checking",
+  );
+});
+
+test("bridge status tone matches connectivity and relay state", () => {
+  assert.equal(
+    bridgeStatusTone({ relayConfigured: false, connectedDevices: 0, totalDevices: 0, loading: false }),
+    "neutral",
+  );
+  assert.equal(
+    bridgeStatusTone({ relayConfigured: true, connectedDevices: 0, totalDevices: 0, loading: false }),
+    "neutral",
+  );
+  assert.equal(
+    bridgeStatusTone({ relayConfigured: true, connectedDevices: 0, totalDevices: 2, loading: false }),
+    "offline",
+  );
+  assert.equal(
+    bridgeStatusTone({ relayConfigured: true, connectedDevices: 1, totalDevices: 2, loading: false }),
+    "online",
+  );
+  assert.equal(
+    bridgeStatusTone({ relayConfigured: true, connectedDevices: 0, totalDevices: 2, loading: true }),
+    "neutral",
   );
 });

--- a/packages/web/src/components/bridge/BridgeStatusPill.tsx
+++ b/packages/web/src/components/bridge/BridgeStatusPill.tsx
@@ -27,6 +27,12 @@ import {
 } from "@/lib/bridgeOnboarding";
 import { formatBridgeVersionSuffix, normalizeBridgeDevices } from "@/lib/bridgeDevices";
 import { resolveBridgeRelayUrl } from "@/lib/bridgeRelayUrl";
+import {
+  bridgeStatusBadgeLabel,
+  bridgeStatusTone,
+  type BridgeStatusBadgeLabelInput,
+  type BridgeStatusTone,
+} from "@/lib/bridgeStatusLabel";
 
 type BridgeDevice = {
   device_id: string;
@@ -63,34 +69,54 @@ type BridgeStatusPillProps = {
 
 const BRIDGE_CONNECT_PATH = "/bridge/connect";
 
+function bridgeStatusToneClasses(tone: BridgeStatusTone) {
+  if (tone === "online") {
+    return {
+      pill: "border-[rgba(24,197,143,0.35)] bg-[rgba(24,197,143,0.12)] text-[var(--vk-green)]",
+      dot: "bg-[var(--vk-green)]",
+    };
+  }
+  if (tone === "neutral") {
+    return {
+      pill: "border-[var(--vk-border)] bg-[rgba(255,255,255,0.04)] text-[var(--vk-text-muted)]",
+      dot: "bg-[var(--vk-text-muted)]",
+    };
+  }
+  return {
+    pill: "border-[rgba(255,143,122,0.24)] bg-[rgba(255,143,122,0.08)] text-[var(--vk-red)]",
+    dot: "bg-[var(--vk-red)]",
+  };
+}
+
 function StatusBadge({
-  connected,
+  label,
+  tone,
   className,
   title,
   suffix,
 }: {
-  connected: boolean;
+  label: string;
+  tone: BridgeStatusTone;
   className?: string;
   title?: string;
   suffix?: ReactNode;
 }) {
+  const toneClasses = bridgeStatusToneClasses(tone);
   return (
     <span
       className={cn(
         "inline-flex items-center gap-2 rounded-full border px-2.5 py-1 text-[12px] font-medium",
-        connected
-          ? "border-[rgba(24,197,143,0.35)] bg-[rgba(24,197,143,0.12)] text-[var(--vk-green)]"
-          : "border-[rgba(255,143,122,0.24)] bg-[rgba(255,143,122,0.08)] text-[var(--vk-red)]",
+        toneClasses.pill,
         className,
       )}
       title={title}
     >
       <span className={cn(
         "h-2.5 w-2.5 rounded-full",
-        connected ? "bg-[var(--vk-green)]" : "bg-[var(--vk-red)]",
+        toneClasses.dot,
       )}
       />
-      <span>{connected ? "Online" : "Offline"}</span>
+      <span>{label}</span>
       {suffix}
     </span>
   );
@@ -216,7 +242,7 @@ function BridgeStatusDropdown({ className }: { className?: string }) {
   const selectedBridgeDevice = selectedBridgeId
     ? devices.find((device) => device.device_id === selectedBridgeId) ?? null
     : null;
-  const shouldLinkToDeviceScreen = !loading && connectedDevices.length === 0;
+  const shouldLinkToDeviceScreen = relayConfigured && !loading && connectedDevices.length === 0;
   const recentPairingDevice = recentPairingDeviceId
     ? devices.find((device) => device.device_id === recentPairingDeviceId) ?? null
     : null;
@@ -230,8 +256,16 @@ function BridgeStatusDropdown({ className }: { className?: string }) {
           : BRIDGE_CONNECT_PATH
     : BRIDGE_CONNECT_PATH;
   const connected = connectedDevices.length > 0;
+  const statusInput = {
+    relayConfigured,
+    connectedDevices: connectedDevices.length,
+    totalDevices: devices.length,
+    loading,
+  } satisfies BridgeStatusBadgeLabelInput;
+  const badgeLabel = bridgeStatusBadgeLabel(statusInput);
+  const badgeTone = bridgeStatusTone(statusInput);
   const title = !relayConfigured
-    ? relayUnavailableReason ?? "Bridge relay URL is not configured"
+    ? "Local backend is running. Paired-device bridge relay is not configured."
     : error
     ?? (connected
       ? `${connectedDevices.length} bridge${connectedDevices.length === 1 ? "" : "s"} online`
@@ -347,7 +381,8 @@ function BridgeStatusDropdown({ className }: { className?: string }) {
         title={devices.length > 0 ? "Reconnect paired device" : "Pair a device"}
       >
         <StatusBadge
-          connected={false}
+          label={badgeLabel}
+          tone={badgeTone}
           className={className}
           title={devices.length > 0 ? "Reconnect paired device" : "Pair a device"}
           suffix={<ArrowUpRight className="h-3.5 w-3.5" />}
@@ -361,7 +396,8 @@ function BridgeStatusDropdown({ className }: { className?: string }) {
       <DropdownMenu.Trigger asChild>
         <button type="button" className="outline-none">
           <StatusBadge
-            connected={connected}
+            label={badgeLabel}
+            tone={badgeTone}
             className={className}
             title={title}
             suffix={<ChevronDown className="h-3.5 w-3.5 text-current/70" />}
@@ -381,7 +417,9 @@ function BridgeStatusDropdown({ className }: { className?: string }) {
             <div className="mt-2 text-[13px] text-[var(--vk-text-normal)]">
               {connected
                 ? `${connectedDevices.length} device${connectedDevices.length === 1 ? "" : "s"} online`
-                : loading
+                : !relayConfigured
+                  ? "Local backend is healthy. Paired-device relay is not configured."
+                  : loading
                   ? "Loading device status"
                   : "No live bridge connection"}
             </div>
@@ -531,7 +569,10 @@ function BridgeStatusDropdown({ className }: { className?: string }) {
                           </div>
                         ) : null}
                       </div>
-                      <StatusBadge connected={device.connected === true} />
+                      <StatusBadge
+                        label={device.connected === true ? "Online" : "Offline"}
+                        tone={device.connected === true ? "online" : "offline"}
+                      />
                     </div>
                   </div>
                 );
@@ -562,7 +603,14 @@ function BridgeStatusDropdown({ className }: { className?: string }) {
 
 export function BridgeStatusPill({ connected, className, title }: BridgeStatusPillProps = {}) {
   if (typeof connected === "boolean") {
-    return <StatusBadge connected={connected} className={className} title={title} />;
+    return (
+      <StatusBadge
+        label={connected ? "Online" : "Offline"}
+        tone={connected ? "online" : "offline"}
+        className={className}
+        title={title}
+      />
+    );
   }
 
   return <BridgeStatusDropdown className={className} />;

--- a/packages/web/src/components/layout/AppUpdateNotice.test.ts
+++ b/packages/web/src/components/layout/AppUpdateNotice.test.ts
@@ -4,7 +4,7 @@ import test from "node:test";
 import { noticeTitle } from "./AppUpdateNotice";
 import type { AppUpdateStatus } from "@/lib/types";
 
-test("noticeTitle includes the installed build version when already up to date", () => {
+test("noticeTitle labels package versions explicitly when already up to date", () => {
   const status = {
     enabled: true,
     reason: null,
@@ -14,10 +14,10 @@ test("noticeTitle includes the installed build version when already up to date",
     latestVersion: null,
   } as AppUpdateStatus;
 
-  assert.equal(noticeTitle(status), "Conductor update available (build 0.3.4)");
+  assert.equal(noticeTitle(status), "Conductor package is up to date (installed package 0.3.4)");
 });
 
-test("noticeTitle includes the installed build version alongside an available release", () => {
+test("noticeTitle labels package versions explicitly alongside an available release", () => {
   const status = {
     enabled: true,
     reason: null,
@@ -27,7 +27,7 @@ test("noticeTitle includes the installed build version alongside an available re
     latestVersion: "0.3.5",
   } as AppUpdateStatus;
 
-  assert.equal(noticeTitle(status), "Conductor 0.3.5 is available (build 0.3.4)");
+  assert.equal(noticeTitle(status), "Conductor package 0.3.5 is available (installed package 0.3.4)");
 });
 
 test("mobile update notice collapses into a compact card instead of covering the whole workspace", () => {

--- a/packages/web/src/components/layout/AppUpdateNotice.tsx
+++ b/packages/web/src/components/layout/AppUpdateNotice.tsx
@@ -23,24 +23,27 @@ function installModeHint(mode: AppInstallMode): string | null {
   }
 }
 
-function formatBuildVersionSuffix(update: AppUpdateStatus): string {
+function formatInstalledPackageVersionSuffix(update: AppUpdateStatus): string {
   const version = update.currentVersion?.trim();
-  return version ? ` (build ${version})` : "";
+  return version ? ` (installed package ${version})` : "";
 }
 
 export function noticeTitle(update: AppUpdateStatus): string {
-  const buildVersionSuffix = formatBuildVersionSuffix(update);
+  const installedPackageVersionSuffix = formatInstalledPackageVersionSuffix(update);
 
   if (!update.enabled && update.reason) {
-    return `Conductor update unavailable${buildVersionSuffix}`;
+    return `Conductor package update unavailable${installedPackageVersionSuffix}`;
   }
-  if (update.restarting) return `Restarting Conductor${buildVersionSuffix}`;
-  if (update.jobStatus === "running") return `Updating Conductor${buildVersionSuffix}`;
-  if (update.jobStatus === "completed") return `Conductor updated${buildVersionSuffix}`;
-  if (update.jobStatus === "failed") return `Update failed${buildVersionSuffix}`;
+  if (update.restarting) return `Restarting Conductor${installedPackageVersionSuffix}`;
+  if (update.jobStatus === "running") return `Updating Conductor package${installedPackageVersionSuffix}`;
+  if (update.jobStatus === "completed") return `Conductor package updated${installedPackageVersionSuffix}`;
+  if (update.jobStatus === "failed") return `Package update failed${installedPackageVersionSuffix}`;
+  if (!update.updateAvailable && !update.latestVersion) {
+    return `Conductor package is up to date${installedPackageVersionSuffix}`;
+  }
   return update.latestVersion
-    ? `Conductor ${update.latestVersion} is available${buildVersionSuffix}`
-    : `Conductor update available${buildVersionSuffix}`;
+    ? `Conductor package ${update.latestVersion} is available${installedPackageVersionSuffix}`
+    : `Conductor package update available${installedPackageVersionSuffix}`;
 }
 
 function noticeDescription(update: AppUpdateStatus): string {
@@ -60,7 +63,9 @@ function noticeDescription(update: AppUpdateStatus): string {
     return update.jobMessage ?? "The update command did not finish successfully.";
   }
 
-  const currentVersion = update.currentVersion ? `You are running ${update.currentVersion}. ` : "";
+  const currentVersion = update.currentVersion
+    ? `Installed Conductor package: ${update.currentVersion}. `
+    : "";
   if (update.canAutoUpdate) {
     return `${currentVersion}Install the new release now and restart when it finishes.`;
   }

--- a/packages/web/src/lib/bridgeStatusLabel.ts
+++ b/packages/web/src/lib/bridgeStatusLabel.ts
@@ -1,0 +1,22 @@
+export type BridgeStatusTone = "online" | "neutral" | "offline";
+
+export type BridgeStatusBadgeLabelInput = {
+  relayConfigured: boolean;
+  connectedDevices: number;
+  totalDevices: number;
+  loading: boolean;
+};
+
+export function bridgeStatusBadgeLabel(input: BridgeStatusBadgeLabelInput): string {
+  if (input.connectedDevices > 0) return "Online";
+  if (!input.relayConfigured) return "Local backend";
+  if (input.loading) return "Checking";
+  if (input.totalDevices === 0) return "No bridge";
+  return "Bridge offline";
+}
+
+export function bridgeStatusTone(input: BridgeStatusBadgeLabelInput): BridgeStatusTone {
+  if (input.connectedDevices > 0) return "online";
+  if (!input.relayConfigured || input.totalDevices === 0 || input.loading) return "neutral";
+  return "offline";
+}


### PR DESCRIPTION
## Summary

Fixes the Conductor OSS QA findings around credential exposure, project notes isolation, relay clippy warnings, bridge status wording, and update version labels.

## User-Facing Release Notes

- Prevented repository credentials from appearing in dashboard and API project payloads.
- Fixed project notes so one workspace cannot accidentally show another project's Obsidian root.
- Clarified local backend, bridge, and Conductor package update labels in the dashboard.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Plugin addition / modification
- [ ] Documentation update
- [ ] Refactor / chore

## Testing

- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `bun run typecheck`
- `bun run test:packages`
- `bun run build`
- `bun run --cwd packages/cli typecheck && bun run --cwd packages/cli test`
- Runtime API smoke checked `/api/config`, `/api/repositories`, `/api/projects`, and `/api/project-notes?projectId=conductor-oss` with a credentialed test repo URL and cross-project notes root.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced bridge status indicators with improved labeling and visual distinction based on relay configuration and device connectivity.
  * Refined app update notice messaging for clarity on installed package versions.

* **Bug Fixes**
  * Repository URLs displayed in API responses no longer expose embedded credentials.
  * Strengthened project notes isolation to prevent cross-project access.

* **Tests**
  * Added coverage for bridge status labeling and project notes security boundaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/charannyk06/conductor-oss/pull/500)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->