### PR TITLE
ci: configure npm registry for dependabot

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
## User-Facing Release Notes

N/A - internal maintenance only

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [ ] Bug Fix
- [ ] Documentation Update
- [x] Refactor / Chore

## Summary

Adds a repo-level npm registry config so Dependabot's npm update jobs use the public npm registry instead of failing on the auto-injected GitHub Packages credential.

## Testing

- `npm config get registry --userconfig .npmrc`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s package registry configuration to use the standard npm registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->