### PR TITLE
fix: preserve bridge preview manual URLs

### DIFF
--- a/bridge-cmd/relay/client_test.go
+++ b/bridge-cmd/relay/client_test.go
@@ -130,3 +130,53 @@ func TestTtydInstallHintForGOOS(t *testing.T) {
 		t.Fatalf("Darwin ttyd hint = %q, want Homebrew guidance", darwinHint)
 	}
 }
+
+func TestNormalizePreviewURLAllowsLoopbackDevServers(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"http://localhost:3000",
+		"http://127.0.0.1:3000/app",
+		"http://[::1]:3000",
+	}
+	for _, raw := range cases {
+		raw := raw
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			if _, err := normalizePreviewURL(raw); err != nil {
+				t.Fatalf("normalizePreviewURL(%q) returned error: %v", raw, err)
+			}
+		})
+	}
+}
+
+func TestNormalizePreviewURLRewritesUnspecifiedHost(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := normalizePreviewURL("http://0.0.0.0:3000")
+	if err != nil {
+		t.Fatalf("normalizePreviewURL returned error: %v", err)
+	}
+	if parsed.Host != "127.0.0.1:3000" {
+		t.Fatalf("Host = %q, want 127.0.0.1:3000", parsed.Host)
+	}
+}
+
+func TestNormalizePreviewURLRejectsNonLoopbackHosts(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"https://example.com",
+		"http://192.168.1.10",
+		"file:///tmp/app.html",
+	}
+	for _, raw := range cases {
+		raw := raw
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			if _, err := normalizePreviewURL(raw); err == nil {
+				t.Fatalf("normalizePreviewURL(%q) succeeded, want error", raw)
+			}
+		})
+	}
+}

