### PR TITLE
fix: complete protected production rollouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Relay lifecycle safety** — relay ownership, reconnect generations, persistence ordering, and pending terminal lifecycles are bounded and consistent.
 - **Preview lifecycle safety** — browser allocation is capacity-safe and timed-out work is cancelled without leaving untracked sessions.
 - **Recoverable production updates** — relay state is snapshotted transactionally, failed relay/preview candidates roll back through public health, and release retries reuse the exact npm artifact bytes already published.
+- **Sandboxed preview rollout** — the production worker retains only Chromium's required `SYS_ADMIN` and `SYS_CHROOT` capabilities, allowing the browser sandbox smoke test to pass without disabling `no-new-privileges` or the read-only container boundary.
 
 ## [0.61.11] - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Preview lifecycle safety** — browser allocation is capacity-safe and timed-out work is cancelled without leaving untracked sessions.
 - **Recoverable production updates** — relay state is snapshotted transactionally, failed relay/preview candidates roll back through public health, and release retries reuse the exact npm artifact bytes already published.
 - **Sandboxed preview rollout** — the production worker retains only Chromium's required `SYS_ADMIN` and `SYS_CHROOT` capabilities, allowing the browser sandbox smoke test to pass without disabling `no-new-privileges` or the read-only container boundary.
+- **Relay state migration** — the protected rollout command securely migrates the known legacy `/data/relay-state.json` volume layout to the canonical state path without losing device ownership or weakening rollback.
 
 ## [0.61.11] - 2026-07-02
 

--- a/docs/preview-worker-deployment.md
+++ b/docs/preview-worker-deployment.md
@@ -14,7 +14,7 @@ Create the `preview-production` GitHub environment, restrict its deployment bran
 - `PREVIEW_DEPLOY_SSH_HOST_KEY`: pinned `known_hosts` entry collected out of band
 - `PREVIEW_WORKER_HEALTHCHECK_URL`: public TLS endpoint, such as `https://preview-worker.example.com/health`
 
-The worker host must already have a `WORKER_API_KEY` of at least 32 bytes. Keep `CONDUCTOR_PREVIEW_WORKER_DISABLE_SANDBOX=false`; the host's unprivileged user namespaces must support Chromium's sandbox. The forced deployment command launches a real browser session before accepting the rollout, so a sandbox or capability regression triggers rollback.
+The worker host must already have a `WORKER_API_KEY` of at least 32 bytes. Keep `CONDUCTOR_PREVIEW_WORKER_DISABLE_SANDBOX=false`. Chromium's sandbox setup requires `SYS_ADMIN` and `SYS_CHROOT` in this container; the forced command drops every capability and then restores only those two. The command launches a real browser session before accepting the rollout, so a sandbox or capability regression triggers rollback.
 
 ## Host command contract
 
@@ -33,7 +33,7 @@ restrict,command="/usr/local/sbin/conductor-preview-deploy" ssh-ed25519 ...
 
 The deployment user needs Docker access, GNU `timeout`, `jq`, and an owner-writable `/var/lock/conductor-preview-deploy.lock`, but no unrestricted SSH key. The workflow uses the non-mutating integrity probe to require that the installed command matches the reviewed repository script, so an administrator must reinstall the root-owned command whenever it changes.
 
-The forced command preserves the existing API key and session limits without putting the key in Docker command arguments, applies `no-new-privileges`, drops Linux capabilities, uses a read-only root filesystem plus a bounded temporary filesystem, enforces process/memory/CPU and Docker-log limits, joins the private Caddy network without publishing port 3099 on the host, verifies the exact build, creates and deletes a sandboxed session, checks both Caddy and the public TLS endpoint, and restores the previous container on failure. Destructive Docker operations have host-side deadlines so a stuck daemon call cannot leave the rollout lock held indefinitely.
+The forced command preserves the existing API key and session limits without putting the key in Docker command arguments, applies `no-new-privileges`, drops all Linux capabilities before restoring only `SYS_ADMIN` and `SYS_CHROOT` for Chromium's sandbox, uses a read-only root filesystem plus a bounded temporary filesystem, enforces process/memory/CPU and Docker-log limits, joins the private Caddy network without publishing port 3099 on the host, verifies the exact build, creates and deletes a sandboxed session, checks both Caddy and the public TLS endpoint, and restores the previous container on failure. Destructive Docker operations have host-side deadlines so a stuck daemon call cannot leave the rollout lock held indefinitely.
 
 ## Network boundary
 

