### PR TITLE
Fix bridged agent installation status

### DIFF
--- a/crates/conductor-server/src/routes/config.rs
+++ b/crates/conductor-server/src/routes/config.rs
@@ -2,6 +2,7 @@ use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::routing::get;
 use axum::{Json, Router};
+use futures_util::future::join_all;
 use jsonwebtoken::{decode, decode_header, Algorithm, DecodingKey, Validation};
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -1050,22 +1051,27 @@ async fn list_agents(State(state): State<Arc<AppState>>) -> Json<Value> {
             .map(|(kind, executor)| (kind.clone(), executor.binary_path().to_path_buf()))
             .collect::<Vec<_>>()
     };
-    let mut agents = Vec::with_capacity(executor_entries.len());
-    for (kind, binary_path) in executor_entries {
-        let (description, homepage, icon_url) = agent_metadata(&kind);
-        agents.push(json!({
-            "name": kind.to_string(),
-            "description": description,
-            "version": Value::Null,
-            "homepage": homepage,
-            "iconUrl": icon_url,
-            "installed": true,
-            "configured": true,
-            "ready": true,
-            "runtimeModelCatalog": build_runtime_model_catalog(&kind, &binary_path).await,
-            "binary": binary_path.display().to_string(),
-        }));
-    }
+
+    let agent_tasks = executor_entries
+        .into_iter()
+        .map(|(kind, binary_path)| async move {
+            let (description, homepage, icon_url) = agent_metadata(&kind);
+            let runtime_model_catalog = build_runtime_model_catalog(&kind, &binary_path).await;
+            json!({
+                "name": kind.to_string(),
+                "description": description,
+                "version": Value::Null,
+                "homepage": homepage,
+                "iconUrl": icon_url,
+                "installed": true,
+                "configured": true,
+                "ready": true,
+                "runtimeModelCatalog": runtime_model_catalog,
+                "binary": binary_path.display().to_string(),
+            })
+        });
+
+    let agents = join_all(agent_tasks).await;
     Json(json!({ "agents": agents }))
 }
 

--- a/packages/web/src/features/dashboard/DashboardClient.tsx
+++ b/packages/web/src/features/dashboard/DashboardClient.tsx
@@ -494,6 +494,7 @@ type RepositorySettingsPayload = {
 
 type AgentSetupState = {
   name: string;
+  checking: boolean;
   ready: boolean;
   installed: boolean;
   configured: boolean;
@@ -991,7 +992,7 @@ export default function DashboardClient({
   const { projects, loading: configLoading, error: configError, refresh: refreshConfig } = useConfig(effectiveBridgeId, {
     enabled: scopeRequestsEnabled,
   });
-  const { agents } = useAgents(effectiveBridgeId, { enabled: scopeRequestsEnabled });
+  const { agents, loading: agentsLoading } = useAgents(effectiveBridgeId, { enabled: scopeRequestsEnabled });
   const {
     mobileSidebarOpen,
     desktopSidebarOpen,
@@ -1528,6 +1529,7 @@ export default function DashboardClient({
     for (const known of KNOWN_AGENTS) {
       states[normalizeAgentName(known.name)] = {
         name: known.name,
+        checking: agentsLoading,
         ready: false,
         installed: false,
         configured: false,
@@ -1558,6 +1560,7 @@ export default function DashboardClient({
       const known = getKnownAgent(agent.name);
       states[normalizeAgentName(agent.name)] = {
         name: known?.name ?? agent.name,
+        checking: false,
         ready: agent.ready === true,
         installed: agent.installed !== false,
         configured: agent.configured === true,
@@ -1580,7 +1583,7 @@ export default function DashboardClient({
     }
 
     return states;
-  }, [agents]);
+  }, [agents, agentsLoading]);
 
   const runtimeModelCatalogs = useMemo(() => {
     const catalogs: Record<string, RuntimeAgentModelCatalog> = {};
@@ -1787,6 +1790,10 @@ export default function DashboardClient({
 
     const effectiveAgent = resolveTerminalAgent(selectedAgent || DEFAULT_AGENT, DEFAULT_AGENT);
     const selectedAgentState = agentStatesByName[normalizeAgentName(effectiveAgent)] ?? null;
+    if (selectedAgentState?.checking) {
+      setCreateError(`${getAgentLabel(effectiveAgent)} is still checking installation status. Try again in a moment.`);
+      return false;
+    }
     if (selectedAgentState && !selectedAgentState.ready) {
       setCreateError(
         selectedAgentState.installed

--- a/packages/web/src/hooks/useAgents.ts
+++ b/packages/web/src/hooks/useAgents.ts
@@ -138,8 +138,11 @@ async function refreshAgents(scopeKey: string, bridgeId?: string | null, force =
     return store.inFlight;
   }
 
-  store.loading = true;
-  emitChange(scopeKey);
+  const hasCachedAgents = store.agents.length > 0;
+  if (!force || !hasCachedAgents) {
+    store.loading = true;
+    emitChange(scopeKey);
+  }
 
   store.inFlight = (async () => {
     try {

--- a/packages/web/src/lib/agentSetupStatus.test.ts
+++ b/packages/web/src/lib/agentSetupStatus.test.ts
@@ -5,6 +5,7 @@ import { agentModelAccessBadgeLabel, agentSetupStatusLabel } from "./agentSetupS
 
 test("agentSetupStatusLabel separates CLI readiness from auth and install state", () => {
   assert.equal(agentSetupStatusLabel(null), "Install needed");
+  assert.equal(agentSetupStatusLabel({ checking: true, installed: false, ready: false, configured: false }), "Checking install");
   assert.equal(agentSetupStatusLabel({ installed: false, ready: false, configured: false }), "Install needed");
   assert.equal(agentSetupStatusLabel({ installed: true, ready: false, configured: false }), "Auth needed");
   assert.equal(agentSetupStatusLabel({ installed: true, ready: false, configured: true }), "Setup needed");

--- a/packages/web/src/lib/agentSetupStatus.ts
+++ b/packages/web/src/lib/agentSetupStatus.ts
@@ -1,10 +1,12 @@
 export type AgentSetupStatusInput = {
+  checking?: boolean;
   installed?: boolean;
   ready?: boolean;
   configured?: boolean;
 } | null | undefined;
 
 export function agentSetupStatusLabel(state: AgentSetupStatusInput): string {
+  if (state?.checking) return "Checking install";
   if (!state?.installed) return "Install needed";
   if (state.ready) return "CLI ready";
   if (state.configured === false) return "Auth needed";


### PR DESCRIPTION
## User-Facing Release Notes

- Agent installation status now loads correctly through the paired-device bridge instead of showing every installed CLI as needing installation.
- The dashboard shows a checking state while agent detection is still loading, rather than falsely labeling agents as missing.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Testing

- `cargo fmt --check`
- `cargo test -p conductor-server routes::config::tests:: --lib`
- `bun run --cwd packages/web typecheck`
- `tsx --test packages/web/src/lib/agentSetupStatus.test.ts`
- Local `/api/agents` returns 12 installed and ready agents in ~8s.
- Relay `/api/devices/:id/proxy` to `/api/agents` returns 12 installed and ready agents in ~9s.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent metadata is now fetched concurrently, improving listing performance.
  * Added "Checking install" status indicator to display when agents are being validated.
  * Session creation is now blocked when the selected agent is checking, with guidance to retry later.

* **Tests**
  * Added test coverage for the checking status label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->