--- a/crates/conductor-cli/src/bridge.rs
+++ b/crates/conductor-cli/src/bridge.rs
@@ -428,7 +428,7 @@ fn is_allowed_preview_ip(ip: &std::net::IpAddr) -> bool {
 
 /// Resolve a hostname and allow only paired-device loopback preview targets.
 /// Returns the block reason, if any.
-fn check_preview_host_allowed(host: &str, port: Option<u16>) -> Option<String> {
+fn check_preview_host_allowed(host: &str, _port: Option<u16>) -> Option<String> {
     let host_lower = host.to_ascii_lowercase();
     if host_lower == "localhost"
         || host_lower == "ip6-localhost"
@@ -436,7 +436,6 @@ fn check_preview_host_allowed(host: &str, port: Option<u16>) -> Option<String> {
         || host_lower == "::1"
         || host_lower == "[::1]"
         || host_lower == "0.0.0.0"
-        || host_lower.ends_with(".localhost")
     {
         return None;
     }
@@ -448,27 +447,7 @@ fn check_preview_host_allowed(host: &str, port: Option<u16>) -> Option<String> {
         return Some(format!("non-loopback preview IP: {host}"));
     }
 
-    let host_for_dns = host.trim_start_matches('[').trim_end_matches(']');
-    let ip_addrs: Vec<std::net::SocketAddr> =
-        match std::net::ToSocketAddrs::to_socket_addrs(&(host_for_dns, port.unwrap_or(0))) {
-            Ok(addrs) => addrs.collect(),
-            Err(_) => return Some(format!("unverified preview hostname: {host}")),
-        };
-
-    if ip_addrs.is_empty() {
-        return Some(format!("unresolved preview hostname: {host}"));
-    }
-
-    if ip_addrs
-        .iter()
-        .all(|addr| is_allowed_preview_ip(&addr.ip()))
-    {
-        return None;
-    }
-
-    Some(format!(
-        "preview hostname resolved outside loopback: {host}"
-    ))
+    Some(format!("non-loopback preview hostname: {host}"))
 }
 
 /// Strips CR/LF characters from header names and values to prevent response splitting attacks.

--- a/crates/conductor-cli/src/bridge.rs
+++ b/crates/conductor-cli/src/bridge.rs
@@ -459,11 +459,16 @@ fn check_preview_host_allowed(host: &str, port: Option<u16>) -> Option<String> {
         return Some(format!("unresolved preview hostname: {host}"));
     }
 
-    if ip_addrs.iter().all(|addr| is_allowed_preview_ip(&addr.ip())) {
+    if ip_addrs
+        .iter()
+        .all(|addr| is_allowed_preview_ip(&addr.ip()))
+    {
         return None;
     }
 
-    Some(format!("preview hostname resolved outside loopback: {host}"))
+    Some(format!(
+        "preview hostname resolved outside loopback: {host}"
+    ))
 }
 
 /// Strips CR/LF characters from header names and values to prevent response splitting attacks.

--- a/crates/conductor-cli/src/bridge.rs
+++ b/crates/conductor-cli/src/bridge.rs
@@ -353,10 +353,11 @@ async fn proxy_preview_request(
         ),
     }
 
-    // SSRF protection — check host before any connection is made
+    // Preview requests intentionally target the paired machine's own dev server.
+    // Keep the bridge path loopback-only, but do not block localhost itself.
     let host = parsed_url.host_str().unwrap_or("");
-    if let Some(blocked) = check_host_for_ssrf(host, parsed_url.port()) {
-        tracing::warn!(target: "conductor-bridge", "ssrf blocked: {}", blocked);
+    if let Some(blocked) = check_preview_host_allowed(host, parsed_url.port()) {
+        tracing::warn!(target: "conductor-bridge", "preview host blocked: {}", blocked);
         anyhow::bail!("request to {} is not allowed", host);
     }
 
@@ -418,110 +419,51 @@ async fn proxy_preview_request(
     })
 }
 
-/// Returns true if the IP is in a private, loopback, link-local, or reserved range.
-fn is_blocked_ip(ip: &std::net::IpAddr) -> bool {
+fn is_allowed_preview_ip(ip: &std::net::IpAddr) -> bool {
     match ip {
-        std::net::IpAddr::V4(v4) => {
-            v4.is_loopback()
-                || v4.is_private()
-                || v4.is_multicast()
-                || v4.is_unspecified()
-                || is_cloud_metadata_ip(&std::net::IpAddr::V4(*v4))
-                || is_broadcast_ip(&std::net::IpAddr::V4(*v4))
-                || is_documentation_ip(&std::net::IpAddr::V4(*v4))
-        }
-        std::net::IpAddr::V6(v6) => {
-            v6.is_loopback()
-                || v6.is_unicast_link_local()
-                || v6.is_multicast()
-                || is_ipv6_unique_local(&std::net::IpAddr::V6(*v6))
-                || is_ipv6_teredo(&std::net::IpAddr::V6(*v6))
-        }
+        std::net::IpAddr::V4(v4) => v4.is_loopback() || v4.is_unspecified(),
+        std::net::IpAddr::V6(v6) => v6.is_loopback(),
     }
 }
 
-fn is_cloud_metadata_ip(ip: &std::net::IpAddr) -> bool {
-    // 169.254.169.254, 169.254.169.253, 169.254.169.255 — AWS/GCP/Azure metadata endpoints
-    match ip {
-        std::net::IpAddr::V4(v4) => {
-            let octets = v4.octets();
-            octets[0] == 169 && octets[1] == 254 && octets[2] == 169
-        }
-        _ => false,
-    }
-}
-
-fn is_broadcast_ip(ip: &std::net::IpAddr) -> bool {
-    // 255.255.255.255
-    matches!(ip, std::net::IpAddr::V4(v4) if v4.octets() == [255, 255, 255, 255])
-}
-
-fn is_documentation_ip(ip: &std::net::IpAddr) -> bool {
-    // 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24 — RFC 5737 documentation ranges
-    match ip {
-        std::net::IpAddr::V4(v4) => {
-            let octets = v4.octets();
-            octets[0] == 192 && octets[1] == 0 && octets[2] == 2
-                || octets[0] == 198 && octets[1] == 51 && octets[2] == 100
-                || octets[0] == 203 && octets[1] == 0 && octets[2] == 113
-        }
-        _ => false,
-    }
-}
-
-fn is_ipv6_unique_local(ip: &std::net::IpAddr) -> bool {
-    // fc00::/7 — IPv6 unique local addresses
-    matches!(ip, std::net::IpAddr::V6(v6) if v6.segments()[0] & 0xfe00 == 0xfc00)
-}
-
-fn is_ipv6_teredo(ip: &std::net::IpAddr) -> bool {
-    // 2001::/32 — IPv6 Teredo tunnel addresses
-    matches!(ip, std::net::IpAddr::V6(v6) if v6.segments()[0] == 0x2001)
-}
-
-/// Resolve a hostname and check all resulting IPs against blocked ranges.
-/// Returns the first blocked IP found, if any.
-fn check_host_for_ssrf(host: &str, port: Option<u16>) -> Option<String> {
-    // Block obvious internal hostnames before DNS lookup
+/// Resolve a hostname and allow only paired-device loopback preview targets.
+/// Returns the block reason, if any.
+fn check_preview_host_allowed(host: &str, port: Option<u16>) -> Option<String> {
     let host_lower = host.to_ascii_lowercase();
     if host_lower == "localhost"
         || host_lower == "ip6-localhost"
         || host_lower == "ip6-loopback"
+        || host_lower == "::1"
         || host_lower == "[::1]"
         || host_lower == "0.0.0.0"
-        || host_lower == "*"
-        || host_lower.ends_with(".local")
-        || host_lower.ends_with(".internal")
-        || host_lower.ends_with(".private")
+        || host_lower.ends_with(".localhost")
     {
-        return Some(format!("blocked hostname: {host}"));
-    }
-
-    // Try to parse as IP directly first
-    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
-        if is_blocked_ip(&ip) {
-            return Some(format!("blocked IP: {host}"));
-        }
         return None;
     }
 
-    // Strip brackets from IPv6 hosts in URL format
-    let host_for_dns = host.trim_start_matches('[').trim_end_matches(']');
+    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+        if is_allowed_preview_ip(&ip) {
+            return None;
+        }
+        return Some(format!("non-loopback preview IP: {host}"));
+    }
 
-    // Attempt DNS resolution and check all IPs against blocked ranges
+    let host_for_dns = host.trim_start_matches('[').trim_end_matches(']');
     let ip_addrs: Vec<std::net::SocketAddr> =
         match std::net::ToSocketAddrs::to_socket_addrs(&(host_for_dns, port.unwrap_or(0))) {
             Ok(addrs) => addrs.collect(),
-            Err(_) => return None, // Let reqwest handle invalid hostnames
+            Err(_) => return Some(format!("unverified preview hostname: {host}")),
         };
 
-    for addr in &ip_addrs {
-        if is_blocked_ip(&addr.ip()) {
-            return Some(format!("DNS resolved to blocked IP: {host} -> {addr}"));
-        }
+    if ip_addrs.is_empty() {
+        return Some(format!("unresolved preview hostname: {host}"));
     }
 
-    None
+    if ip_addrs.iter().all(|addr| is_allowed_preview_ip(&addr.ip())) {
+        return None;
+    }
+
+    Some(format!("preview hostname resolved outside loopback: {host}"))
 }
 
 /// Strips CR/LF characters from header names and values to prevent response splitting attacks.
@@ -1194,5 +1136,20 @@ mod tests {
                 .and_then(|value| value.to_str().ok()),
             Some("tty")
         );
+    }
+
+    #[test]
+    fn preview_host_allows_loopback_dev_servers() {
+        assert_eq!(check_preview_host_allowed("localhost", Some(3000)), None);
+        assert_eq!(check_preview_host_allowed("127.0.0.1", Some(3000)), None);
+        assert_eq!(check_preview_host_allowed("[::1]", Some(3000)), None);
+        assert_eq!(check_preview_host_allowed("0.0.0.0", Some(3000)), None);
+    }
+
+    #[test]
+    fn preview_host_blocks_non_loopback_targets() {
+        assert!(check_preview_host_allowed("192.168.1.1", Some(80)).is_some());
+        assert!(check_preview_host_allowed("example.com", Some(443)).is_some());
+        assert!(check_preview_host_allowed("metadata.google.internal", Some(80)).is_some());
     }
 }