--- a/docs/relay-deployment.md
+++ b/docs/relay-deployment.md
@@ -62,7 +62,7 @@ The host command should:
 1. Reject every other command and image registry
 2. Serialize rollouts with a host lock
 3. Pull the requested digest-pinned image
-4. Require the exact `/var/lib/conductor-relay/state.json` path on the named state volume
+4. Require the exact `/var/lib/conductor-relay/state.json` path on the named state volume, or migrate the single known legacy `/data/relay-state.json` layout
 5. Take a mode-`0600`, memory-backed state snapshot while the old relay is stopped
 6. Pass the JWT secret through the Docker client environment, never as a command argument
 7. Replace the container with a read-only root filesystem, bounded resources and logs, dropped capabilities, and `no-new-privileges`
@@ -78,6 +78,8 @@ restrict,command="/usr/local/sbin/conductor-relay-deploy" ssh-ed25519 ...
 Install [`scripts/conductor-relay-deploy-host.sh`](../scripts/conductor-relay-deploy-host.sh) as the root-owned, non-writable `/usr/local/sbin/conductor-relay-deploy` forced command. Its deployment user needs access to Docker, `flock`, `jq`, GNU `timeout`, a writable memory-backed `/dev/shm`, and an owner-writable `/var/lock/conductor-relay-deploy.lock`; the account itself should have a locked password and no unrestricted authorized key. The temporary rollback snapshot is never printed, is removed after success or rollback, and is not a substitute for an encrypted off-host backup.
 
 The workflow checks the installed command against the reviewed repository script before every rollout. A script change therefore requires an administrator to reinstall the root-owned host command before merging; a stale command fails closed instead of deploying with host drift.
+
+The migration exception is deliberately narrow: only the same named volume mounted at `/data` with `RELAY_STATE_FILE=/data/relay-state.json` is accepted. The command stops the old relay, takes the memory-backed mode-`0600` snapshot, copies it to the canonical filename while retaining the legacy file for rollback, and deletes the legacy duplicate only after private, proxy, and public exact-build health all pass. Any other mount, filename, symlink, non-regular file, conflicting canonical file, or insecure state-file mode fails closed.
 
 ## Manual fallback
 

--- a/scripts/conductor-preview-deploy-host.sh
+++ b/scripts/conductor-preview-deploy-host.sh
@@ -147,6 +147,8 @@ run_docker run -d \
   --read-only \
   --security-opt no-new-privileges:true \
   --cap-drop ALL \
+  --cap-add SYS_ADMIN \
+  --cap-add SYS_CHROOT \
   --pids-limit 512 \
   --memory 4g \
   --cpus 2 \

--- a/scripts/conductor-relay-deploy-host.sh
+++ b/scripts/conductor-relay-deploy-host.sh
@@ -9,12 +9,21 @@ secondary_network="clawcloud_clawnet"
 state_volume="conductor-relay-state"
 state_mount_destination_expected="/var/lib/conductor-relay"
 state_file_expected="/var/lib/conductor-relay/state.json"
+state_mount_destination_legacy="/data"
+state_file_legacy="/data/relay-state.json"
+state_filename_expected="state.json"
+state_filename_legacy="relay-state.json"
+state_layout=""
+state_filename_current=""
 public_health_url="https://relay.conductross.com/health"
 docker_command_timeout_seconds=45
+state_backup_max_bytes=67108864
 state_backup_dir=""
 state_backup_owner=""
+state_backup_size=0
 state_backup_existed=0
 state_backup_ready=0
