### PR TITLE
fix: reduce dispatcher feed churn

### DIFF
--- a/crates/conductor-server/src/routes/dispatcher.rs
+++ b/crates/conductor-server/src/routes/dispatcher.rs
@@ -5,8 +5,11 @@ use axum::routing::{get, patch, post};
 use axum::{Json, Router};
 use serde::Deserialize;
 use serde_json::{json, Value};
+use std::collections::hash_map::DefaultHasher;
 use std::convert::Infallible;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::Mutex;
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::{self as stream, StreamExt};
@@ -26,6 +29,7 @@ type ApiResponse = (StatusCode, Json<Value>);
 
 const DEFAULT_FEED_WINDOW_LIMIT: usize = 120;
 const MAX_FEED_WINDOW_LIMIT: usize = 240;
+const DISPATCHER_FEED_KEEP_ALIVE_INTERVAL_SECS: u64 = 15;
 const DISPATCHER_APPROVAL_STATE_METADATA_KEY: &str = "acpPlanApprovalState";
 const DISPATCHER_APPROVAL_REQUIRED: &str = "approval_required";
 const DISPATCHER_APPROVAL_PARSER_STATE_KEY: &str = "parserState";
@@ -866,6 +870,15 @@ fn streaming_tail_patch(previous_entries: &[Value], next_entries: &[Value]) -> O
         .iter()
         .take(shared_prefix_len)
         .zip(next_entries.iter().take(shared_prefix_len))
+        .all(|(left, right)| feed_entry_patch_signature(left) == feed_entry_patch_signature(right))
+    {
+        return None;
+    }
+
+    if !previous_entries
+        .iter()
+        .take(shared_prefix_len)
+        .zip(next_entries.iter().take(shared_prefix_len))
         .all(|(left, right)| left == right)
     {
         return None;
@@ -915,6 +928,27 @@ fn streaming_tail_patch(previous_entries: &[Value], next_entries: &[Value]) -> O
         "entry": next_last,
         "textDelta": text_delta,
     }))
+}
+
+fn feed_entry_patch_signature(entry: &Value) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    entry.get("id").and_then(Value::as_str).hash(&mut hasher);
+    entry.get("kind").and_then(Value::as_str).hash(&mut hasher);
+    entry
+        .get("source")
+        .and_then(Value::as_str)
+        .hash(&mut hasher);
+    entry
+        .get("streaming")
+        .and_then(Value::as_bool)
+        .hash(&mut hasher);
+    if let Some(text) = entry.get("text").and_then(Value::as_str) {
+        text.len().hash(&mut hasher);
+        text.hash(&mut hasher);
+    } else {
+        0usize.hash(&mut hasher);
+    }
+    hasher.finish()
 }
 
 fn build_feed_delta_event(previous: &Value, next: &Value) -> Value {
@@ -1078,7 +1112,12 @@ async fn feed_stream(
         })
         .filter_map(|item| item);
 