--- a/docs/preview-functionality-review.md
+++ b/docs/preview-functionality-review.md
@@ -1,0 +1,62 @@
+# Preview functionality review
+
+Date: 2026-06-23
+
+## Scope
+
+Reviewed the production preview path end to end:
+
+1. `SessionPreview` UI controls and screenshot/DOM loading.
+2. Next.js preview API routes under `packages/web/src/app/api/sessions/[id]/preview`.
+3. Candidate discovery in `packages/web/src/lib/previewSession.ts`.
+4. Remote preview worker client in `packages/web/src/lib/previewWorkerClient.ts`.
+5. Preview worker browser/session implementation under `preview-worker/src`.
+6. Relay bridge forwarding in `crates/conductor-relay/src/relay.rs`.
+7. Paired-device bridge client code in `bridge-cmd/relay/client.go` and Rust CLI bridge fallback in `crates/conductor-cli/src/bridge.rs`.
+8. Current production wiring for Vercel, relay, and preview-worker health.
+
+## Production findings
+
+- `app.conductross.com` production deployment is ready and recent.
+- Vercel production has `CONDUCTOR_PREVIEW_WORKER_URL`, `CONDUCTOR_PREVIEW_WORKER_KEY`, `CONDUCTOR_BRIDGE_RELAY_URL`, `NEXT_PUBLIC_CONDUCTOR_BRIDGE_RELAY_URL`, and `RELAY_JWT_SECRET` configured.
+- Relay public health is healthy and reported one active bridge channel during review.
+- Preview worker public health is healthy at the Contabo-backed worker endpoint and reported zero active sessions at the time of review.
+- Preview worker container has bridge-preview support present: `clientSessionId`, `bridgePreview`, `requestBridgePreview`, and tunnel readiness code are in the live container.
+
+## Main broken path found
+
+Manual preview URLs on hosted bridge sessions were not preserved across every preview endpoint.
+
+The main status and connect route accepted `previewUrlHint`, so a user could type `http://localhost:3000` and press Connect. But screenshot and DOM inspector requests did not forward that hint. For bridge sessions without a saved project dev-server URL or session metadata, those follow-up routes reconstructed preview context without the manual URL, then called the preview manager with no bridge preview config.
+
+That means a successful manual connection could immediately lose the bridge config when the screenshot image or DOM inspector loaded. From the product surface this looks like preview never really starts in production.
+
+Fixed in this branch by:
+
+- Passing `previewUrlHint` from `SessionPreview` to screenshot and DOM requests.
+- Teaching `/preview/screenshot` and `/preview/dom` routes to read `previewUrlHint` and preserve the bridge preview config.
+- Adding a regression test that proves bridge DOM and screenshot routes use the manual URL hint and do not fall through to repository lookup.
+
+## Secondary broken path found
+
+The Rust `conductor-cli` bridge preview proxy blocked `localhost` and `127.0.0.1` as SSRF targets. That is backwards for bridge preview: the paired device must be able to proxy its own loopback dev server.
+
+The hosted installer currently uses the Go `conductor-bridge` client, whose preview URL handling already allows loopback hosts and rejects non-loopback hosts. Still, the Rust CLI bridge fallback was wrong and could break anyone using `co bridge` directly.
+
+Fixed in this branch by:
+
+- Replacing the Rust preview host check with a loopback-only allowlist.
+- Allowing `localhost`, `127.0.0.1`, `[::1]`, and `0.0.0.0` for dev servers.
+- Blocking public, LAN, metadata, and unverified hosts on the bridge preview path.
+- Adding Rust regression tests for loopback and non-loopback preview hosts.
+
+## Verified behavior after fixes
+
+- Hosted bridge UI keeps the manual preview URL attached to status, screenshot, and DOM inspector calls.
+- Bridge preview stays loopback-only on the paired device side.
+- Direct remote preview URLs still use direct worker navigation, not bridge relay proxying.
+- Production services needed by preview are online and configured.
+
+## Follow-up recommendation
+
+The next product hardening pass should add a visible preview health panel in the UI that shows which layer is failing: candidate discovery, worker session creation, bridge relay forwarding, paired-device HTTP fetch, screenshot capture, or DOM inspection. Right now those failures blur into a generic disconnected preview state, which makes production issues feel like the feature simply does not exist.