+candidate_state_owner=""
 
 run_docker() {
   timeout --foreground --kill-after=5s "${docker_command_timeout_seconds}s" docker "$@"
@@ -26,13 +35,22 @@ cleanup_state_backup() {
   fi
   state_backup_dir=""
   state_backup_owner=""
+  state_backup_size=0
   state_backup_existed=0
   state_backup_ready=0
 }
 
 backup_relay_state() {
-  if [ ! -d /dev/shm ] || [ ! -w /dev/shm ]; then
+  if [ ! -d /dev/shm ] || [ ! -w /dev/shm ] \
+    || ! command -v findmnt >/dev/null 2>&1 \
+    || [ "$(findmnt -n -o FSTYPE --target /dev/shm 2>/dev/null || true)" != "tmpfs" ]; then
     echo "A writable memory-backed /dev/shm is required for the relay rollback snapshot." >&2
+    return 1
+  fi
+  state_backup_available_bytes=$(df -PB1 /dev/shm | awk 'NR == 2 { print $4 }')
+  if [[ ! "$state_backup_available_bytes" =~ ^[0-9]+$ ]] \
+    || [ "$state_backup_available_bytes" -lt "$state_backup_max_bytes" ]; then
+    echo "Insufficient memory-backed capacity for the relay rollback snapshot." >&2
     return 1
   fi
 
@@ -44,36 +62,84 @@ backup_relay_state() {
     --user 0:0 \
     --security-opt no-new-privileges:true \
     --cap-drop ALL \
+    --cap-add DAC_OVERRIDE \
     --mount "type=volume,src=${state_volume},dst=/state,readonly" \
     --mount "type=bind,src=${state_backup_dir},dst=/backup" \
     --entrypoint /bin/sh \
     "$current_image_id" \
     -ec '
-      if [ -L /state/state.json ]; then
+      source_name="$1"
+      expected_owner="$2"
+      max_bytes="$3"
+      case "$source_name" in
+        state.json) other_name="relay-state.json" ;;
+        relay-state.json) other_name="state.json" ;;
+        *) exit 2 ;;
+      esac
+      source_path="/state/$source_name"
+      other_path="/state/$other_name"
+      if [ ! -d /state ] \
+        || [ "$(stat -c %a /state)" != "700" ] \
+        || [ "$(stat -c %u:%g /state)" != "$expected_owner" ]; then
         exit 2
       fi