-    Sse::new(initial_stream.chain(updates)).keep_alive(KeepAlive::default())
+    let keep_alive = KeepAlive::new()
+        .interval(Duration::from_secs(
+            DISPATCHER_FEED_KEEP_ALIVE_INTERVAL_SECS,
+        ))
+        .event(SseEvent::default().event("ping").data("ping"));
+    Sse::new(initial_stream.chain(updates)).keep_alive(keep_alive)
 }
 
 async fn send_to_dispatcher(

--- a/crates/conductor-server/src/state/acp_dispatcher.rs
+++ b/crates/conductor-server/src/state/acp_dispatcher.rs
@@ -1100,9 +1100,11 @@ fn append_runtime_assistant_entry(session: &mut SessionRecord, text: &str) -> bo
 
     if let Some(last) = session.conversation.last_mut() {
         if last.kind == "assistant_message" && last.source == "runtime" {
-            merge_assistant_fragment(&mut last.text, normalized);
-            last.created_at = Utc::now().to_rfc3339();
-            return true;
+            if merge_assistant_fragment(&mut last.text, normalized) {
+                last.created_at = Utc::now().to_rfc3339();
+                return true;
+            }
+            return false;
         }
     }
 

--- a/crates/conductor-server/src/state/helpers.rs
+++ b/crates/conductor-server/src/state/helpers.rs
@@ -681,19 +681,19 @@ pub(crate) fn runtime_tool_metadata(line: &str) -> Option<Value> {
     None
 }
 
-pub(crate) fn merge_assistant_fragment(current: &mut String, fragment: &str) {
+pub(crate) fn merge_assistant_fragment(current: &mut String, fragment: &str) -> bool {
     let trimmed = fragment.trim();
     if trimmed.is_empty() {
-        return;
+        return false;
     }
 
     if current.is_empty() {
         current.push_str(trimmed);
-        return;
+        return true;
     }
 
     if current == trimmed || current.ends_with(trimmed) {
-        return;
+        return false;
     }
     // Cap contains check to last 512 bytes to avoid O(n*m) on large buffers.
     let mut tail_start = current.len().saturating_sub(512);
@@ -702,17 +702,18 @@ pub(crate) fn merge_assistant_fragment(current: &mut String, fragment: &str) {
     }
     let check_region = &current[tail_start..];
     if check_region.contains(trimmed) {
-        return;
+        return false;
     }
 
     if trimmed.starts_with(current.as_str()) {
         current.clear();
         current.push_str(trimmed);
-        return;
+        return true;
     }
 
     current.push('\n');
     current.push_str(trimmed);
+    true
 }
 
 fn is_runtime_transport_event_line(line: &str) -> bool {
@@ -1633,6 +1634,20 @@ mod tests {
     fn sanitize_terminal_text_strips_ansi_and_control_sequences() {
         let input = "\u{001b}[90m{\"type\":\"assistant\"}\u{001b}[0m\u{0008}";
         assert_eq!(sanitize_terminal_text(input), "{\"type\":\"assistant\"}");
+    }
+
+    #[test]
+    fn merge_assistant_fragment_reports_whether_text_changed() {
+        let mut current = "Working".to_string();
+
+        assert!(!merge_assistant_fragment(&mut current, "Working"));
+        assert_eq!(current, "Working");
+
+        assert!(merge_assistant_fragment(&mut current, "Working on it"));
+        assert_eq!(current, "Working on it");
+
+        assert!(!merge_assistant_fragment(&mut current, "on it"));
+        assert_eq!(current, "Working on it");
     }
 
     #[test]

--- a/crates/conductor-server/src/state/session_manager.rs
+++ b/crates/conductor-server/src/state/session_manager.rs
@@ -592,8 +592,9 @@ fn append_runtime_assistant_entry(session: &mut SessionRecord, text: &str) {
 
     if let Some(last) = session.conversation.last_mut() {
         if last.kind == "assistant_message" && last.source == "runtime" {
-            merge_assistant_fragment(&mut last.text, normalized);
-            last.created_at = Utc::now().to_rfc3339();
+            if merge_assistant_fragment(&mut last.text, normalized) {
+                last.created_at = Utc::now().to_rfc3339();
+            }
             return;
         }
     }


### PR DESCRIPTION
## User-Facing Release Notes

- Dispatcher chat feeds should feel steadier under fast streaming agents, with fewer redundant updates and lightweight SSE pings.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Summary

- Avoids marking dispatcher assistant feed entries dirty when a duplicate runtime fragment does not change text.
- Adds a cheap signature gate before deeper tail-patch comparison for dispatcher feed streaming deltas.
- Uses a named 15-second SSE ping keepalive for dispatcher feed streams.

## Testing

- `cargo fmt --check`
- `cargo check -p conductor-server`
- `cargo test -p conductor-server merge_assistant_fragment_reports_whether_text_changed -- --nocapture`
- `cargo test -p conductor-server feed_delta_patch_updates_last_streaming_entry -- --nocapture`
- `cargo clippy -p conductor-server -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed assistant message timestamps to update only when content actually changes, not on every merge attempt.
  * Improved detection and handling of duplicate message fragments.

* **Improvements**
  * Enhanced feed streaming stability with periodic keep-alive signals.
  * Optimized patch detection using efficient hashing comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->