### PR TITLE
Fix agent model selection and bridge startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1961,9 +1961,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/bridge-cmd/daemon/daemon.go
+++ b/bridge-cmd/daemon/daemon.go
@@ -19,6 +19,8 @@ import (
 
 var ErrNotPaired = errors.New("bridge is not paired")
 
+const defaultPairingValidationTimeout = 8 * time.Second
+
 type Options struct {
 	RelayURL     string
 	Store        *token.Store
@@ -54,10 +56,7 @@ func Run(ctx context.Context, opts Options) error {
 		}
 		return err
 	}
-	if err := validateSavedPairing(ctx, opts.RelayURL, refreshToken); err != nil {
-		if errors.Is(err, ErrNotPaired) {
-			fmt.Fprintln(stderr, "Saved bridge pairing is invalid or expired. Run 'conductor-bridge connect' again.")
-		}
+	if err := validateSavedPairingBestEffort(ctx, opts.RelayURL, refreshToken, stderr, defaultPairingValidationTimeout); err != nil {
 		return err
 	}
 
@@ -118,6 +117,26 @@ func Run(ctx context.Context, opts Options) error {
 			clientCancel, clientDone = startClient(ctx, opts.RelayURL, currentToken, stderr)
 		}
 	}
+}
+
+func validateSavedPairingBestEffort(ctx context.Context, relayURL string, refreshToken string, stderr io.Writer, timeout time.Duration) error {
+	if timeout <= 0 {
+		timeout = defaultPairingValidationTimeout
+	}
+	validationCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	if err := validateSavedPairing(validationCtx, relayURL, refreshToken); err != nil {
+		if errors.Is(err, ErrNotPaired) {
+			fmt.Fprintln(stderr, "Saved bridge pairing is invalid or expired. Run 'conductor-bridge connect' again.")
+			return err
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		fmt.Fprintf(stderr, "saved bridge pairing validation unavailable; continuing with cached pairing: %v\n", err)
+	}
+	return nil
 }
 
 func validateSavedPairing(ctx context.Context, relayURL string, refreshToken string) error {

--- a/bridge-cmd/daemon/daemon_test.go
+++ b/bridge-cmd/daemon/daemon_test.go
@@ -12,10 +12,13 @@ import (
 )
 
 func TestValidateSavedPairingBestEffortContinuesOnNetworkFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	server.Close()
+
 	var stderr bytes.Buffer
 	err := validateSavedPairingBestEffort(
 		context.Background(),
-		"http://127.0.0.1:1",
+		server.URL,
 		"cached-refresh-token",
 		&stderr,
 		50*time.Millisecond,

--- a/bridge-cmd/daemon/daemon_test.go
+++ b/bridge-cmd/daemon/daemon_test.go
@@ -1,0 +1,51 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidateSavedPairingBestEffortContinuesOnNetworkFailure(t *testing.T) {
+	var stderr bytes.Buffer
+	err := validateSavedPairingBestEffort(
+		context.Background(),
+		"http://127.0.0.1:1",
+		"cached-refresh-token",
+		&stderr,
+		50*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatalf("expected network validation failure to continue, got %v", err)
+	}
+	if !strings.Contains(stderr.String(), "continuing with cached pairing") {
+		t.Fatalf("expected warning about cached pairing, got %q", stderr.String())
+	}
+}
+
+func TestValidateSavedPairingBestEffortStopsOnRejectedPairing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"invalid token"}`, http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	var stderr bytes.Buffer
+	err := validateSavedPairingBestEffort(
+		context.Background(),
+		server.URL,
+		"cached-refresh-token",
+		&stderr,
+		500*time.Millisecond,
+	)
+	if !errors.Is(err, ErrNotPaired) {
+		t.Fatalf("expected ErrNotPaired, got %v", err)
+	}
+	if !strings.Contains(stderr.String(), "invalid or expired") {
+		t.Fatalf("expected invalid pairing warning, got %q", stderr.String())
+	}
+}

--- a/crates/conductor-executors/src/agents/ccr.rs
+++ b/crates/conductor-executors/src/agents/ccr.rs
@@ -14,6 +14,49 @@ pub struct CcrExecutor {
     binary: PathBuf,
 }
 
+fn normalize_ccr_model(model: Option<&str>) -> Option<String> {
+    let value = model.map(str::trim).filter(|value| !value.is_empty())?;
+    let normalized = value.to_ascii_lowercase();
+    match normalized.as_str() {
+        "sonnet" | "sonnet-4" | "claude-sonnet-4" => Some("claude-sonnet-4-6".to_string()),
+        "opus" | "opus-4" | "claude-opus-4" => Some("claude-opus-4-6".to_string()),
+        "haiku" | "haiku-4" | "haiku-4-5" | "claude-haiku-4" => {
+            Some("claude-haiku-4-5".to_string())
+        }
+        model if model.starts_with("claude-") => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn normalize_ccr_reasoning_effort(reasoning_effort: Option<&str>) -> Option<String> {
+    let value = reasoning_effort
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?
+        .to_ascii_lowercase();
+    let normalized = match value.as_str() {
+        "minimal" | "min" | "off" | "none" | "low" => "low",
+        "medium" | "med" => "medium",
+        "high" => "high",
+        "max" | "xhigh" | "extra-high" | "extra_high" | "extra high" => "max",
+        _ => return None,
+    };
+    Some(normalized.to_string())
+}
+
+fn push_ccr_model_arg(args: &mut Vec<String>, model: Option<&str>) {
+    if let Some(model) = normalize_ccr_model(model) {
+        args.push("--model".to_string());
+        args.push(model);
+    }
+}
+
+fn push_ccr_reasoning_arg(args: &mut Vec<String>, reasoning_effort: Option<&str>) {
+    if let Some(reasoning_effort) = normalize_ccr_reasoning_effort(reasoning_effort) {
+        args.push("--effort".to_string());
+        args.push(reasoning_effort);
+    }
+}
+
 impl CcrExecutor {
     pub fn new(binary: PathBuf) -> Self {
         Self { binary }
@@ -82,14 +125,8 @@ impl Executor for CcrExecutor {
                 args.push("--verbose".to_string());
             }
 
-            if let Some(model) = &options.model {
-                args.push("--model".to_string());
-                args.push(model.clone());
-            }
-            if let Some(reasoning_effort) = &options.reasoning_effort {
-                args.push("--effort".to_string());
-                args.push(reasoning_effort.clone());
-            }
+            push_ccr_model_arg(&mut args, options.model.as_deref());
+            push_ccr_reasoning_arg(&mut args, options.reasoning_effort.as_deref());
             if options.skip_permissions {
                 args.push("--dangerously-skip-permissions".to_string());
             }
@@ -115,15 +152,8 @@ impl Executor for CcrExecutor {
             args.push("--dangerously-skip-permissions".to_string());
         }
 
-        if let Some(model) = &options.model {
-            args.push("--model".to_string());
-            args.push(model.clone());
-        }
-
-        if let Some(reasoning_effort) = &options.reasoning_effort {
-            args.push("--effort".to_string());
-            args.push(reasoning_effort.clone());
-        }
+        push_ccr_model_arg(&mut args, options.model.as_deref());
+        push_ccr_reasoning_arg(&mut args, options.reasoning_effort.as_deref());
 
         args.extend(options.sanitized_extra_args());
         args.push(options.prompt.clone());
@@ -163,5 +193,28 @@ mod tests {
             panic!("expected needs-input output");
         };
         assert!(prompt.contains("ccr model"));
+    }
+
+    #[test]
+    fn build_args_normalizes_claude_aliases_for_ccr() {
+        let executor = CcrExecutor::new(PathBuf::from("/usr/bin/ccr"));
+        let args = executor.build_args(&SpawnOptions {
+            cwd: PathBuf::from("/tmp/demo"),
+            prompt: "hello".to_string(),
+            model: Some("haiku".to_string()),
+            reasoning_effort: Some("max".to_string()),
+            skip_permissions: false,
+            extra_args: Vec::new(),
+            env: std::collections::HashMap::new(),
+            branch: None,
+            timeout: None,
+            interactive: false,
+            structured_output: false,
+            resume_target: None,
+        });
+
+        assert!(args.contains(&"claude-haiku-4-5".to_string()));
+        assert!(args.contains(&"max".to_string()));
+        assert!(!args.contains(&"xhigh".to_string()));
     }
 }

--- a/crates/conductor-executors/src/agents/claude_code.rs
+++ b/crates/conductor-executors/src/agents/claude_code.rs
@@ -16,6 +16,49 @@ pub struct ClaudeCodeExecutor {
     binary: PathBuf,
 }
 
+fn normalize_claude_model(model: Option<&str>) -> Option<String> {
+    let value = model.map(str::trim).filter(|value| !value.is_empty())?;
+    let normalized = value.to_ascii_lowercase();
+    match normalized.as_str() {
+        "sonnet" | "sonnet-4" | "claude-sonnet-4" => Some("claude-sonnet-4-6".to_string()),
+        "opus" | "opus-4" | "claude-opus-4" => Some("claude-opus-4-6".to_string()),
+        "haiku" | "haiku-4" | "haiku-4-5" | "claude-haiku-4" => {
+            Some("claude-haiku-4-5".to_string())
+        }
+        model if model.starts_with("claude-") => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn normalize_claude_reasoning_effort(reasoning_effort: Option<&str>) -> Option<String> {
+    let value = reasoning_effort
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?
+        .to_ascii_lowercase();
+    let normalized = match value.as_str() {
+        "minimal" | "min" | "off" | "none" | "low" => "low",
+        "medium" | "med" => "medium",
+        "high" => "high",
+        "max" | "xhigh" | "extra-high" | "extra_high" | "extra high" => "max",
+        _ => return None,
+    };
+    Some(normalized.to_string())
+}
+
+fn push_claude_model_arg(args: &mut Vec<String>, model: Option<&str>) {
+    if let Some(model) = normalize_claude_model(model) {
+        args.push("--model".to_string());
+        args.push(model);
+    }
+}
+
+fn push_claude_reasoning_arg(args: &mut Vec<String>, reasoning_effort: Option<&str>) {
+    if let Some(reasoning_effort) = normalize_claude_reasoning_effort(reasoning_effort) {
+        args.push("--effort".to_string());
+        args.push(reasoning_effort);
+    }
+}
+
 impl ClaudeCodeExecutor {
     pub fn new(binary: PathBuf) -> Self {
         Self { binary }
@@ -96,15 +139,8 @@ impl Executor for ClaudeCodeExecutor {
                     args.push("--dangerously-skip-permissions".to_string());
                 }
 
-                if let Some(model) = &options.model {
-                    args.push("--model".to_string());
-                    args.push(model.clone());
-                }
-
-                if let Some(reasoning_effort) = &options.reasoning_effort {
-                    args.push("--effort".to_string());
-                    args.push(reasoning_effort.clone());
-                }
+                push_claude_model_arg(&mut args, options.model.as_deref());
+                push_claude_reasoning_arg(&mut args, options.reasoning_effort.as_deref());
 
                 args.extend(sanitized_extra_args);
                 return args;
@@ -114,15 +150,8 @@ impl Executor for ClaudeCodeExecutor {
                 args.push("--dangerously-skip-permissions".to_string());
             }
 
-            if let Some(model) = &options.model {
-                args.push("--model".to_string());
-                args.push(model.clone());
-            }
-
-            if let Some(reasoning_effort) = &options.reasoning_effort {
-                args.push("--effort".to_string());
-                args.push(reasoning_effort.clone());
-            }
+            push_claude_model_arg(&mut args, options.model.as_deref());
+            push_claude_reasoning_arg(&mut args, options.reasoning_effort.as_deref());
 
             args.extend(sanitized_extra_args);
             if !options.prompt.trim().is_empty() {
@@ -148,15 +177,8 @@ impl Executor for ClaudeCodeExecutor {
             args.push("--dangerously-skip-permissions".to_string());
         }
 
-        if let Some(model) = &options.model {
-            args.push("--model".to_string());
-            args.push(model.clone());
-        }
-
-        if let Some(reasoning_effort) = &options.reasoning_effort {
-            args.push("--effort".to_string());
-            args.push(reasoning_effort.clone());
-        }
+        push_claude_model_arg(&mut args, options.model.as_deref());
+        push_claude_reasoning_arg(&mut args, options.reasoning_effort.as_deref());
 
         // Add extra args.
         args.extend(sanitized_extra_args);
@@ -502,9 +524,32 @@ mod tests {
         });
 
         assert!(args.contains(&"--model".to_string()));
-        assert!(args.contains(&"sonnet".to_string()));
+        assert!(args.contains(&"claude-sonnet-4-6".to_string()));
         assert!(args.contains(&"--effort".to_string()));
         assert!(args.contains(&"medium".to_string()));
+    }
+
+    #[test]
+    fn build_args_normalizes_reasoning_aliases_to_claude_supported_levels() {
+        let executor = ClaudeCodeExecutor::new(PathBuf::from("/usr/bin/claude"));
+        let args = executor.build_args(&SpawnOptions {
+            cwd: PathBuf::from("/tmp/demo"),
+            prompt: "hello".to_string(),
+            model: Some("opus".to_string()),
+            reasoning_effort: Some("xhigh".to_string()),
+            skip_permissions: false,
+            extra_args: Vec::new(),
+            env: HashMap::new(),
+            branch: None,
+            timeout: None,
+            interactive: false,
+            structured_output: false,
+            resume_target: None,
+        });
+
+        assert!(args.contains(&"claude-opus-4-6".to_string()));
+        assert!(args.contains(&"max".to_string()));
+        assert!(!args.contains(&"xhigh".to_string()));
     }
 
     #[test]

--- a/crates/conductor-executors/src/agents/codex.rs
+++ b/crates/conductor-executors/src/agents/codex.rs
@@ -20,6 +20,44 @@ pub struct CodexExecutor {
     binary: PathBuf,
 }
 
+fn normalize_codex_model(model: Option<&str>) -> Option<String> {
+    model
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn normalize_codex_reasoning_effort(reasoning_effort: Option<&str>) -> Option<String> {
+    let normalized = reasoning_effort
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?
+        .to_ascii_lowercase();
+
+    let normalized = match normalized.as_str() {
+        "minimal" | "min" | "low" => "low",
+        "medium" | "med" => "medium",
+        "high" => "high",
+        "max" | "xhigh" | "extra-high" | "extra_high" | "extra high" => "xhigh",
+        _ => return None,
+    };
+
+    Some(normalized.to_string())
+}
+
+fn push_codex_model_arg(args: &mut Vec<String>, model: Option<&str>) {
+    if let Some(model) = normalize_codex_model(model) {
+        args.push("--model".to_string());
+        args.push(model);
+    }
+}
+
+fn push_codex_reasoning_arg(args: &mut Vec<String>, reasoning_effort: Option<&str>) {
+    if let Some(reasoning_effort) = normalize_codex_reasoning_effort(reasoning_effort) {
+        args.push("-c".to_string());
+        args.push(format!("model_reasoning_effort=\"{reasoning_effort}\""));
+    }
+}
+
 fn build_codex_spawn_env(overrides: &HashMap<String, String>) -> HashMap<String, String> {
     let mut env = HashMap::new();
     for key in [
@@ -442,15 +480,8 @@ impl Executor for CodexExecutor {
                 args.push("--dangerously-bypass-approvals-and-sandbox".to_string());
             }
 
-            if let Some(model) = &options.model {
-                args.push("--model".to_string());
-                args.push(model.clone());
-            }
-
-            if let Some(reasoning_effort) = &options.reasoning_effort {
-                args.push("-c".to_string());
-                args.push(format!("model_reasoning_effort=\"{reasoning_effort}\""));
-            }
+            push_codex_model_arg(&mut args, options.model.as_deref());
+            push_codex_reasoning_arg(&mut args, options.reasoning_effort.as_deref());
 
             args.extend(options.sanitized_extra_args());
 
@@ -475,15 +506,8 @@ impl Executor for CodexExecutor {
             if let Some(resume_target) = &options.resume_target {
                 args.push("resume".to_string());
 
-                if let Some(model) = &options.model {
-                    args.push("--model".to_string());
-                    args.push(model.clone());
-                }
-
-                if let Some(reasoning_effort) = &options.reasoning_effort {
-                    args.push("-c".to_string());
-                    args.push(format!("model_reasoning_effort=\"{reasoning_effort}\""));
-                }
+                push_codex_model_arg(&mut args, options.model.as_deref());
+                push_codex_reasoning_arg(&mut args, options.reasoning_effort.as_deref());
 
                 if options.skip_permissions {
                     args.push("--dangerously-bypass-approvals-and-sandbox".to_string());
@@ -494,15 +518,8 @@ impl Executor for CodexExecutor {
                 return args;
             }
 
-            if let Some(model) = &options.model {
-                args.push("--model".to_string());
-                args.push(model.clone());
-            }
-
-            if let Some(reasoning_effort) = &options.reasoning_effort {
-                args.push("-c".to_string());
-                args.push(format!("model_reasoning_effort=\"{reasoning_effort}\""));
-            }
+            push_codex_model_arg(&mut args, options.model.as_deref());
+            push_codex_reasoning_arg(&mut args, options.reasoning_effort.as_deref());
 
             if options.skip_permissions {
                 args.push("--dangerously-bypass-approvals-and-sandbox".to_string());
@@ -527,15 +544,8 @@ impl Executor for CodexExecutor {
             args.push("--dangerously-bypass-approvals-and-sandbox".to_string());
         }
 
-        if let Some(model) = &options.model {
-            args.push("--model".to_string());
-            args.push(model.clone());
-        }
-
-        if let Some(reasoning_effort) = &options.reasoning_effort {
-            args.push("-c".to_string());
-            args.push(format!("model_reasoning_effort=\"{reasoning_effort}\""));
-        }
+        push_codex_model_arg(&mut args, options.model.as_deref());
+        push_codex_reasoning_arg(&mut args, options.reasoning_effort.as_deref());
 
         args.extend(options.sanitized_extra_args());
 
@@ -1115,6 +1125,28 @@ mod tests {
         assert!(args.contains(&"gpt-5".to_string()));
         assert!(args.contains(&"-c".to_string()));
         assert!(args.contains(&"model_reasoning_effort=\"high\"".to_string()));
+    }
+
+    #[test]
+    fn build_args_normalizes_legacy_reasoning_aliases() {
+        let executor = CodexExecutor::new(PathBuf::from("/usr/bin/codex"));
+        let args = executor.build_args(&SpawnOptions {
+            cwd: PathBuf::from("/tmp/demo"),
+            prompt: "hello".to_string(),
+            model: Some("gpt-5.4".to_string()),
+            reasoning_effort: Some("max".to_string()),
+            skip_permissions: false,
+            extra_args: Vec::new(),
+            env: HashMap::new(),
+            branch: None,
+            timeout: None,
+            interactive: false,
+            structured_output: false,
+            resume_target: None,
+        });
+
+        assert!(args.contains(&"model_reasoning_effort=\"xhigh\"".to_string()));
+        assert!(!args.contains(&"model_reasoning_effort=\"max\"".to_string()));
     }
 
     #[test]

--- a/crates/conductor-executors/src/agents/copilot.rs
+++ b/crates/conductor-executors/src/agents/copilot.rs
@@ -10,6 +10,25 @@ use super::discover_binary;
 use crate::executor::{wrap_parsed_output, Executor, ExecutorHandle, ExecutorOutput, SpawnOptions};
 use crate::process::{spawn_process, spawn_process_no_stdin};
 
+fn normalize_copilot_model(model: Option<&str>) -> Option<String> {
+    let value = model.map(str::trim).filter(|value| !value.is_empty())?;
+    let normalized = value.to_ascii_lowercase();
+    match normalized.as_str() {
+        "gpt-5" | "gpt-5.4" | "gpt-5.5" => Some("gpt-5.2".to_string()),
+        model if model.starts_with("gpt-") || model.starts_with("claude-") => {
+            Some(value.to_string())
+        }
+        _ => None,
+    }
+}
+
+fn push_copilot_model_arg(args: &mut Vec<String>, model: Option<&str>) {
+    if let Some(model) = normalize_copilot_model(model) {
+        args.push("--model".to_string());
+        args.push(model);
+    }
+}
+
 #[derive(Clone)]
 pub struct CopilotExecutor {
     binary: PathBuf,
@@ -82,10 +101,7 @@ impl Executor for CopilotExecutor {
                 args.push("--allow-all".to_string());
             }
 
-            if let Some(model) = &options.model {
-                args.push("--model".to_string());
-                args.push(model.clone());
-            }
+            push_copilot_model_arg(&mut args, options.model.as_deref());
             push_reasoning_effort_arg(&mut args, options.reasoning_effort.as_deref());
 
             args.extend(options.sanitized_extra_args());
@@ -106,10 +122,7 @@ impl Executor for CopilotExecutor {
             "on".to_string(),
             "--allow-all-tools".to_string(),
         ];
-        if let Some(model) = &options.model {
-            args.push("--model".to_string());
-            args.push(model.clone());
-        }
+        push_copilot_model_arg(&mut args, options.model.as_deref());
         push_reasoning_effort_arg(&mut args, options.reasoning_effort.as_deref());
         if options.skip_permissions {
             args.push("--allow-all".to_string());
@@ -214,15 +227,22 @@ impl Executor for CopilotExecutor {
 }
 
 fn push_reasoning_effort_arg(args: &mut Vec<String>, reasoning_effort: Option<&str>) {
-    let Some(reasoning_effort) = reasoning_effort
+    let Some(raw_reasoning_effort) = reasoning_effort
         .map(str::trim)
         .filter(|value| !value.is_empty())
     else {
         return;
     };
+    let normalized = match raw_reasoning_effort.to_ascii_lowercase().as_str() {
+        "low" => "low",
+        "medium" | "med" => "medium",
+        "high" => "high",
+        "xhigh" | "extra-high" | "extra_high" | "extra high" | "max" => "xhigh",
+        _ => return,
+    };
 
     args.push("--reasoning-effort".to_string());
-    args.push(reasoning_effort.to_ascii_lowercase());
+    args.push(normalized.to_string());
 }
 
 fn extract_copilot_text(data: &Value) -> Option<String> {
@@ -369,7 +389,7 @@ mod tests {
 
         assert!(args.contains(&"--allow-all".to_string()));
         assert!(args.contains(&"--model".to_string()));
-        assert!(args.contains(&"gpt-5".to_string()));
+        assert!(args.contains(&"gpt-5.2".to_string()));
         assert!(args.contains(&"--foo".to_string()));
         assert_eq!(
             args.iter().position(|arg| arg == "-i"),

--- a/crates/conductor-executors/src/agents/cursor.rs
+++ b/crates/conductor-executors/src/agents/cursor.rs
@@ -15,16 +15,28 @@ use crate::process::{spawn_process, spawn_process_no_stdin};
 /// unrecognized names so the agent falls back to `auto` (its default).
 fn normalize_cursor_model(model: Option<&str>) -> Option<String> {
     let value = model.map(str::trim).filter(|v| !v.is_empty())?;
-    match value {
-        // Cursor-native names pass through unchanged
-        "auto" | "composer-2-fast" | "composer-2" | "composer-1.5" => Some(value.to_string()),
-        // Cursor uses gpt-5.x-codex naming, not bare gpt-5
-        "gpt-5" => Some("gpt-5.3-codex".to_string()),
-        "gpt-5-fast" => Some("gpt-5.3-codex-fast".to_string()),
-        "gpt-5-high" => Some("gpt-5.3-codex-high".to_string()),
-        // Already a Cursor-compatible model id (gpt-5.x-codex-*, etc.)
-        s if s.starts_with("gpt-5.") => Some(value.to_string()),
-        s if s.starts_with("composer-") => Some(value.to_string()),
+    let normalized = value.to_ascii_lowercase();
+    match normalized.as_str() {
+        "auto" => Some("auto".to_string()),
+        // Preserve older saved Cursor aliases by remapping them onto the
+        // current GPT-5 preset family that the CLI still accepts.
+        "gpt-5.3-codex" => Some("gpt-5".to_string()),
+        "gpt-5.3-codex-fast" => Some("gpt-5-fast".to_string()),
+        "gpt-5.3-codex-high" => Some("gpt-5-high".to_string()),
+        "opus" => Some("opus-4.1".to_string()),
+        // Cursor-native names and runtime-discovered model ids pass through.
+        s if s.starts_with("gpt-")
+            || s.starts_with("composer-")
+            || s.starts_with("sonnet-")
+            || s.starts_with("opus")
+            || s.starts_with("claude-")
+            || s.starts_with("gemini-")
+            || s.starts_with("grok-")
+            || s.starts_with("kimi-")
+            || s.starts_with("qwen-") =>
+        {
+            Some(value.to_string())
+        }
         // Unrecognized model: let Cursor pick its default
         _ => None,
     }
@@ -383,9 +395,7 @@ mod tests {
         assert!(args.contains(&"--print".to_string()));
         assert!(args.contains(&"stream-json".to_string()));
         assert!(args.contains(&"--force".to_string()));
-        // gpt-5 should be mapped to a Cursor-compatible model name
-        assert!(args.contains(&"gpt-5.3-codex".to_string()));
-        assert!(!args.contains(&"gpt-5".to_string()));
+        assert!(args.contains(&"gpt-5".to_string()));
     }
 
     #[test]
@@ -394,7 +404,7 @@ mod tests {
         let args = executor.build_args(&SpawnOptions {
             cwd: PathBuf::from("/tmp/demo"),
             prompt: "hello".to_string(),
-            model: Some("claude-sonnet-4".to_string()),
+            model: Some("not-a-cursor-model".to_string()),
             reasoning_effort: None,
             skip_permissions: false,
             extra_args: Vec::new(),
@@ -407,14 +417,14 @@ mod tests {
         });
 
         assert!(!args.contains(&"--model".to_string()));
-        assert!(!args.contains(&"claude-sonnet-4".to_string()));
+        assert!(!args.contains(&"not-a-cursor-model".to_string()));
     }
 
     #[test]
     fn normalize_cursor_model_maps_common_names() {
         assert_eq!(
             normalize_cursor_model(Some("gpt-5")),
-            Some("gpt-5.3-codex".to_string())
+            Some("gpt-5".to_string())
         );
         assert_eq!(
             normalize_cursor_model(Some("auto")),
@@ -422,9 +432,17 @@ mod tests {
         );
         assert_eq!(
             normalize_cursor_model(Some("gpt-5.3-codex-high")),
-            Some("gpt-5.3-codex-high".to_string())
+            Some("gpt-5-high".to_string())
         );
-        assert_eq!(normalize_cursor_model(Some("claude-sonnet-4")), None);
+        assert_eq!(
+            normalize_cursor_model(Some("sonnet-4")),
+            Some("sonnet-4".to_string())
+        );
+        assert_eq!(
+            normalize_cursor_model(Some("opus")),
+            Some("opus-4.1".to_string())
+        );
+        assert_eq!(normalize_cursor_model(Some("openai/gpt-5")), None);
         assert_eq!(normalize_cursor_model(None), None);
     }
 

--- a/crates/conductor-executors/src/agents/cursor.rs
+++ b/crates/conductor-executors/src/agents/cursor.rs
@@ -28,7 +28,7 @@ fn normalize_cursor_model(model: Option<&str>) -> Option<String> {
         s if s.starts_with("gpt-")
             || s.starts_with("composer-")
             || s.starts_with("sonnet-")
-            || s.starts_with("opus")
+            || s.starts_with("opus-")
             || s.starts_with("claude-")
             || s.starts_with("gemini-")
             || s.starts_with("grok-")
@@ -442,6 +442,11 @@ mod tests {
             normalize_cursor_model(Some("opus")),
             Some("opus-4.1".to_string())
         );
+        assert_eq!(
+            normalize_cursor_model(Some("opus-4.1")),
+            Some("opus-4.1".to_string())
+        );
+        assert_eq!(normalize_cursor_model(Some("opustypo")), None);
         assert_eq!(normalize_cursor_model(Some("openai/gpt-5")), None);
         assert_eq!(normalize_cursor_model(None), None);
     }

--- a/crates/conductor-executors/src/agents/droid.rs
+++ b/crates/conductor-executors/src/agents/droid.rs
@@ -28,7 +28,7 @@ fn normalize_droid_model(model: Option<&str>) -> Option<String> {
                 || other.starts_with("claude-")
                 || other.starts_with("gemini-") =>
         {
-            return Some(value.to_string());
+            return Some(normalized);
         }
         _ => return None,
     };
@@ -355,6 +355,18 @@ fn tool_metadata(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn normalize_droid_model_lowercases_runtime_prefixed_ids() {
+        assert_eq!(
+            normalize_droid_model(Some("Claude-Sonnet-4-6")),
+            Some("claude-sonnet-4-6".to_string())
+        );
+        assert_eq!(
+            normalize_droid_reasoning_effort(Some("xhigh"), Some("Claude-Sonnet-4-6")),
+            Some("max".to_string())
+        );
+    }
 
     #[test]
     fn parse_auth_failure_requests_input() {

--- a/crates/conductor-executors/src/agents/droid.rs
+++ b/crates/conductor-executors/src/agents/droid.rs
@@ -10,6 +10,75 @@ use super::discover_binary;
 use crate::executor::{wrap_parsed_output, Executor, ExecutorHandle, ExecutorOutput, SpawnOptions};
 use crate::process::{spawn_process, spawn_process_no_stdin};
 
+fn normalize_droid_model(model: Option<&str>) -> Option<String> {
+    let value = model.map(str::trim).filter(|value| !value.is_empty())?;
+    let normalized = value.to_ascii_lowercase();
+    let mapped = match normalized.as_str() {
+        "gpt-5" | "gpt-5.4" => "gpt-5.4-fast",
+        "claude-sonnet" | "sonnet" | "sonnet-4" | "claude-sonnet-4" => "claude-sonnet-4-6",
+        "claude-opus" | "opus" | "opus-4" | "claude-opus-4" => "claude-opus-4-6",
+        "claude-haiku" | "haiku" | "haiku-4" | "claude-haiku-4" => "claude-haiku-4-5-20251001",
+        "gemini-pro" | "gemini-3.1-pro" => "gemini-3.1-pro-preview",
+        "gemini-flash" | "gemini-3-flash" => "gemini-3-flash-preview",
+        "glm-4.7" | "glm-5" | "kimi-k2.5" | "minimax-m2.5" | "minimax-m2.7" => {
+            return Some(normalized);
+        }
+        other
+            if other.starts_with("gpt-5.")
+                || other.starts_with("claude-")
+                || other.starts_with("gemini-") =>
+        {
+            return Some(value.to_string());
+        }
+        _ => return None,
+    };
+    Some(mapped.to_string())
+}
+
+fn normalize_droid_reasoning_effort(
+    reasoning_effort: Option<&str>,
+    model: Option<&str>,
+) -> Option<String> {
+    let value = reasoning_effort
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?
+        .to_ascii_lowercase();
+    let model = normalize_droid_model(model);
+    let is_claude_model = model
+        .as_deref()
+        .is_some_and(|model| model.starts_with("claude-"));
+    let mapped = match value.as_str() {
+        "off" | "none" => "none",
+        "minimal" | "min" => "minimal",
+        "low" => "low",
+        "medium" | "med" => "medium",
+        "high" => "high",
+        "max" => "max",
+        "xhigh" | "extra-high" | "extra_high" | "extra high" if is_claude_model => "max",
+        "xhigh" | "extra-high" | "extra_high" | "extra high" => "xhigh",
+        _ => return None,
+    };
+    Some(mapped.to_string())
+}
+
+fn push_droid_model_arg(args: &mut Vec<String>, model: Option<&str>) {
+    if let Some(model) = normalize_droid_model(model) {
+        args.push("--model".to_string());
+        args.push(model);
+    }
+}
+
+fn push_droid_reasoning_arg(
+    args: &mut Vec<String>,
+    reasoning_effort: Option<&str>,
+    model: Option<&str>,
+) {
+    if let Some(reasoning_effort) = normalize_droid_reasoning_effort(reasoning_effort, model) {
+        args.push("--reasoning-effort".to_string());
+        args.push(reasoning_effort);
+    }
+}
+
 #[derive(Clone)]
 pub struct DroidExecutor {
     binary: PathBuf,
@@ -76,15 +145,12 @@ impl Executor for DroidExecutor {
                 args.push("json".to_string());
             }
 
-            if let Some(model) = &options.model {
-                args.push("--model".to_string());
-                args.push(model.clone());
-            }
-
-            if let Some(reasoning_effort) = &options.reasoning_effort {
-                args.push("--reasoning-effort".to_string());
-                args.push(reasoning_effort.clone());
-            }
+            push_droid_model_arg(&mut args, options.model.as_deref());
+            push_droid_reasoning_arg(
+                &mut args,
+                options.reasoning_effort.as_deref(),
+                options.model.as_deref(),
+            );
 
             if options.skip_permissions {
                 args.push("--skip-permissions-unsafe".to_string());
@@ -103,14 +169,12 @@ impl Executor for DroidExecutor {
             "--output-format".to_string(),
             "json".to_string(),
         ];
-        if let Some(model) = &options.model {
-            args.push("--model".to_string());
-            args.push(model.clone());
-        }
-        if let Some(reasoning_effort) = &options.reasoning_effort {
-            args.push("--reasoning-effort".to_string());
-            args.push(reasoning_effort.clone());
-        }
+        push_droid_model_arg(&mut args, options.model.as_deref());
+        push_droid_reasoning_arg(
+            &mut args,
+            options.reasoning_effort.as_deref(),
+            options.model.as_deref(),
+        );
         if options.skip_permissions {
             args.push("--skip-permissions-unsafe".to_string());
         }

--- a/crates/conductor-executors/src/agents/gemini.rs
+++ b/crates/conductor-executors/src/agents/gemini.rs
@@ -10,6 +10,26 @@ use super::discover_binary;
 use crate::executor::{wrap_parsed_output, Executor, ExecutorHandle, ExecutorOutput, SpawnOptions};
 use crate::process::{spawn_process, spawn_process_no_stdin};
 
+fn normalize_gemini_model(model: Option<&str>) -> Option<String> {
+    let value = model.map(str::trim).filter(|value| !value.is_empty())?;
+    let normalized = value.to_ascii_lowercase();
+    let stripped = normalized.strip_prefix("models/").unwrap_or(&normalized);
+    match stripped {
+        "gemini-pro" | "gemini-3.1-pro" => Some("gemini-3.1-pro-preview".to_string()),
+        "gemini-flash" | "gemini-3-flash" => Some("gemini-3-flash-preview".to_string()),
+        "gemini-3.1-flash-preview" => Some("gemini-3-flash-preview".to_string()),
+        model if model.starts_with("gemini-") => Some(stripped.to_string()),
+        _ => None,
+    }
+}
+
+fn push_gemini_model_arg(args: &mut Vec<String>, model: Option<&str>) {
+    if let Some(model) = normalize_gemini_model(model) {
+        args.push("--model".to_string());
+        args.push(model);
+    }
+}
+
 /// Gemini CLI executor.
 #[derive(Clone)]
 pub struct GeminiExecutor {
@@ -81,10 +101,7 @@ impl Executor for GeminiExecutor {
                 args.push("stream-json".to_string());
             }
 
-            if let Some(model) = &options.model {
-                args.push("--model".to_string());
-                args.push(model.clone());
-            }
+            push_gemini_model_arg(&mut args, options.model.as_deref());
             if options.skip_permissions {
                 args.push("--yolo".to_string());
             }
@@ -109,10 +126,7 @@ impl Executor for GeminiExecutor {
             args.push("--yolo".to_string());
         }
 
-        if let Some(model) = &options.model {
-            args.push("--model".to_string());
-            args.push(model.clone());
-        }
+        push_gemini_model_arg(&mut args, options.model.as_deref());
 
         args.push("--output-format".to_string());
         args.push("stream-json".to_string());

--- a/crates/conductor-executors/src/agents/opencode.rs
+++ b/crates/conductor-executors/src/agents/opencode.rs
@@ -163,10 +163,9 @@ fn normalize_variant(reasoning_effort: Option<&str>) -> Option<String> {
         .to_ascii_lowercase();
 
     let variant = match normalized.as_str() {
-        "minimal" | "low" => "minimal",
-        "medium" | "high" => "high",
-        "xhigh" | "extra-high" | "extra_high" | "extra high" | "max" => "max",
-        other => other,
+        "minimal" | "low" | "medium" | "high" | "max" | "off" | "none" => normalized.as_str(),
+        "xhigh" | "extra-high" | "extra_high" | "extra high" => "max",
+        _ => return None,
     };
 
     Some(variant.to_string())

--- a/crates/conductor-executors/src/agents/qwen.rs
+++ b/crates/conductor-executors/src/agents/qwen.rs
@@ -13,6 +13,27 @@ use crate::process::{spawn_process_no_stdin_with_env_removals, spawn_process_wit
 
 const QWEN_ENV_REMOVE_KEYS: &[&str] = &["NO_COLOR", "FORCE_COLOR", "CLICOLOR_FORCE"];
 
+fn normalize_qwen_model(model: Option<&str>) -> Option<String> {
+    let value = model.map(str::trim).filter(|value| !value.is_empty())?;
+    let normalized = value.to_ascii_lowercase();
+    match normalized.as_str() {
+        "coder-model" | "qwen-max" | "qwen-plus" | "qwen-turbo" | "qwen3-coder-plus" => {
+            Some(normalized)
+        }
+        model if model.starts_with("qwen") || model.starts_with("dashscope/") => {
+            Some(value.to_string())
+        }
+        _ => None,
+    }
+}
+
+fn push_qwen_model_arg(args: &mut Vec<String>, model: Option<&str>) {
+    if let Some(model) = normalize_qwen_model(model) {
+        args.push("--model".to_string());
+        args.push(model);
+    }
+}
+
 #[derive(Clone)]
 pub struct QwenCodeExecutor {
     binary: PathBuf,
@@ -106,10 +127,7 @@ impl Executor for QwenCodeExecutor {
             if options.skip_permissions {
                 args.push("--yolo".to_string());
             }
-            if let Some(model) = &options.model {
-                args.push("--model".to_string());
-                args.push(model.clone());
-            }
+            push_qwen_model_arg(&mut args, options.model.as_deref());
             if let Some(resume_target) = &options.resume_target {
                 args.push("--resume".to_string());
                 args.push(resume_target.clone());
@@ -126,10 +144,7 @@ impl Executor for QwenCodeExecutor {
         if options.skip_permissions {
             args.push("--yolo".to_string());
         }
-        if let Some(model) = &options.model {
-            args.push("--model".to_string());
-            args.push(model.clone());
-        }
+        push_qwen_model_arg(&mut args, options.model.as_deref());
         args.push("--output-format".to_string());
         args.push("stream-json".to_string());
         args.push("--include-partial-messages".to_string());

--- a/crates/conductor-executors/src/agents/qwen.rs
+++ b/crates/conductor-executors/src/agents/qwen.rs
@@ -20,9 +20,7 @@ fn normalize_qwen_model(model: Option<&str>) -> Option<String> {
         "coder-model" | "qwen-max" | "qwen-plus" | "qwen-turbo" | "qwen3-coder-plus" => {
             Some(normalized)
         }
-        model if model.starts_with("qwen") || model.starts_with("dashscope/") => {
-            Some(value.to_string())
-        }
+        model if model.starts_with("qwen") || model.starts_with("dashscope/") => Some(normalized),
         _ => None,
     }
 }
@@ -208,6 +206,18 @@ fn is_qwen_login_prompt(line: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn normalize_qwen_model_lowercases_prefixed_models() {
+        assert_eq!(
+            normalize_qwen_model(Some("QWEN3-Coder-Plus")),
+            Some("qwen3-coder-plus".to_string())
+        );
+        assert_eq!(
+            normalize_qwen_model(Some("DashScope/Qwen3-Coder-Plus")),
+            Some("dashscope/qwen3-coder-plus".to_string())
+        );
+    }
 
     #[test]
     fn build_args_interactive_uses_prompt_interactive_flag() {

--- a/crates/conductor-executors/tests/agent_matrix_test.rs
+++ b/crates/conductor-executors/tests/agent_matrix_test.rs
@@ -96,7 +96,10 @@ fn headless_build_args_include_expected_flags_and_safe_extra_args() {
     );
     assert_filters_blocked_flags(&hermes);
 
-    let ccr = CcrExecutor::new(PathBuf::from("/usr/bin/ccr")).build_args(&options("ccr prompt"));
+    let mut ccr_options = options("ccr prompt");
+    ccr_options.model = Some("sonnet".to_string());
+    ccr_options.reasoning_effort = Some("xhigh".to_string());
+    let ccr = CcrExecutor::new(PathBuf::from("/usr/bin/ccr")).build_args(&ccr_options);
     assert_contains(
         &ccr,
         &[
@@ -104,15 +107,20 @@ fn headless_build_args_include_expected_flags_and_safe_extra_args() {
             "--print",
             "--output-format",
             "stream-json",
+            "--model",
+            "claude-sonnet-4-6",
             "--effort",
-            "high",
+            "max",
             "ccr prompt",
         ],
     );
     assert_filters_blocked_flags(&ccr);
 
+    let mut claude_options = options("claude");
+    claude_options.model = Some("sonnet".to_string());
+    claude_options.reasoning_effort = Some("xhigh".to_string());
     let claude =
-        ClaudeCodeExecutor::new(PathBuf::from("/usr/bin/claude")).build_args(&options("claude"));
+        ClaudeCodeExecutor::new(PathBuf::from("/usr/bin/claude")).build_args(&claude_options);
     assert_contains(
         &claude,
         &[
@@ -120,9 +128,9 @@ fn headless_build_args_include_expected_flags_and_safe_extra_args() {
             "--output-format",
             "stream-json",
             "--model",
-            "gpt-5",
+            "claude-sonnet-4-6",
             "--effort",
-            "high",
+            "max",
             "claude",
         ],
     );
@@ -157,6 +165,8 @@ fn headless_build_args_include_expected_flags_and_safe_extra_args() {
             "--stream",
             "on",
             "--allow-all-tools",
+            "--model",
+            "gpt-5.2",
             "--reasoning-effort",
             "high",
         ],
@@ -173,7 +183,7 @@ fn headless_build_args_include_expected_flags_and_safe_extra_args() {
             "--output-format",
             "stream-json",
             "--model",
-            "gpt-5.3-codex",
+            "gpt-5",
             "cursor",
         ],
     );
@@ -187,7 +197,7 @@ fn headless_build_args_include_expected_flags_and_safe_extra_args() {
             "--output-format",
             "json",
             "--model",
-            "gpt-5",
+            "gpt-5.4-fast",
             "--reasoning-effort",
             "high",
             "droid",
@@ -195,13 +205,14 @@ fn headless_build_args_include_expected_flags_and_safe_extra_args() {
     );
     assert_filters_blocked_flags(&droid);
 
-    let gemini =
-        GeminiExecutor::new(PathBuf::from("/usr/bin/gemini")).build_args(&options("gemini"));
+    let mut gemini_options = options("gemini");
+    gemini_options.model = Some("gemini-3.1-pro-preview".to_string());
+    let gemini = GeminiExecutor::new(PathBuf::from("/usr/bin/gemini")).build_args(&gemini_options);
     assert_contains(
         &gemini,
         &[
             "--model",
-            "gpt-5",
+            "gemini-3.1-pro-preview",
             "--output-format",
             "stream-json",
             "--prompt",
@@ -281,9 +292,12 @@ fn interactive_launch_matrix_tracks_model_and_reasoning_parameters() {
     assert_no_flag(&amp, "--reasoning-effort");
     assert_no_flag(&amp, "--variant");
 
-    let ccr = CcrExecutor::new(PathBuf::from("/usr/bin/ccr")).build_args(&interactive);
-    assert_has_pair(&ccr, "--model", "gpt-5");
-    assert_has_pair(&ccr, "--effort", "high");
+    let mut ccr_interactive = interactive.clone();
+    ccr_interactive.model = Some("sonnet".to_string());
+    ccr_interactive.reasoning_effort = Some("xhigh".to_string());
+    let ccr = CcrExecutor::new(PathBuf::from("/usr/bin/ccr")).build_args(&ccr_interactive);
+    assert_has_pair(&ccr, "--model", "claude-sonnet-4-6");
+    assert_has_pair(&ccr, "--effort", "max");
 
     let hermes = HermesExecutor::new(PathBuf::from("/usr/bin/hermes")).build_args(&interactive);
     assert_contains(&hermes, &["--toolsets", "terminal"]);
@@ -292,9 +306,13 @@ fn interactive_launch_matrix_tracks_model_and_reasoning_parameters() {
     assert_no_flag(&hermes, "--reasoning-effort");
     assert_no_flag(&hermes, "-q");
 
-    let claude = ClaudeCodeExecutor::new(PathBuf::from("/usr/bin/claude")).build_args(&interactive);
-    assert_has_pair(&claude, "--model", "gpt-5");
-    assert_has_pair(&claude, "--effort", "high");
+    let mut claude_interactive = interactive.clone();
+    claude_interactive.model = Some("sonnet".to_string());
+    claude_interactive.reasoning_effort = Some("xhigh".to_string());
+    let claude =
+        ClaudeCodeExecutor::new(PathBuf::from("/usr/bin/claude")).build_args(&claude_interactive);
+    assert_has_pair(&claude, "--model", "claude-sonnet-4-6");
+    assert_has_pair(&claude, "--effort", "max");
 
     let codex = CodexExecutor::new(PathBuf::from("/usr/bin/codex")).build_args(&interactive);
     assert_has_pair(&codex, "--model", "gpt-5");
@@ -303,23 +321,26 @@ fn interactive_launch_matrix_tracks_model_and_reasoning_parameters() {
         .any(|arg| arg == "model_reasoning_effort=\"high\""));
 
     let copilot = CopilotExecutor::new(PathBuf::from("/usr/bin/copilot")).build_args(&interactive);
-    assert_has_pair(&copilot, "--model", "gpt-5");
+    assert_has_pair(&copilot, "--model", "gpt-5.2");
     assert_no_flag(&copilot, "--effort");
     assert_has_pair(&copilot, "--reasoning-effort", "high");
 
     let cursor =
         CursorExecutor::new(PathBuf::from("/usr/bin/cursor-agent")).build_args(&interactive);
-    assert_has_pair(&cursor, "--model", "gpt-5.3-codex");
+    assert_has_pair(&cursor, "--model", "gpt-5");
     assert_no_flag(&cursor, "--effort");
     assert_no_flag(&cursor, "--reasoning-effort");
     assert_no_flag(&cursor, "--variant");
 
     let droid = DroidExecutor::new(PathBuf::from("/usr/bin/droid")).build_args(&interactive);
-    assert_has_pair(&droid, "--model", "gpt-5");
+    assert_has_pair(&droid, "--model", "gpt-5.4-fast");
     assert_has_pair(&droid, "--reasoning-effort", "high");
 
-    let gemini = GeminiExecutor::new(PathBuf::from("/usr/bin/gemini")).build_args(&interactive);
-    assert_has_pair(&gemini, "--model", "gpt-5");
+    let mut gemini_interactive = interactive.clone();
+    gemini_interactive.model = Some("gemini-3.1-pro-preview".to_string());
+    let gemini =
+        GeminiExecutor::new(PathBuf::from("/usr/bin/gemini")).build_args(&gemini_interactive);
+    assert_has_pair(&gemini, "--model", "gemini-3.1-pro-preview");
     assert_no_flag(&gemini, "--effort");
     assert_no_flag(&gemini, "--reasoning-effort");
 
@@ -355,7 +376,7 @@ fn interactive_launch_matrix_tracks_model_and_reasoning_parameters() {
 fn cursor_wrapper_binary_uses_agent_subcommand() {
     let args = CursorExecutor::new(PathBuf::from("/usr/bin/cursor")).build_args(&options("cursor"));
     assert_eq!(args.first().map(String::as_str), Some("agent"));
-    assert_has_pair(&args, "--model", "gpt-5.3-codex");
+    assert_has_pair(&args, "--model", "gpt-5");
 }
 
 #[test]

--- a/crates/conductor-server/src/routes/agents.rs
+++ b/crates/conductor-server/src/routes/agents.rs
@@ -465,7 +465,7 @@ fn read_text_file(path: &Path) -> Option<String> {
 async fn read_command_output(commands: &[&str], args: &[&str]) -> Option<String> {
     for cmd in commands {
         let result = tokio::time::timeout(
-            Duration::from_millis(3_000),
+            Duration::from_millis(8_000),
             Command::new(cmd).args(args).output(),
         )
         .await
@@ -487,7 +487,7 @@ async fn read_command_output(commands: &[&str], args: &[&str]) -> Option<String>
 async fn read_command_help(commands: &[&str]) -> Option<String> {
     for cmd in commands {
         let result = tokio::time::timeout(
-            Duration::from_millis(1_500),
+            Duration::from_millis(6_000),
             Command::new(cmd).arg("--help").output(),
         )
         .await
@@ -1026,7 +1026,7 @@ fn collect_claude_stats_models(stats: &Value) -> Vec<String> {
 
 async fn detect_claude_reasoning_options(binary_path: &Path) -> Vec<Value> {
     let output = tokio::time::timeout(
-        Duration::from_millis(1_500),
+        Duration::from_millis(6_000),
         Command::new(binary_path).arg("--help").output(),
     )
     .await
@@ -1593,7 +1593,7 @@ async fn build_cursor_runtime_model_catalog(binary_path: Option<&Path>) -> Optio
     }
 
     if models.is_empty() {
-        return None;
+        return default_access_catalog("cursor-cli", vec![], None, Some("auto"), vec![], None);
     }
 
     default_access_catalog(
@@ -1761,7 +1761,13 @@ fn parse_pi_list_models_output(output: &str) -> Vec<PiModelRow> {
         .map(str::trim)
         .filter(|line| !line.is_empty())
     {
-        if line.starts_with("provider") || line.starts_with("npm ") {
+        let lower = line.to_ascii_lowercase();
+        if lower.starts_with("provider")
+            || lower.starts_with("npm ")
+            || lower.starts_with("no models available")
+            || lower.starts_with("use /login")
+            || lower.starts_with("see:")
+        {
             continue;
         }
         let parts: Vec<&str> = line.split_whitespace().collect();
@@ -1770,7 +1776,13 @@ fn parse_pi_list_models_output(output: &str) -> Vec<PiModelRow> {
         }
         let provider = parts[0].trim();
         let model = parts[1].trim();
-        if provider.is_empty() || model.is_empty() {
+        if provider.is_empty()
+            || model.is_empty()
+            || !provider
+                .chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+            || model.eq_ignore_ascii_case("models")
+        {
             continue;
         }
         let id = format!("{provider}/{model}");
@@ -2046,6 +2058,23 @@ fn read_copilot_config_model() -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
+fn is_valid_copilot_model_id(model_id: &str) -> bool {
+    let normalized = model_id.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        return false;
+    }
+    if matches!(
+        normalized.as_str(),
+        "text" | "json" | "auto" | "default" | "interactive" | "plan" | "autopilot"
+    ) {
+        return false;
+    }
+    normalized.starts_with("gpt-")
+        || normalized.starts_with("claude-")
+        || normalized.starts_with("gemini-")
+        || normalized.starts_with("o")
+}
+
 fn collect_copilot_session_observations(contents: &[String]) -> (Vec<String>, Option<String>) {
     let mut seen_models = HashSet::new();
     let mut models = Vec::new();
@@ -2071,7 +2100,7 @@ fn collect_copilot_session_observations(contents: &[String]) -> (Vec<String>, Op
                 else {
                     continue;
                 };
-                if seen_models.insert(model_id.to_string()) {
+                if is_valid_copilot_model_id(model_id) && seen_models.insert(model_id.to_string()) {
                     models.push(model_id.to_string());
                 }
             }
@@ -2108,12 +2137,15 @@ async fn build_copilot_runtime_model_catalog(binary_path: Option<&Path>) -> Opti
     let mut seen = HashSet::new();
     let mut model_ids = Vec::new();
     for model_id in extract_quoted_choices_from_help(&help, "--model <model>") {
-        if seen.insert(model_id.clone()) {
+        if is_valid_copilot_model_id(&model_id) && seen.insert(model_id.clone()) {
             model_ids.push(model_id);
         }
     }
 
-    if let Some(config_model_id) = config_model.clone() {
+    if let Some(config_model_id) = config_model
+        .clone()
+        .filter(|model_id| is_valid_copilot_model_id(model_id))
+    {
         if seen.insert(config_model_id.clone()) {
             model_ids.push(config_model_id);
         }
@@ -2140,7 +2172,7 @@ async fn build_copilot_runtime_model_catalog(binary_path: Option<&Path>) -> Opti
         .collect();
 
     if model_ids.is_empty() {
-        return None;
+        model_ids.push("gpt-5.2".to_string());
     }
 
     let models: Vec<Value> = model_ids
@@ -2508,6 +2540,14 @@ anthropic claude-haiku 200K     8K       no        no",
     }
 
     #[test]
+    fn parse_pi_list_models_output_ignores_no_models_message() {
+        let rows = parse_pi_list_models_output(
+            "No models available. Use /login to log into a provider via OAuth or API key. See:\n  docs/providers.md",
+        );
+        assert!(rows.is_empty());
+    }
+
+    #[test]
     fn parse_opencode_verbose_models_collects_reasoning_variants() {
         let output = r#"
 opencode/gpt-5-nano
@@ -2539,7 +2579,9 @@ opencode/gpt-5-nano
         let contents = vec![r#"
 {"type":"session.model_change","data":{"newModel":"claude-haiku-4.5","reasoningEffort":"xhigh"}}
 {"type":"tool.execution_complete","data":{"model":"gpt-5.4"}}
+{"type":"tool.execution_complete","data":{"model":"json"}}
 {"type":"session.shutdown","data":{"currentModel":"claude-sonnet-4.6"}}
+{"type":"session.mode_change","data":{"currentModel":"auto"}}
 "#
         .to_string()];
 

--- a/crates/conductor-server/src/routes/agents.rs
+++ b/crates/conductor-server/src/routes/agents.rs
@@ -2072,7 +2072,10 @@ fn is_valid_copilot_model_id(model_id: &str) -> bool {
     normalized.starts_with("gpt-")
         || normalized.starts_with("claude-")
         || normalized.starts_with("gemini-")
-        || normalized.starts_with("o")
+        || normalized
+            .strip_prefix('o')
+            .and_then(|rest| rest.chars().next())
+            .is_some_and(|ch| ch.is_ascii_digit())
 }
 
 fn collect_copilot_session_observations(contents: &[String]) -> (Vec<String>, Option<String>) {
@@ -2572,6 +2575,17 @@ opencode/gpt-5-nano
                 "high".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn is_valid_copilot_model_id_accepts_real_models_only() {
+        assert!(is_valid_copilot_model_id("gpt-5.2"));
+        assert!(is_valid_copilot_model_id("claude-sonnet-4.6"));
+        assert!(is_valid_copilot_model_id("gemini-3-pro"));
+        assert!(is_valid_copilot_model_id("o3-mini"));
+        assert!(!is_valid_copilot_model_id("output"));
+        assert!(!is_valid_copilot_model_id("off"));
+        assert!(!is_valid_copilot_model_id("auto"));
     }
 
     #[test]

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1072,10 +1072,10 @@ const STATIC_AGENT_MODEL_CATALOGS: Record<
           "Sonnet 4"
         ),
         modelOption(
-          "opus",
+          "opus-4.1",
           "Cursor Agent's Opus preset alias.",
           ["default"],
-          "Opus"
+          "Opus 4.1"
         ),
       ],
     },

--- a/packages/web/src/lib/agentModelSelection.test.ts
+++ b/packages/web/src/lib/agentModelSelection.test.ts
@@ -102,3 +102,98 @@ test("openclaw suppresses frontend model and reasoning selection", () => {
   });
   assert.deepEqual(getSelectableAgentModels("openclaw", {}, {}), []);
 });
+
+test("empty runtime catalogs suppress stale static and custom model choices", () => {
+  const emptyCursorCatalog: RuntimeAgentModelCatalog = {
+    agent: "cursor-cli",
+    customModelPlaceholder: "auto",
+    defaultModelByAccess: {},
+    modelsByAccess: {},
+  };
+
+  assert.deepEqual(
+    getSelectableAgentModels(
+      "cursor-cli",
+      { cursorCli: "default" },
+      { "cursor-cli": emptyCursorCatalog },
+    ),
+    [],
+  );
+
+  const selection = buildModelSelection(
+    "cursor-cli",
+    { cursorCli: "default" },
+    { "cursor-cli": emptyCursorCatalog },
+    "gpt-5.3-codex",
+    "high",
+  );
+  assert.deepEqual(selection, {
+    catalogModel: "",
+    customModel: "",
+    reasoningEffort: "",
+  });
+});
+
+test("buildModelSelection normalizes stale saved model and reasoning aliases", () => {
+  const cursorCatalog: RuntimeAgentModelCatalog = {
+    agent: "cursor-cli",
+    customModelPlaceholder: "gpt-5",
+    defaultModelByAccess: { default: "gpt-5" },
+    modelsByAccess: {
+      default: [
+        {
+          id: "gpt-5",
+          label: "GPT-5",
+          description: "Runtime Cursor model",
+          access: ["default"],
+        },
+      ],
+    },
+  };
+  const claudeCatalog: RuntimeAgentModelCatalog = {
+    agent: "claude-code",
+    customModelPlaceholder: "claude-sonnet-4-6",
+    defaultModelByAccess: { pro: "claude-sonnet-4-6" },
+    modelsByAccess: {
+      pro: [
+        {
+          id: "claude-sonnet-4-6",
+          label: "Claude Sonnet 4.6",
+          description: "Runtime Claude model",
+          access: ["pro"],
+        },
+      ],
+    },
+    reasoningOptionsByAccess: {
+      pro: [
+        { id: "low", label: "Low", description: "Low" },
+        { id: "medium", label: "Medium", description: "Medium" },
+        { id: "high", label: "High", description: "High" },
+        { id: "max", label: "Max", description: "Max" },
+      ],
+    },
+    defaultReasoningByAccess: { pro: "high" },
+  };
+
+  assert.deepEqual(
+    buildModelSelection(
+      "cursor-cli",
+      { cursorCli: "default" },
+      { "cursor-cli": cursorCatalog },
+      "gpt-5.3-codex",
+      null,
+    ),
+    { catalogModel: "gpt-5", customModel: "", reasoningEffort: "" },
+  );
+
+  assert.deepEqual(
+    buildModelSelection(
+      "claude-code",
+      { claudeCode: "pro" },
+      { "claude-code": claudeCatalog },
+      "sonnet",
+      "xhigh",
+    ),
+    { catalogModel: "claude-sonnet-4-6", customModel: "", reasoningEffort: "max" },
+  );
+});

--- a/packages/web/src/lib/agentModelSelection.ts
+++ b/packages/web/src/lib/agentModelSelection.ts
@@ -24,8 +24,111 @@ export type ModelSelectionState = {
   reasoningEffort: string;
 };
 
+const STALE_GEMINI_FLASH_MODEL_ID = "gemini-3.1-flash-preview";
+const GEMINI_FLASH_MODEL_ID = "gemini-3-flash-preview";
+
 function usesBackendManagedModelConfig(agent: string): boolean {
   return normalizeAgentName(agent) === "openclaw";
+}
+
+function normalizePreferredModel(agent: string, model: string | null | undefined): string {
+  const trimmed = model?.trim() ?? "";
+  if (trimmed.length === 0) {
+    return "";
+  }
+
+  const normalizedAgent = normalizeAgentName(agent);
+  const normalizedModel = trimmed.toLowerCase();
+
+  if (normalizedAgent === "gemini" && normalizedModel === STALE_GEMINI_FLASH_MODEL_ID) {
+    return GEMINI_FLASH_MODEL_ID;
+  }
+
+  if (normalizedAgent === "cursor-cli") {
+    if (normalizedModel === "gpt-5.3-codex") return "gpt-5";
+    if (normalizedModel === "gpt-5.3-codex-fast") return "gpt-5-fast";
+    if (normalizedModel === "gpt-5.3-codex-high") return "gpt-5-high";
+    if (normalizedModel === "opus") return "opus-4.1";
+  }
+
+  if (normalizedAgent === "claude-code" || normalizedAgent === "ccr") {
+    if (normalizedModel === "sonnet" || normalizedModel === "sonnet-4") {
+      return "claude-sonnet-4-6";
+    }
+    if (normalizedModel === "opus" || normalizedModel === "opus-4") {
+      return "claude-opus-4-6";
+    }
+    if (normalizedModel === "haiku" || normalizedModel === "haiku-4" || normalizedModel === "haiku-4-5") {
+      return "claude-haiku-4-5";
+    }
+  }
+
+  return trimmed;
+}
+
+function normalizePreferredReasoning(agent: string, reasoningEffort: string | null | undefined): string {
+  const normalizedAgent = normalizeAgentName(agent);
+  const normalizedReasoning = reasoningEffort?.trim().toLowerCase() ?? "";
+  if (normalizedReasoning.length === 0) {
+    return "";
+  }
+
+  if (normalizedAgent === "claude-code" || normalizedAgent === "ccr") {
+    if (["minimal", "min", "off", "none", "low"].includes(normalizedReasoning)) return "low";
+    if (["medium", "med"].includes(normalizedReasoning)) return "medium";
+    if (normalizedReasoning === "high") return "high";
+    if (["max", "xhigh", "extra-high", "extra_high", "extra high"].includes(normalizedReasoning)) {
+      return "max";
+    }
+    return normalizedReasoning;
+  }
+
+  if (normalizedAgent === "github-copilot") {
+    if (["minimal", "min", "off", "none", "low"].includes(normalizedReasoning)) return "low";
+    if (["medium", "med"].includes(normalizedReasoning)) return "medium";
+    if (normalizedReasoning === "high") return "high";
+    if (["max", "xhigh", "extra-high", "extra_high", "extra high"].includes(normalizedReasoning)) {
+      return "xhigh";
+    }
+    return normalizedReasoning;
+  }
+
+  if (normalizedAgent === "codex") {
+    if (["minimal", "min", "low"].includes(normalizedReasoning)) return "low";
+    if (["medium", "med"].includes(normalizedReasoning)) return "medium";
+    if (normalizedReasoning === "high") return "high";
+    if (["max", "xhigh", "extra-high", "extra_high", "extra high"].includes(normalizedReasoning)) {
+      return "xhigh";
+    }
+    return normalizedReasoning;
+  }
+
+  if (normalizedAgent === "droid") {
+    if (["minimal", "min"].includes(normalizedReasoning)) return "minimal";
+    if (["medium", "med"].includes(normalizedReasoning)) return "medium";
+    if (["extra-high", "extra_high", "extra high"].includes(normalizedReasoning)) return "xhigh";
+    return normalizedReasoning;
+  }
+
+  if (normalizedAgent === "opencode") {
+    if (["minimal", "min"].includes(normalizedReasoning)) return "minimal";
+    if (["medium", "med"].includes(normalizedReasoning)) return "medium";
+    if (["xhigh", "extra-high", "extra_high", "extra high"].includes(normalizedReasoning)) {
+      return "max";
+    }
+    return normalizedReasoning;
+  }
+
+  if (normalizedAgent === "pi") {
+    if (["minimal", "min"].includes(normalizedReasoning)) return "minimal";
+    if (["medium", "med"].includes(normalizedReasoning)) return "medium";
+    if (["max", "xhigh", "extra-high", "extra_high", "extra high"].includes(normalizedReasoning)) {
+      return "xhigh";
+    }
+    return normalizedReasoning;
+  }
+
+  return normalizedReasoning;
 }
 
 export function emptyModelSelection(): ModelSelectionState {
@@ -79,7 +182,7 @@ export function getSelectableAgentModels(
   const scopedModels = getRuntimeCatalogModelsForAccess(runtimeCatalog, access);
   const allRuntimeModels = getAllRuntimeCatalogModels(runtimeCatalog);
 
-  if (allRuntimeModels.length > 0) {
+  if (runtimeCatalog) {
     const merged: AgentModelOption[] = [];
     const seen = new Set<string>();
     for (const model of [...scopedModels, ...allRuntimeModels]) {
@@ -182,12 +285,12 @@ export function buildModelSelection(
     return emptyModelSelection();
   }
 
-  const trimmedPreferred = preferredModel?.trim() ?? "";
-  const trimmedPreferredReasoning = preferredReasoningEffort?.trim().toLowerCase() ?? "";
+  const trimmedPreferred = normalizePreferredModel(agent, preferredModel);
+  const trimmedPreferredReasoning = normalizePreferredReasoning(agent, preferredReasoningEffort);
   const runtimeCatalog = getRuntimeModelCatalog(agent, runtimeModelCatalogs);
   const availableModels = getSelectableAgentModels(agent, modelAccess, runtimeModelCatalogs);
   const defaultModel = getSelectableDefaultAgentModel(agent, modelAccess, runtimeModelCatalogs);
-  const runtimeModelsAreAuthoritative = hasRuntimeModels(runtimeCatalog);
+  const runtimeModelsAreAuthoritative = runtimeCatalog !== null;
 
   const resolveReasoningEffort = (resolvedModel: string | null | undefined): string => {
     const options = getSelectableAgentReasoningOptions(


### PR DESCRIPTION
## User-Facing Release Notes

- Agent model and thinking selections now normalize stale aliases before launch, so supported coding agents start cleanly instead of failing on invalid CLI args.
- The Mac bridge now keeps the local backend alive when relay auth validation is temporarily unreachable.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Summary

- Normalizes model and reasoning aliases across Codex, Claude Code, CCR, Copilot, Cursor, Droid, Gemini, OpenCode, Pi, and Qwen.
- Makes runtime model catalogs authoritative when discovered, including empty catalogs, so stale static choices do not leak into launcher args.
- Filters bogus Pi and Copilot model catalog values from CLI/help output.
- Makes bridge saved-pairing validation best-effort for transient relay timeouts while preserving hard failure for rejected/expired tokens.

## Testing

- `cargo test -p conductor-executors`
- `cargo test -p conductor-server routes::agents`
- `bun run --cwd packages/web test`
- `bun run --cwd packages/web typecheck`
- `go test ./...` from `bridge-cmd`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p conductor-executors -p conductor-server -- -D warnings`
- Local prod smoke: `http://127.0.0.1:4749/api/health`
- Relay smoke: `https://relay.conductross.com/health`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved bridge pairing validation resilience with graceful fallback during daemon startup.
  * Enhanced agent catalog detection with extended timeout handling and stricter model filtering.
  * Added normalization for saved model and reasoning aliases to improve backward compatibility.

* **New Features**
  * Implemented model name and reasoning effort parameter normalization across multiple agents.

* **Tests**
  * Added validation tests for pairing and model normalization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->