--- a/packages/web/src/app/api/sessions/[id]/preview/dom/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/preview/dom/route.ts
@@ -14,6 +14,12 @@ export const dynamic = "force-dynamic";
 
 type RouteParams = { params: Promise<{ id: string }> };
 
+function readPreviewUrlHint(request: NextRequest): string | null {
+  const value = request.nextUrl.searchParams.get("previewUrlHint");
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
 export async function GET(request: NextRequest, context: RouteParams): Promise<Response> {
   const denied = await guardApiAccess(request, "viewer");
   if (denied) return denied;
@@ -32,6 +38,7 @@ export async function GET(request: NextRequest, context: RouteParams): Promise<R
   const previewContext = await loadPreviewSessionContext(id, {
     request,
     headers: forwardedHeaders,
+    previewUrlHint: readPreviewUrlHint(request),
   });
   if (!previewContext.session && !previewContext.error) {
     return NextResponse.json({ error: `Session ${id} not found` }, { status: 404 });

--- a/packages/web/src/app/api/sessions/[id]/preview/route.test.ts
+++ b/packages/web/src/app/api/sessions/[id]/preview/route.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { NextRequest } from "next/server";
 import { GET, POST } from "./route";
+import { GET as GET_DOM } from "./dom/route";
+import { GET as GET_SCREENSHOT } from "./screenshot/route";
 
 const originalBackendUrl = process.env.CONDUCTOR_BACKEND_URL;
 const originalBridgeRelayUrl = process.env.CONDUCTOR_BRIDGE_RELAY_URL;
@@ -489,6 +491,88 @@ test("POST clones the bridge request before preview lookup so body reuse does no
     assert.ok(!payload.error.includes("Body is unusable"));
     assert.deepEqual(payload.status.candidateUrls, ["http://localhost:3002/"]);
     assert.ok(payload.status.lastError === null || !payload.status.lastError.includes("Body is unusable"));
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("bridge DOM and screenshot routes preserve explicit previewUrlHint", async () => {
+  resetEnv();
+  process.env.CONDUCTOR_BACKEND_URL = "https://api.example.com";
+  process.env.CONDUCTOR_BRIDGE_RELAY_URL = "https://relay.example.com";
+  process.env.RELAY_JWT_SECRET = "preview-route-test-secret";
+
+  const seenPaths: string[] = [];
+
+  global.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" || input instanceof URL
+      ? String(input)
+      : input.url;
+
+    assert.equal(url, "https://relay.example.com/api/devices/bridge-1/proxy");
+    assert.equal(init?.method, "POST");
+
+    const body = JSON.parse(String(init?.body)) as { path: string };
+    seenPaths.push(body.path);
+
+    if (body.path === "/api/sessions/session-1") {
+      return new Response(JSON.stringify({
+        id: "session-1",
+        projectId: "demo",
+        status: "working",
+        activity: "active",
+        branch: "feature/demo",
+        issueId: null,
+        summary: null,
+        createdAt: new Date().toISOString(),
+        lastActivityAt: new Date().toISOString(),
+        pr: null,
+        metadata: {},
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (body.path === "/api/sessions/session-1/output?lines=400") {
+      return new Response(JSON.stringify({ output: "" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (body.path === "/api/repositories") {
+      return new Response(JSON.stringify({ repositories: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify({ error: "not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  try {
+    const screenshotResponse = await GET_SCREENSHOT(
+      new NextRequest("http://127.0.0.1:3000/api/sessions/bridge%3Abridge-1%3Asession-1/preview/screenshot?previewUrlHint=http%3A%2F%2Flocalhost%3A3002%2F"),
+      { params: Promise.resolve({ id: "bridge:bridge-1:session-1" }) },
+    );
+    assert.equal(screenshotResponse.status, 404);
+
+    const domResponse = await GET_DOM(
+      new NextRequest("http://127.0.0.1:3000/api/sessions/bridge%3Abridge-1%3Asession-1/preview/dom?interactiveOnly=1&previewUrlHint=http%3A%2F%2Flocalhost%3A3002%2F"),
+      { params: Promise.resolve({ id: "bridge:bridge-1:session-1" }) },
+    );
+    assert.equal(domResponse.status, 400);
+
+    assert.deepEqual(seenPaths, [
+      "/api/sessions/session-1",
+      "/api/sessions/session-1/output?lines=400",
+      "/api/sessions/session-1",
+      "/api/sessions/session-1/output?lines=400",
+    ]);
   } finally {
     global.fetch = originalFetch;
   }

--- a/packages/web/src/app/api/sessions/[id]/preview/screenshot/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/preview/screenshot/route.ts
@@ -14,6 +14,12 @@ export const dynamic = "force-dynamic";
 
 type RouteParams = { params: Promise<{ id: string }> };
 
+function readPreviewUrlHint(request: NextRequest): string | null {
+  const value = request.nextUrl.searchParams.get("previewUrlHint");
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
 export async function GET(request: NextRequest, context: RouteParams): Promise<Response> {
   const denied = await guardApiAccess(request, "viewer");
   if (denied) return denied;
@@ -32,6 +38,7 @@ export async function GET(request: NextRequest, context: RouteParams): Promise<R
   const previewContext = await loadPreviewSessionContext(id, {
     request,
     headers: forwardedHeaders,
+    previewUrlHint: readPreviewUrlHint(request),
   });
   if (!previewContext.session && !previewContext.error) {
     return NextResponse.json({ error: `Session ${id} not found` }, { status: 404 });

--- a/packages/web/src/components/sessions/SessionPreview.tsx
+++ b/packages/web/src/components/sessions/SessionPreview.tsx
@@ -565,6 +565,8 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
       const searchParams = new URLSearchParams();
       if (frameId) searchParams.set("frameId", frameId);
       if (interactiveOnly) searchParams.set("interactiveOnly", "1");
+      const previewUrlHint = urlInput.trim();
+      if (previewUrlHint) searchParams.set("previewUrlHint", previewUrlHint);
       const response = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/preview/dom?${searchParams.toString()}`, {
         cache: "no-store",
       });
@@ -583,7 +585,7 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
     } finally {
       setDomLoading(false);
     }
-  }, [interactiveOnly, sessionId, status?.connected]);
+  }, [interactiveOnly, sessionId, status?.connected, urlInput]);
 
   useEffect(() => {
     if (!shouldRunPreview) {
@@ -719,11 +721,17 @@ export function SessionPreview({ sessionId, active, onQueueTerminalInsert, onCon
     };
   }, [active, domNodes.length, pageVisible, previewInspectorTab, previewMode, sessionId, shouldRunPreview, status?.connected, status?.screenshotKey]);
 
-  const screenshotUrl = useMemo(() => (
-    status?.connected
-      ? `/api/sessions/${encodeURIComponent(sessionId)}/preview/screenshot?ts=${encodeURIComponent(status.screenshotKey)}`
-      : null
-  ), [sessionId, status?.connected, status?.screenshotKey]);
+  const screenshotUrl = useMemo(() => {
+    if (!status?.connected) {
+      return null;
+    }
+    const searchParams = new URLSearchParams({ ts: status.screenshotKey });
+    const previewUrlHint = urlInput.trim();
+    if (previewUrlHint) {
+      searchParams.set("previewUrlHint", previewUrlHint);
+    }
+    return `/api/sessions/${encodeURIComponent(sessionId)}/preview/screenshot?${searchParams.toString()}`;
+  }, [sessionId, status?.connected, status?.screenshotKey, urlInput]);
   const preferredUrlInputCandidate = autoConnectCandidate ?? status?.candidateUrls[0] ?? null;
 
   const activeFrame = useMemo(


### PR DESCRIPTION
## Summary

- Fixed hosted bridge preview manual URLs so the screenshot and DOM inspector routes preserve `previewUrlHint` instead of dropping the bridge preview config after Connect.
- Tightened the Rust `co bridge` preview proxy to allow only loopback dev-server targets while no longer blocking localhost itself.
- Added a review doc covering the preview stack and production wiring check.
- Added regression coverage for the hosted preview routes, Go bridge loopback URL handling, and Rust bridge preview host allowlist.

## User-Facing Release Notes

- Fixes hosted bridge previews for manually entered local dev-server URLs such as `http://localhost:3000`.
- Keeps preview screenshots and DOM inspection attached to the same manually entered URL after connecting.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [x] Documentation Update
- [ ] Refactor / Chore

## Testing

- `bun test packages/web/src/app/api/sessions/[id]/preview/route.test.ts packages/web/src/lib/previewSession.test.ts packages/web/src/lib/previewWorkerClient.test.ts packages/web/src/lib/devPreviewBrowser.test.ts`
- `bun run --cwd packages/web test`
- `bun run --cwd packages/web typecheck`
- `bun run --cwd packages/web build`
- `bun run --cwd preview-worker test`
- `bun run --cwd preview-worker typecheck`
- `bun run --cwd preview-worker build`
- `go test ./...` from `bridge-cmd/`
- `cargo test -p conductor-cli --quiet`
- `cargo test -p conductor-relay --quiet`
- `cargo build -p conductor-cli --release`
- `cargo clippy -p conductor-cli -- -D warnings`
- `cargo fmt --all`
- `git diff --check`

## Production Review Notes

- Vercel production deployment for `app.conductross.com` is Ready.
- Vercel production has preview worker, bridge relay, and relay signing env vars configured.
- `https://relay.conductross.com/health` is healthy and reported an active bridge channel during review.
- The Contabo preview worker container is healthy and has bridge preview support present in the live build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed preview functionality that incorrectly blocked local development servers.
  * Fixed preview URL hints not being preserved across screenshot and DOM inspection requests.

* **Documentation**
  * Added comprehensive documentation for the preview functionality flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->