-      if [ -e /state/state.json ] && [ ! -f /state/state.json ]; then
+      entry_count=0
+      for entry in /state/.[!.]* /state/..?* /state/*; do
+        if [ ! -e "$entry" ] && [ ! -L "$entry" ]; then
+          continue
+        fi
+        entry_count=$((entry_count + 1))
+        if [ "$entry" != "$source_path" ]; then
+          exit 2
+        fi
+      done
+      if [ -L "$source_path" ] || [ -L "$other_path" ]; then
         exit 2
       fi
-      if [ ! -f /state/state.json ]; then
+      if [ -e "$other_path" ]; then
+        exit 2
+      fi
+      if [ -e "$source_path" ] && [ ! -f "$source_path" ]; then
+        exit 2
+      fi
+      if [ ! -f "$source_path" ]; then
+        if [ "$entry_count" -ne 0 ]; then
+          exit 2
+        fi
         printf "missing"
         exit 0
       fi
+      if [ "$entry_count" -ne 1 ] \
+        || [ "$(stat -c %h "$source_path")" != "1" ] \
+        || [ "$(stat -c %u:%g "$source_path")" != "$expected_owner" ]; then
+        exit 2
+      fi
+      if [ "$(stat -c %a "$source_path")" != "600" ]; then
+        exit 2
+      fi
+      source_size=$(stat -c %s "$source_path")
+      if [ "$source_size" -lt 1 ] || [ "$source_size" -gt "$max_bytes" ]; then
+        exit 2
+      fi
       umask 077
-      cp -- /state/state.json /backup/state.json
+      cp -- "$source_path" /backup/state.json
       chmod 600 /backup/state.json
-      stat -c "%u:%g" /state/state.json
-    '); then
+      cmp -s -- "$source_path" /backup/state.json
+      printf "%s:%s" "$expected_owner" "$source_size"
+    ' sh "$state_filename_current" "$candidate_state_owner" "$state_backup_max_bytes"); then
     echo "Could not create a secure relay state rollback snapshot." >&2
     return 1
   fi
 
   if [ "$backup_result" = "missing" ]; then
     state_backup_existed=0
-  elif [[ "$backup_result" =~ ^[0-9]+:[0-9]+$ ]] \
+    state_backup_owner="$candidate_state_owner"
+    state_backup_size=0
+  elif [[ "$backup_result" =~ ^([0-9]+:[0-9]+):([0-9]+)$ ]] \
     && [ -s "$state_backup_dir/state.json" ]; then
     state_backup_existed=1
-    state_backup_owner="$backup_result"
+    state_backup_owner="${BASH_REMATCH[1]}"
+    state_backup_size="${BASH_REMATCH[2]}"
   else
     echo "Could not create a secure relay state rollback snapshot." >&2
     return 1
@@ -93,18 +159,52 @@ restore_relay_state() {
       --user 0:0 \
       --security-opt no-new-privileges:true \
       --cap-drop ALL \
+      --cap-add CHOWN \
+      --cap-add DAC_OVERRIDE \
       --mount "type=volume,src=${state_volume},dst=/state" \
       --mount "type=bind,src=${state_backup_dir},dst=/backup,readonly" \
       --entrypoint /bin/sh \
       "$current_image_id" \
       -ec '
-        owner="$1"
-        rm -f -- /state/state.*.tmp /state/.state.json.rollback
+        target_name="$1"
+        owner="$2"
+        case "$target_name" in
+          state.json) other_name="relay-state.json" ;;
+          relay-state.json) other_name="state.json" ;;
+          *) exit 2 ;;
+        esac
+        if [ ! -d /state ] \
+          || [ "$(stat -c %a /state)" != "700" ] \
+          || [ "$(stat -c %u:%g /state)" != "$owner" ]; then
+          exit 2
+        fi
+        rm -f -- /state/state.*.tmp /state/relay-state.*.tmp \
+          /state/.state.json.rollback /state/.state.json.migration
         cp -- /backup/state.json /state/.state.json.rollback
         chmod 600 /state/.state.json.rollback
         chown "$owner" /state/.state.json.rollback
-        mv -f -- /state/.state.json.rollback /state/state.json
-      ' sh "$state_backup_owner" >/dev/null
+        mv -f -- /state/.state.json.rollback "/state/$target_name"
+        rm -f -- "/state/$other_name"
+        entry_count=0
+        for entry in /state/.[!.]* /state/..?* /state/*; do
+          if [ ! -e "$entry" ] && [ ! -L "$entry" ]; then
+            continue
+          fi
+          entry_count=$((entry_count + 1))
+          if [ "$entry" != "/state/$target_name" ]; then
+            exit 2
+          fi
+        done
+        if [ "$entry_count" -ne 1 ] \
+          || [ -L "/state/$target_name" ] \
+          || [ ! -f "/state/$target_name" ] \
+          || [ "$(stat -c %a "/state/$target_name")" != "600" ] \
+          || [ "$(stat -c %u:%g "/state/$target_name")" != "$owner" ] \
+          || [ "$(stat -c %h "/state/$target_name")" != "1" ]; then
+          exit 2
+        fi
+        cmp -s -- "/state/$target_name" /backup/state.json
+      ' sh "$state_filename_current" "$state_backup_owner" >/dev/null
   else
     run_docker run --rm \
       --network none \
@@ -112,12 +212,172 @@ restore_relay_state() {
       --user 0:0 \
       --security-opt no-new-privileges:true \
       --cap-drop ALL \
+      --cap-add DAC_OVERRIDE \
       --mount "type=volume,src=${state_volume},dst=/state" \
       --entrypoint /bin/sh \
       "$current_image_id" \
-      -ec 'rm -f -- /state/state.json /state/state.*.tmp /state/.state.json.rollback' \
+      -ec 'owner="$1"; \
+        if [ ! -d /state ] || [ "$(stat -c %a /state)" != "700" ] \
+          || [ "$(stat -c %u:%g /state)" != "$owner" ]; then exit 2; fi; \
+        rm -f -- /state/state.json /state/relay-state.json /state/state.*.tmp \
+        /state/relay-state.*.tmp /state/.state.json.rollback /state/.state.json.migration; \
+        for entry in /state/.[!.]* /state/..?* /state/*; do \
+          if [ -e "$entry" ] || [ -L "$entry" ]; then exit 2; fi; \
+        done' sh "$candidate_state_owner" \
       >/dev/null
   fi
+}
+
+prepare_relay_state_layout() {
+  if [ "$state_layout" != "legacy" ] || [ "$state_backup_existed" -ne 1 ]; then
+    return 0
+  fi
+
+  run_docker run --rm \
+    --network none \
+    --read-only \
+    --user 0:0 \
+    --security-opt no-new-privileges:true \
+    --cap-drop ALL \
+    --cap-add CHOWN \
+    --cap-add DAC_OVERRIDE \
+    --mount "type=volume,src=${state_volume},dst=/state" \
+    --mount "type=bind,src=${state_backup_dir},dst=/backup,readonly" \
+    --entrypoint /bin/sh \
+    "$current_image_id" \
+    -ec '
+      owner="$1"
+      expected_size="$2"
+      if [ ! -d /state ] \
+        || [ "$(stat -c %a /state)" != "700" ] \
+        || [ "$(stat -c %u:%g /state)" != "$owner" ]; then
+        exit 2
+      fi
+      entry_count=0
+      for entry in /state/.[!.]* /state/..?* /state/*; do
+        if [ ! -e "$entry" ] && [ ! -L "$entry" ]; then
+          continue
+        fi
+        entry_count=$((entry_count + 1))
+        if [ "$entry" != "/state/relay-state.json" ]; then
+          exit 2
+        fi
+      done
+      if [ "$entry_count" -ne 1 ] \
+        || [ -L /state/relay-state.json ] \
+        || [ ! -f /state/relay-state.json ] \
+        || [ "$(stat -c %a /state/relay-state.json)" != "600" ] \
+        || [ "$(stat -c %u:%g /state/relay-state.json)" != "$owner" ] \
+        || [ "$(stat -c %h /state/relay-state.json)" != "1" ] \
+        || [ "$(stat -c %s /state/relay-state.json)" != "$expected_size" ]; then
+        exit 2
+      fi
+      if ! cmp -s -- /state/relay-state.json /backup/state.json; then
+        exit 2
+      fi
+      cp -- /backup/state.json /state/.state.json.migration
+      chmod 600 /state/.state.json.migration
+      chown "$owner" /state/.state.json.migration
+      mv -- /state/.state.json.migration /state/state.json
+      entry_count=0
+      for entry in /state/.[!.]* /state/..?* /state/*; do
+        if [ ! -e "$entry" ] && [ ! -L "$entry" ]; then
+          continue
+        fi
+        entry_count=$((entry_count + 1))
+        case "$entry" in
+          /state/relay-state.json|/state/state.json) ;;
+          *) exit 2 ;;
+        esac
+      done
+      if [ "$entry_count" -ne 2 ] \
+        || [ -L /state/state.json ] \
+        || [ ! -f /state/state.json ] \
+        || [ "$(stat -c %a /state/state.json)" != "600" ] \
+        || [ "$(stat -c %u:%g /state/state.json)" != "$owner" ] \
+        || [ "$(stat -c %h /state/state.json)" != "1" ]; then
+        exit 2
+      fi
+      cmp -s -- /state/state.json /backup/state.json
+    ' sh "$state_backup_owner" "$state_backup_size" >/dev/null
+}
+
+finalize_relay_state_layout() {
+  if [ "$state_layout" != "legacy" ]; then
+    return 0
+  fi
+
+  for _ in $(seq 1 5); do
+    if run_docker run --rm \
+      --network none \
+      --read-only \
+      --user 0:0 \
+      --security-opt no-new-privileges:true \
+      --cap-drop ALL \
+      --cap-add DAC_OVERRIDE \
+      --mount "type=volume,src=${state_volume},dst=/state" \
+      --mount "type=bind,src=${state_backup_dir},dst=/backup,readonly" \
+      --entrypoint /bin/sh \
+      "$current_image_id" \
+      -ec '
+        backup_existed="$1"
+        owner="$2"
+        expected_size="$3"
+        max_size="$4"
+        if [ ! -d /state ] \
+          || [ "$(stat -c %a /state)" != "700" ] \
+          || [ "$(stat -c %u:%g /state)" != "$owner" ]; then
+          exit 2
+        fi
+        entry_count=0
+        for entry in /state/.[!.]* /state/..?* /state/*; do
+          if [ ! -e "$entry" ] && [ ! -L "$entry" ]; then
+            continue
+          fi
+          entry_count=$((entry_count + 1))
+          case "$entry" in
+            /state/relay-state.json|/state/state.json) ;;
+            *) exit 2 ;;
+          esac
+        done
+        if [ -L /state/state.json ] \
+          || { [ -e /state/state.json ] && [ ! -f /state/state.json ]; }; then
+          exit 2
+        fi
+        if [ -f /state/state.json ] \
+          && { [ "$(stat -c %a /state/state.json)" != "600" ] \
+            || [ "$(stat -c %u:%g /state/state.json)" != "$owner" ] \
+            || [ "$(stat -c %h /state/state.json)" != "1" ] \
+            || [ "$(stat -c %s /state/state.json)" -lt 1 ] \
+            || [ "$(stat -c %s /state/state.json)" -gt "$max_size" ]; }; then
+          exit 2
+        fi
+        if [ "$backup_existed" = "1" ]; then
+          if [ "$entry_count" -ne 2 ] \
+            || [ ! -f /state/state.json ] \
+            || [ -L /state/relay-state.json ] \
+            || [ ! -f /state/relay-state.json ] \
+            || [ "$(stat -c %a /state/relay-state.json)" != "600" ] \
+            || [ "$(stat -c %u:%g /state/relay-state.json)" != "$owner" ] \
+            || [ "$(stat -c %h /state/relay-state.json)" != "1" ] \
+            || [ "$(stat -c %s /state/relay-state.json)" != "$expected_size" ]; then
+            exit 2
+          fi
+          cmp -s -- /state/relay-state.json /backup/state.json || exit 2
+        else
+          if [ -e /state/relay-state.json ] || [ -L /state/relay-state.json ] \
+            || [ "$entry_count" -gt 1 ]; then
+            exit 2
+          fi
+        fi
+        rm -f -- /state/relay-state.json
+      ' sh "$state_backup_existed" "$state_backup_owner" "$state_backup_size" \
+        "$state_backup_max_bytes" >/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
 }
 
 original_command="${SSH_ORIGINAL_COMMAND:-}"
@@ -151,15 +411,31 @@ if run_docker container inspect "$rollback_name" >/dev/null 2>&1; then
 fi
 
 current_env=$(run_docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$container_name")
-relay_jwt_secret=$(sed -n 's/^RELAY_JWT_SECRET=//p' <<< "$current_env" | head -n 1)
-relay_allowed_origins=$(sed -n 's/^RELAY_ALLOWED_ORIGINS=//p' <<< "$current_env" | head -n 1)
+relay_jwt_secret_count=$(grep -c '^RELAY_JWT_SECRET=' <<< "$current_env" || true)
+relay_allowed_origins_count=$(grep -c '^RELAY_ALLOWED_ORIGINS=' <<< "$current_env" || true)
+relay_state_file_count=$(grep -c '^RELAY_STATE_FILE=' <<< "$current_env" || true)
+if [ "$relay_jwt_secret_count" -ne 1 ] \
+  || [ "$relay_allowed_origins_count" -gt 1 ] \
+  || [ "$relay_state_file_count" -ne 1 ]; then
+  unset current_env
+  echo "Current relay has ambiguous security or state environment entries; refusing to deploy." >&2
+  exit 78
+fi
+relay_jwt_secret=$(sed -n 's/^RELAY_JWT_SECRET=//p' <<< "$current_env")
+relay_allowed_origins=$(sed -n 's/^RELAY_ALLOWED_ORIGINS=//p' <<< "$current_env")
 relay_allowed_origins="${relay_allowed_origins:-https://app.conductross.com}"
-relay_state_file=$(sed -n 's/^RELAY_STATE_FILE=//p' <<< "$current_env" | head -n 1)
-relay_state_file="${relay_state_file:-/var/lib/conductor-relay/state.json}"
+relay_state_file=$(sed -n 's/^RELAY_STATE_FILE=//p' <<< "$current_env")
 unset current_env
+state_mount_count=$(run_docker inspect "$container_name" \
+  | jq -r --arg volume "$state_volume" \
+    '[.[0].Mounts[] | select(.Type == "volume" and .Name == $volume)] | length')
 state_mount_destination=$(run_docker inspect "$container_name" \
   | jq -r --arg volume "$state_volume" \
     '.[0].Mounts[] | select(.Type == "volume" and .Name == $volume) | .Destination' \
+  | head -n 1)
+state_mount_writable=$(run_docker inspect "$container_name" \
+  | jq -r --arg volume "$state_volume" \
+    '.[0].Mounts[] | select(.Type == "volume" and .Name == $volume) | .RW' \
   | head -n 1)
 
 if [ -z "$relay_jwt_secret" ]; then
@@ -171,13 +447,37 @@ if [ "$relay_secret_bytes" -lt 32 ]; then
   echo "Current relay JWT secret is weaker than 32 bytes; rotate it before deployment." >&2
   exit 78
 fi
-if ! run_docker volume inspect "$state_volume" >/dev/null 2>&1; then
-  echo "Relay state volume $state_volume is missing; refusing to deploy." >&2
+if ! run_docker volume inspect "$state_volume" >/dev/null 2>&1 \
+  || [ "$state_mount_count" -ne 1 ] \
+  || [ "$state_mount_writable" != "true" ]; then
+  echo "Relay state volume $state_volume is missing, duplicated, or not writable; refusing to deploy." >&2
   exit 78
 fi
-if [ "$state_mount_destination" != "$state_mount_destination_expected" ] \
-  || [ "$relay_state_file" != "$state_file_expected" ]; then
+if [ "$state_mount_destination" = "$state_mount_destination_expected" ] \
+  && [ "$relay_state_file" = "$state_file_expected" ]; then
+  state_layout="canonical"
+  state_filename_current="$state_filename_expected"
+elif [ "$state_mount_destination" = "$state_mount_destination_legacy" ] \
+  && [ "$relay_state_file" = "$state_file_legacy" ]; then
+  state_layout="legacy"
+  state_filename_current="$state_filename_legacy"
+  echo "Migrating the known legacy relay state layout to $state_file_expected."
+else
   echo "Current relay must use the exact durable state path $state_file_expected; refusing to deploy." >&2
+  exit 78
+fi
+state_overlap_mount_count=$(run_docker inspect "$container_name" \
+  | jq -r --arg root "$state_mount_destination" '
+    [.[0].Mounts[]
+      | .Destination as $destination
+      | select(
+          $destination == $root
+          or ($destination | startswith($root + "/"))
+          or ($root | startswith($destination + "/"))
+        )]
+    | length')
+if [ "$state_overlap_mount_count" -ne 1 ]; then
+  echo "Current relay has overlapping state mounts; refusing to deploy." >&2
   exit 78
 fi
 current_image_id=$(run_docker inspect -f '{{.Image}}' "$container_name")
@@ -198,6 +498,18 @@ if [ -z "$relay_trusted_proxies" ]; then
 fi
 
 timeout --foreground --kill-after=10s 300s docker pull "$image_ref" >/dev/null
+candidate_state_owner=$(run_docker run --rm \
+  --network none \
+  --read-only \
+  --security-opt no-new-privileges:true \
+  --cap-drop ALL \
+  --entrypoint /bin/sh \
+  "$image_ref" \
+  -ec 'printf "%s:%s" "$(id -u)" "$(id -g)"')
+if [[ ! "$candidate_state_owner" =~ ^[0-9]+:[0-9]+$ ]]; then
+  echo "Could not resolve the candidate relay state owner." >&2
+  exit 78
+fi
 
 previous_stopped=0
 previous_renamed=0
@@ -244,7 +556,12 @@ restore_previous_relay() {
       health_json=$(run_docker exec "$container_name" \
         curl --connect-timeout 2 --max-time 5 -fsS \
         http://127.0.0.1:8080/health 2>/dev/null || true)
-      if jq -e '.ok == true and .ready == true' <<< "$health_json" >/dev/null 2>&1; then
+      if [ "$state_layout" = "legacy" ]; then
+        restored_health_filter='.ok == true'
+      else
+        restored_health_filter='.ok == true and .ready == true'
+      fi
+      if jq -e "$restored_health_filter" <<< "$health_json" >/dev/null 2>&1; then
         restored=1
         break
       fi
@@ -268,6 +585,7 @@ run_docker stop --time 20 "$container_name" >/dev/null
 run_docker rename "$container_name" "$rollback_name"
 previous_renamed=1
 backup_relay_state
+prepare_relay_state_layout
 
 export RELAY_STATE_FILE="$state_file_expected"
 export RELAY_JWT_SECRET="$relay_jwt_secret"
@@ -281,7 +599,7 @@ run_docker run -d \
   --init \
   --network "$primary_network" \
   --network-alias conductor-relay \
-  --mount "type=volume,src=${state_volume},dst=${state_mount_destination}" \
+  --mount "type=volume,src=${state_volume},dst=${state_mount_destination_expected}" \
   --read-only \
   --tmpfs /tmp:rw,nosuid,nodev,noexec,size=67108864,mode=1777 \
   --security-opt no-new-privileges:true \
@@ -349,13 +667,16 @@ if [ "$public_ready" -ne 1 ]; then
   exit 1
 fi
 
-trap - EXIT INT TERM
+finalize_relay_state_layout
+
+if ! run_docker rm "$rollback_name" >/dev/null; then
+  if run_docker container inspect "$rollback_name" >/dev/null 2>&1; then
+    echo "The new relay is healthy, but the stopped rollback container could not be removed." >&2
+    exit 93
+  fi
+fi
 previous_stopped=0
 previous_renamed=0
-if ! run_docker rm "$rollback_name" >/dev/null; then
-  cleanup_state_backup
-  echo "The new relay is healthy, but the stopped rollback container could not be removed." >&2
-  exit 93
-fi
+trap - EXIT INT TERM
 cleanup_state_backup
 echo "Relay deployment completed for $expected_sha."


### PR DESCRIPTION
## Summary

Fixes both first-run production regressions exposed by the hardened deployment workflows.

- Preview keeps a read-only root filesystem, no-new-privileges, and cap-drop ALL, then restores only SYS_ADMIN and SYS_CHROOT for Chromium's real sandbox startup.
- Relay accepts only the exact known legacy /data/relay-state.json layout, snapshots it on tmpfs, migrates it to the canonical path, and retains exact rollback through public build health and old-container removal.

## User-Facing Release Notes

- Hosted previews now start Chromium with sandboxing enabled inside the hardened container boundary.
- Relay upgrades now preserve existing paired devices while securely migrating the legacy state-volume layout.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Agent or integration addition / modification
- [x] Documentation update
- [ ] Refactor / chore

## Checklist

- [x] bun run build:frontend passes for frontend changes
- [x] bun run typecheck passes for TypeScript changes
- [x] bun run test:packages passes for package changes
- [x] cargo test --workspace and cargo clippy --workspace --all-targets -- -D warnings pass for Rust changes
- [x] cd bridge-cmd && go test ./... passes for bridge changes
- [x] No any types introduced without justification
- [x] No secrets or credentials committed
- [x] Security boundaries, authentication, persistence, and network behavior have regression tests when changed
- [x] User-facing release notes are filled in plain English or marked internal-only
- [x] PR title follows conventional commits

## Testing

    bash -n scripts/conductor-preview-deploy-host.sh
    bash -n scripts/conductor-relay-deploy-host.sh
    bash scripts/validate-docs.sh
    PATH="$HOME/.bun/bin:$PATH" bun test scripts/*.test.mjs
    git diff --check

Preview verification used the immutable failed-rollout image and a disposable exact-host container matrix. The reviewed forced command then completed end to end with sandboxing enabled, exact build health, private Caddy routing, no rollback residue, and host port 3099 closed.

Relay verification used a cloned production state volume to exercise snapshot, migration, rollback restoration, and finalization without exposing its contents. After independent security review, the reviewed forced command migrated production end to end. Ten device records remained present, state.json is mode 0600 with the expected owner, the legacy duplicate and rollback snapshot are gone, private/Caddy/public health report the exact build SHA, the container is read-only with all capabilities dropped, host port 8080 is closed, and the paired bridge reconnected.

## Screenshots / Demo

N/A - deployment-only changes.
