### PR TITLE
fix: publish valid bundled package identities

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -410,6 +410,32 @@ jobs:
             --pack-destination .release-native | tail -n 1)
           echo "tarball_path=$tarball_path" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve native npm artifact identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ needs.version.outputs.recovering }}" = true ]; then
+            existing_mode=canonicalize
+          else
+            existing_mode=reject
+          fi
+          required_file=bin/conductor
+          if [ "${{ matrix.id }}" = win32-x64 ]; then
+            required_file=bin/conductor.exe
+          fi
+          node scripts/release-artifact-identity.mjs \
+            --tarball "${{ steps.pack.outputs.tarball_path }}" \
+            --allow-missing \
+            --on-existing "$existing_mode" \
+            --require-file "$required_file"
+
+      - name: Verify packed native artifact
+        run: >-
+          node scripts/verify-native-package.mjs
+          --tarball "${{ steps.pack.outputs.tarball_path }}"
+          --target "${{ matrix.id }}"
+          --version "${{ needs.version.outputs.new_version }}"
+
       - name: Upload native tarball
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -561,9 +587,6 @@ jobs:
       - name: Install tmux
         run: sudo apt-get update && sudo apt-get install -y tmux
 
-      - name: Verify packaged CLI
-        run: node scripts/verify-cli-package.mjs
-
       - name: Download native tarballs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -585,6 +608,7 @@ jobs:
             --tarball "${{ steps.pack.outputs.tarball_path }}" \
             --allow-missing \
             --on-existing "$existing_mode" \
+            --require-bundled-dependency @conductor-oss/core \
             --require-file dist/launcher.js \
             --require-file web/package.json
 
@@ -597,9 +621,12 @@ jobs:
             node scripts/release-artifact-identity.mjs \
               --tarball "$tarball" \
               --allow-missing \
-              --on-existing "$existing_mode" \
+              --on-existing verify \
               --require-file "$required_file"
           done
+
+      - name: Verify packaged CLI
+        run: node scripts/verify-cli-package.mjs --tarball "${{ steps.pack.outputs.tarball_path }}"
 
       - name: Generate release notes
         env:
@@ -686,8 +713,15 @@ jobs:
           set -euo pipefail
           cli_tarball=""
           github_tarball=""
+          expected_version="${{ needs.version.outputs.new_version }}"
           for tarball in .release-artifacts/*.tgz; do
-            package_name=$(tar -xOf "$tarball" package/package.json | jq -r '.name')
+            package_json=$(tar -xOf "$tarball" package/package.json)
+            package_name=$(jq -r '.name' <<< "$package_json")
+            package_version=$(jq -r '.version' <<< "$package_json")
+            if [ "$package_version" != "$expected_version" ]; then
+              echo "::error::CLI artifact $package_name has version $package_version, expected $expected_version."
+              exit 1
+            fi
             case "$package_name" in
               conductor-oss) cli_tarball="$tarball" ;;
               @charannyk06/conductor-oss) github_tarball="$tarball" ;;
@@ -700,6 +734,35 @@ jobs:
           fi
           echo "CLI_TARBALL=$cli_tarball" >> "$GITHUB_ENV"
           echo "GITHUB_TARBALL=$github_tarball" >> "$GITHUB_ENV"
+
+          declare -A native_packages=()
+          for tarball in .release-native/*.tgz; do
+            package_json=$(tar -xOf "$tarball" package/package.json)
+            package_name=$(jq -r '.name' <<< "$package_json")
+            package_version=$(jq -r '.version' <<< "$package_json")
+            case "$package_name" in
+              conductor-oss-native-darwin-universal|conductor-oss-native-linux-x64|conductor-oss-native-win32-x64) ;;
+              *) echo "::error::Unexpected native artifact package $package_name"; exit 1 ;;
+            esac
+            if [ "${native_packages[$package_name]+present}" = present ]; then
+              echo "::error::Duplicate native artifact package $package_name"
+              exit 1
+            fi
+            if [ "$package_version" != "$expected_version" ]; then
+              echo "::error::Native artifact $package_name has version $package_version, expected $expected_version."
+              exit 1
+            fi
+            native_packages[$package_name]=present
+          done
+          for package_name in \
+            conductor-oss-native-darwin-universal \
+            conductor-oss-native-linux-x64 \
+            conductor-oss-native-win32-x64; do
+            if [ "${native_packages[$package_name]+present}" != present ]; then
+              echo "::error::Release bundle is missing native artifact $package_name."
+              exit 1
+            fi
+          done
 
           verify_dir=$(mktemp -d)
           cp "$cli_tarball" .release-native/*.tgz \
@@ -728,6 +791,7 @@ jobs:
             --tarball "$CLI_TARBALL" \
             --allow-missing \
             --on-existing "$existing_mode" \
+            --require-bundled-dependency @conductor-oss/core \
             --require-file dist/launcher.js \
             --require-file web/package.json
           for tarball in .release-native/*.tgz; do
@@ -766,8 +830,16 @@ jobs:
             --registry https://npm.pkg.github.com \
             --allow-missing \
             --on-existing "$existing_mode" \
+            --require-bundled-dependency @conductor-oss/core \
             --require-file dist/launcher.js \
             --require-file web/package.json
+
+      - name: Verify public and GitHub CLI artifact equivalence
+        run: >-
+          node scripts/verify-cli-artifact-equivalence.mjs
+          --public-tarball "$CLI_TARBALL"
+          --github-tarball "$GITHUB_TARBALL"
+          --version "${{ needs.version.outputs.new_version }}"
 
       - name: Attest release provenance
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
@@ -889,6 +961,7 @@ jobs:
           status=$(node scripts/release-artifact-identity.mjs \
             --tarball "$CLI_TARBALL" \
             --allow-missing \
+            --require-bundled-dependency @conductor-oss/core \
             --require-file dist/launcher.js \
             --require-file web/package.json)
           if [ "$status" = missing ]; then
@@ -901,12 +974,14 @@ jobs:
           node scripts/release-artifact-identity.mjs \
             --tarball "$CLI_TARBALL" \
             --wait-ms 600000 \
+            --require-bundled-dependency @conductor-oss/core \
             --require-file dist/launcher.js \
             --require-file web/package.json
           node scripts/verify-npm-publication.mjs \
             --package conductor-oss \
             --version "${{ needs.version.outputs.new_version }}" \
             --local-tarball "$CLI_TARBALL" \
+            --require-bundled-dependency @conductor-oss/core \
             --require-file dist/launcher.js \
             --require-file web/package.json
 
@@ -927,6 +1002,7 @@ jobs:
             --tarball "$GITHUB_TARBALL" \
             --registry https://npm.pkg.github.com \
             --allow-missing \
+            --require-bundled-dependency @conductor-oss/core \
             --require-file dist/launcher.js \
             --require-file web/package.json)
           if [ "$status" = missing ]; then
@@ -936,6 +1012,7 @@ jobs:
             --tarball "$GITHUB_TARBALL" \
             --registry https://npm.pkg.github.com \
             --wait-ms 600000 \
+            --require-bundled-dependency @conductor-oss/core \
             --require-file dist/launcher.js \
             --require-file web/package.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -584,8 +584,8 @@ jobs:
             --publish-registry https://npm.pkg.github.com | tail -n 1)
           echo "tarball_path=$tarball_path" >> "$GITHUB_OUTPUT"
 
-      - name: Install tmux
-        run: sudo apt-get update && sudo apt-get install -y tmux
+      - name: Install tmux and ttyd
+        run: sudo apt-get update && sudo apt-get install -y tmux ttyd
 
       - name: Download native tarballs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Each adapter in `crates/conductor-executors/src/agents/` defines launch commands
 
 - Rust toolchain (stable)
 - Bun >= 1.2
-- Node.js >= 18
+- Node.js >= 20.9.0
 - git
 
 ### Commands

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ cargo build --workspace
 
 - Rust toolchain (stable)
 - Bun >= 1.2
-- Node.js >= 18
+- Node.js >= 20.9.0
 - git
 
 ### Running locally

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ This is the flow the current app is built around.
 
 ## Quick start
 
+The published launcher requires Node.js `>= 20.9.0` and includes native
+backends for macOS (Apple Silicon and Intel), Linux x64, and Windows x64.
+Other platforms can run Conductor from a source build.
+
 ### Option A, point Conductor at an existing repo
 
 ```bash
@@ -296,7 +300,7 @@ The hosted Chromium preview worker is also deployed independently. See `docs/pre
 ### Prerequisites
 - Rust stable toolchain
 - Bun `>= 1.2`
-- Node.js `>= 18`
+- Node.js `>= 20.9.0`
 - `git`
 
 ### Install

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,6 +4,10 @@
 
 It starts the local dashboard and Rust backend, scaffolds `conductor.yaml` and `CONDUCTOR.md`, launches agent sessions, and powers the bridge setup flow for paired-device access.
 
+The published launcher requires Node.js `>= 20.9.0`. Prebuilt native backends
+are included for macOS (Apple Silicon and Intel), Linux x64, and Windows x64;
+other platforms require a source build.
+
 ## Choose the right setup
 
 ### Local dashboard on the same machine

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,7 +34,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=20.9.0"
   },
   "description": "Local-first control surface for AI coding agents, workspaces, worktrees, terminals, diffs, previews, and paired-device access.",
   "keywords": [

--- a/packages/cli/src/__tests__/start.test.ts
+++ b/packages/cli/src/__tests__/start.test.ts
@@ -8,9 +8,42 @@ import {
   isLoopbackHost,
   quoteWindowsCliArg,
   resolveDashboardPackageManager,
+  resolveDashboardRuntimeMode,
+  resolveDashboardWebMode,
   resolveLocalDashboardAuthEnv,
   resolveRustBackendLaunch,
 } from "../commands/start.js";
+
+test("dashboard runtime modes keep installed launchers on the standalone server", () => {
+  for (const webMode of ["auto", "dev", "production", "standalone"] as const) {
+    assert.equal(resolveDashboardRuntimeMode({
+      webMode,
+      isSourceCheckout: false,
+      hasNextBuild: true,
+      hasStandaloneServer: true,
+    }), "standalone");
+  }
+
+  assert.equal(resolveDashboardRuntimeMode({
+    webMode: "auto",
+    isSourceCheckout: true,
+    hasNextBuild: true,
+    hasStandaloneServer: true,
+  }), "dev");
+  assert.equal(resolveDashboardRuntimeMode({
+    webMode: "production",
+    isSourceCheckout: true,
+    hasNextBuild: true,
+    hasStandaloneServer: true,
+  }), "production");
+  assert.equal(resolveDashboardRuntimeMode({
+    webMode: "standalone",
+    isSourceCheckout: false,
+    hasNextBuild: true,
+    hasStandaloneServer: false,
+  }), null);
+  assert.equal(resolveDashboardWebMode("prod"), "production");
+});
 
 test("isLoopbackHost recognizes local-only bind hosts", () => {
   assert.equal(isLoopbackHost("127.0.0.1"), true);

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -44,6 +44,9 @@ type CliUpdateContext = {
 };
 
 type DashboardPackageManager = "bun" | "pnpm";
+type DashboardWebMode = "auto" | "dev" | "production" | "standalone";
+type DashboardRuntimeMode = "dev" | "production" | "standalone";
+const PUBLISHED_NATIVE_TARGETS = "macOS arm64/x64, Linux x64, and Windows x64";
 
 export function quoteWindowsCliArg(value: string): string {
   let escaped = "";
@@ -693,7 +696,7 @@ function resolveBundledRustBinary(): string | null {
     }
   }
 
-  const cliDir = new URL(".", import.meta.url).pathname;
+  const cliDir = dirname(fileURLToPath(import.meta.url));
   const candidates = [
     resolve(cliDir, "..", "..", "native", binaryName),
     resolve(cliDir, "..", "..", "..", "native", binaryName),
@@ -859,7 +862,7 @@ export function resolveRustBackendLaunch(
 
   return {
     launch: null,
-    reason: "No compatible bundled Rust backend was found, and this install does not have a repo-local Cargo fallback.",
+    reason: `No compatible bundled Rust backend was found for ${process.platform}-${process.arch}. Published binaries support ${PUBLISHED_NATIVE_TARGETS}; use a source build on other platforms.`,
   };
 }
 
@@ -902,7 +905,7 @@ async function killStalePortListener(port: number): Promise<void> {
   }
 }
 
-function resolveDashboardWebMode(mode: string | undefined): "auto" | "dev" | "production" | "standalone" {
+export function resolveDashboardWebMode(mode: string | undefined): DashboardWebMode {
   switch (mode?.trim().toLowerCase()) {
     case "dev":
       return "dev";
@@ -914,6 +917,39 @@ function resolveDashboardWebMode(mode: string | undefined): "auto" | "dev" | "pr
     default:
       return "auto";
   }
+}
+
+export function resolveDashboardRuntimeMode({
+  webMode,
+  isSourceCheckout,
+  hasNextBuild,
+  hasStandaloneServer,
+}: {
+  webMode: DashboardWebMode;
+  isSourceCheckout: boolean;
+  hasNextBuild: boolean;
+  hasStandaloneServer: boolean;
+}): DashboardRuntimeMode | null {
+  if (webMode === "standalone") {
+    return hasStandaloneServer ? "standalone" : null;
+  }
+
+  if (isSourceCheckout && (webMode === "dev" || webMode === "auto")) {
+    return "dev";
+  }
+
+  if (isSourceCheckout && webMode === "production" && hasNextBuild) {
+    return "production";
+  }
+
+  // Published packages intentionally ship a self-contained standalone server,
+  // not a second package-manager-driven web dependency tree. This also makes
+  // explicit dev/production overrides safe for installed launchers.
+  if (hasStandaloneServer) {
+    return "standalone";
+  }
+
+  return null;
 }
 
 export function registerStart(program: Command): void {
@@ -1115,7 +1151,7 @@ export function registerStart(program: Command): void {
           const dashSpinner = ora("Starting web dashboard").start();
 
           try {
-            const cliDir = new URL(".", import.meta.url).pathname;
+            const cliDir = dirname(fileURLToPath(import.meta.url));
             const { cpSync, readdirSync, statSync } = await import("node:fs");
 
             let webDir: string | null = null;
@@ -1146,7 +1182,6 @@ export function registerStart(program: Command): void {
             const webMode = resolveDashboardWebMode(process.env["CONDUCTOR_WEB_MODE"]);
             const isSourceCheckout = existsSync(join(webDir, "src", "app", "page.tsx"))
               && existsSync(join(webDir, "next.config.ts"));
-            const preferDevServer = webMode === "dev" || (webMode === "auto" && isSourceCheckout);
             const standaloneDir = join(webDir, ".next", "standalone");
             const hasNextBuild = existsSync(join(webDir, ".next"));
 
@@ -1178,12 +1213,31 @@ export function registerStart(program: Command): void {
             let args: string[];
             let dashboardCwd = webDir;
 
-            if (preferDevServer) {
+            const runtimeMode = resolveDashboardRuntimeMode({
+              webMode,
+              isSourceCheckout,
+              hasNextBuild,
+              hasStandaloneServer: standaloneServer !== null,
+            });
+
+            if (!runtimeMode) {
+              if (isSourceCheckout) {
+                throw new Error(`Dashboard build is missing. Run: ${buildHint}`);
+              }
+              throw new Error(
+                "Packaged dashboard bundle is incomplete: no standalone server was found. Reinstall conductor-oss.",
+              );
+            }
+
+            if (runtimeMode === "dev") {
               ({ cmd, args } = buildDashboardPackageManagerCommand(packageManager, "dev", bindHost, dashboardPort));
-            } else if (webMode === "production" && hasNextBuild) {
+            } else if (runtimeMode === "production") {
               ({ cmd, args } = buildDashboardPackageManagerCommand(packageManager, "start", bindHost, dashboardPort));
-            } else if (standaloneServer) {
-              const standaloneAppDir = dirname(standaloneServer);
+            } else {
+              // runtimeMode can only be standalone here, so the resolver above
+              // guarantees this path exists.
+              const resolvedStandaloneServer = standaloneServer!;
+              const standaloneAppDir = dirname(resolvedStandaloneServer);
               const standaloneStaticDir = join(standaloneAppDir, ".next", "static");
               const sourceStaticDir = join(webDir, ".next", "static");
               const standalonePublicDir = join(standaloneAppDir, "public");
@@ -1196,12 +1250,8 @@ export function registerStart(program: Command): void {
                 cpSync(sourcePublicDir, standalonePublicDir, { recursive: true });
               }
               cmd = process.execPath;
-              args = [standaloneServer];
+              args = [resolvedStandaloneServer];
               dashboardCwd = standaloneDir;
-            } else if (hasNextBuild) {
-              ({ cmd, args } = buildDashboardPackageManagerCommand(packageManager, "start", bindHost, dashboardPort));
-            } else {
-              ({ cmd, args } = buildDashboardPackageManagerCommand(packageManager, "dev", bindHost, dashboardPort));
             }
 
             dashboardProcess = spawn(cmd, args, {

--- a/packages/cli/src/rust-cli.ts
+++ b/packages/cli/src/rust-cli.ts
@@ -3,6 +3,8 @@ import { createRequire } from "node:module";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+const PUBLISHED_NATIVE_TARGETS = "macOS arm64/x64, Linux x64, and Windows x64";
+
 export interface RustCliLaunch {
   cmd: string;
   argsPrefix: string[];
@@ -130,7 +132,9 @@ export function resolveRustCliLaunch(): RustCliLaunch {
     };
   }
 
-  throw new Error("Rust CLI was not found. Build the workspace or run from a source checkout.");
+  throw new Error(
+    `Rust CLI was not found for ${process.platform}-${process.arch}. Published binaries support ${PUBLISHED_NATIVE_TARGETS}; build the workspace or run from a source checkout on other platforms.`,
+  );
 }
 
 export function rustCliGlobalArgs(): string[] {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -9,7 +9,7 @@
     "build": "bun run --cwd ../core build && next build --webpack",
     "start": "next start",
     "typecheck": "tsc --noEmit",
-    "test": "find src -name '*.test.ts' -print0 | xargs -0 tsx --test",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "clean": "rm -rf .next"
   },
   "dependencies": {

--- a/packages/web/src/app/api/sessions/[id]/send/route.test.ts
+++ b/packages/web/src/app/api/sessions/[id]/send/route.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+
+const originalBackendUrl = process.env.CONDUCTOR_BACKEND_URL;
+const originalConfigPath = process.env.CO_CONFIG_PATH;
+const originalWorkspace = process.env.CONDUCTOR_WORKSPACE;
+const originalRequireAuth = process.env.CONDUCTOR_REQUIRE_AUTH;
+const originalFetch = global.fetch;
+
+function resetEnv(): void {
+  process.env.CONDUCTOR_BACKEND_URL = "http://127.0.0.1:4749";
+  process.env.CO_CONFIG_PATH = "/tmp/conductor-session-send-route-test-config-does-not-exist.yaml";
+  process.env.CONDUCTOR_WORKSPACE = "";
+  process.env.CONDUCTOR_REQUIRE_AUTH = "";
+}
+
+test.afterEach(() => {
+  resetEnv();
+  global.fetch = originalFetch;
+});
+
+test.after(() => {
+  for (const [name, value] of [
+    ["CONDUCTOR_BACKEND_URL", originalBackendUrl],
+    ["CO_CONFIG_PATH", originalConfigPath],
+    ["CONDUCTOR_WORKSPACE", originalWorkspace],
+    ["CONDUCTOR_REQUIRE_AUTH", originalRequireAuth],
+  ] as const) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+  global.fetch = originalFetch;
+});
+
+test("POST proxies notes and messages to the selected session", async () => {
+  resetEnv();
+  let seenUrl = "";
+  let seenBody = "";
+  global.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    seenUrl = typeof input === "string" || input instanceof URL ? String(input) : input.url;
+    seenBody = init?.body instanceof ArrayBuffer
+      ? new TextDecoder().decode(init.body)
+      : String(init?.body);
+    assert.equal(init?.method, "POST");
+    return Response.json({ success: true });
+  }) as typeof fetch;
+
+  const response = await POST(
+    new NextRequest("http://127.0.0.1:3000/api/sessions/session-1/send", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Origin: "http://127.0.0.1:3000",
+      },
+      body: JSON.stringify({ message: "Review this note", attachments: ["notes/brief.md"] }),
+    }),
+    { params: Promise.resolve({ id: "session-1" }) },
+  );
+
+  assert.equal(seenUrl, "http://127.0.0.1:4749/api/sessions/session-1/send");
+  assert.deepEqual(JSON.parse(seenBody), {
+    message: "Review this note",
+    attachments: ["notes/brief.md"],
+  });
+  assert.equal(response.status, 200);
+});
+
+test("POST rejects cross-origin session mutations before backend I/O", async () => {
+  resetEnv();
+  let called = false;
+  global.fetch = (async () => {
+    called = true;
+    return Response.json({ success: true });
+  }) as typeof fetch;
+
+  const response = await POST(
+    new NextRequest("http://127.0.0.1:3000/api/sessions/session-1/send", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Origin: "https://attacker.example",
+      },
+      body: JSON.stringify({ message: "unsafe" }),
+    }),
+    { params: Promise.resolve({ id: "session-1" }) },
+  );
+
+  assert.equal(response.status, 403);
+  assert.equal(called, false);
+});

--- a/packages/web/src/app/api/sessions/[id]/send/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/send/route.ts
@@ -1,0 +1,8 @@
+import { guardedSessionProxyParamRoute } from "@/lib/proxyRoutes";
+
+export const dynamic = "force-dynamic";
+
+export const POST = guardedSessionProxyParamRoute(
+  ({ id }) => `/api/sessions/${encodeURIComponent(id ?? "")}/send`,
+  { role: "operator", requireActionGuard: true },
+);

--- a/scripts/cli-release-stage.mjs
+++ b/scripts/cli-release-stage.mjs
@@ -157,13 +157,14 @@ function hydrateStandaloneNodeModules(standaloneRoot) {
 
 function sanitizePublishedPackage(pkg, {
   packageName = pkg.name,
+  packageVersion = pkg.version,
   dependencies = {},
   optionalDependencies = undefined,
   publishConfig = undefined,
 } = {}) {
   const sanitized = {
     name: packageName,
-    version: pkg.version,
+    version: packageVersion,
     license: pkg.license,
     type: pkg.type,
     main: pkg.main,
@@ -263,7 +264,14 @@ function buildInternalPackageTarballs({ rootDir, cliVersion, tarballRoot, stagin
       }
     }
 
-    const sanitizedManifest = sanitizePublishedPackage(sourceManifest, { dependencies });
+    // Private workspace packages keep their independent development versions in
+    // source. Once bundled into the public CLI, however, npm validates them
+    // against the release-scoped dependency declared by conductor-oss. Give the
+    // bundled artifact the same immutable release identity as its parent.
+    const sanitizedManifest = sanitizePublishedPackage(sourceManifest, {
+      packageVersion: cliVersion,
+      dependencies,
+    });
     writeJson(join(packageStageDir, "package.json"), sanitizedManifest);
     copyDistDirectory(sourceDistDir, join(packageStageDir, "dist"));
 

--- a/scripts/cli-release-stage.mjs
+++ b/scripts/cli-release-stage.mjs
@@ -227,6 +227,25 @@ function ensureWebBundle(rootDir) {
   return { standaloneDir, staticDir, publicDir };
 }
 
+function collectStandalonePlatformDependencies(standaloneRoot) {
+  const sharpManifestPath = join(standaloneRoot, "node_modules", "sharp", "package.json");
+  if (!existsSync(sharpManifestPath)) {
+    throw new Error("The standalone dashboard is missing its traced sharp runtime.");
+  }
+
+  const sharpManifest = readJson(sharpManifestPath);
+  if (typeof sharpManifest.version !== "string" || sharpManifest.version.length === 0) {
+    throw new Error("The standalone dashboard has an invalid sharp package identity.");
+  }
+
+  // The Linux-built standalone already carries all traced JavaScript. Publishing
+  // the exact sharp version as an optional root dependency lets npm select only
+  // the target host's @img binary packages on macOS, Linux, or Windows. Do not
+  // promote the standalone tree's full optional metadata: production does not
+  // need SWC, and doing so would create a large, unstable public dependency API.
+  return { sharp: sharpManifest.version };
+}
+
 function buildInternalPackageTarballs({ rootDir, cliVersion, tarballRoot, stagingRoot }) {
   const cliPackage = readJson(resolve(rootDir, "packages", "cli", "package.json"));
   const workspacePackages = createWorkspacePackageMap(rootDir);
@@ -295,7 +314,6 @@ export function createCliReleaseStage({
 } = {}) {
   const resolvedRootDir = resolve(rootDir);
   const cliPackage = readJson(resolve(resolvedRootDir, "packages", "cli", "package.json"));
-  const webPackage = readJson(resolve(resolvedRootDir, "packages", "web", "package.json"));
   const webBundle = ensureWebBundle(resolvedRootDir);
   const packageName = publishedName ?? cliPackage.name;
   const publishConfig = publishRegistry ? { registry: publishRegistry } : undefined;
@@ -343,6 +361,9 @@ export function createCliReleaseStage({
     private: true,
     type: "module",
   });
+  const standalonePlatformDependencies = collectStandalonePlatformDependencies(
+    join(webOutputDir, ".next", "standalone"),
+  );
 
   const stagedDependencies = {};
   for (const [dependencyName, specifier] of Object.entries(cliPackage.dependencies ?? {})) {
@@ -353,15 +374,22 @@ export function createCliReleaseStage({
   for (const [dependencyName, specifier] of Object.entries(externalDependencies)) {
     addDependency(stagedDependencies, dependencyName, specifier, "internal workspace package");
   }
-  for (const [dependencyName, specifier] of Object.entries(webPackage.dependencies ?? {})) {
-    if (!dependencyName.startsWith("@conductor-oss/")) {
-      addDependency(stagedDependencies, dependencyName, specifier, "@conductor-oss/web");
-    }
-  }
+  // The production web server and its complete runtime dependency tree are
+  // already traced and hydrated inside web/.next/standalone. Do not install a
+  // second root-level copy: it is never executed and would bypass the locked
+  // security overrides used to create the standalone bundle.
 
   const publishedOptionalDependencies = Object.fromEntries(
     CLI_NATIVE_TARGETS.map((target) => [target.packageName, cliPackage.version]),
   );
+  for (const [dependencyName, specifier] of Object.entries(standalonePlatformDependencies)) {
+    addDependency(
+      publishedOptionalDependencies,
+      dependencyName,
+      specifier,
+      "standalone optional runtime dependency",
+    );
+  }
 
   const stagedManifest = sanitizePublishedPackage(cliPackage, {
     packageName,
@@ -430,11 +458,6 @@ export function createCliReleaseStage({
   }
   for (const [dependencyName, specifier] of Object.entries(externalDependencies)) {
     addDependency(publishedDependencies, dependencyName, specifier, "internal workspace package");
-  }
-  for (const [dependencyName, specifier] of Object.entries(webPackage.dependencies ?? {})) {
-    if (!dependencyName.startsWith("@conductor-oss/")) {
-      addDependency(publishedDependencies, dependencyName, specifier, "@conductor-oss/web");
-    }
   }
 
   const publishedManifest = sanitizePublishedPackage(cliPackage, {

--- a/scripts/cli-release-stage.test.mjs
+++ b/scripts/cli-release-stage.test.mjs
@@ -27,6 +27,8 @@ test("release staging gives bundled private packages the parent release identity
     mkdirSync(join(cliDir, "dist"), { recursive: true });
     mkdirSync(join(coreDir, "dist"), { recursive: true });
     mkdirSync(join(webDir, ".next", "standalone"), { recursive: true });
+    mkdirSync(join(webDir, ".next", "standalone", "node_modules", "next"), { recursive: true });
+    mkdirSync(join(webDir, ".next", "standalone", "node_modules", "sharp"), { recursive: true });
     mkdirSync(join(webDir, ".next", "static"), { recursive: true });
 
     writeJson(join(cliDir, "package.json"), {
@@ -35,6 +37,7 @@ test("release staging gives bundled private packages the parent release identity
       type: "module",
       main: "dist/launcher.js",
       bin: { conductor: "dist/launcher.js" },
+      engines: { node: ">=20.9.0" },
       dependencies: { "@conductor-oss/core": "workspace:*" },
     });
     writeFileSync(join(cliDir, "dist", "launcher.js"), "#!/usr/bin/env node\n", "utf8");
@@ -50,7 +53,15 @@ test("release staging gives bundled private packages the parent release identity
       name: "@conductor-oss/web",
       version: "0.2.7",
       private: true,
-      dependencies: {},
+      dependencies: { next: "16.2.10", react: "19.2.0" },
+    });
+    writeJson(join(webDir, ".next", "standalone", "node_modules", "next", "package.json"), {
+      name: "next",
+      version: "16.2.10",
+    });
+    writeJson(join(webDir, ".next", "standalone", "node_modules", "sharp", "package.json"), {
+      name: "sharp",
+      version: "0.34.5",
     });
 
     const { tarballPath } = packCliReleasePackage({
@@ -65,9 +76,22 @@ test("release staging gives bundled private packages the parent release identity
       "utf8",
     ));
     assert.equal(parentManifest.dependencies["@conductor-oss/core"], "9.8.7");
+    assert.equal(parentManifest.engines.node, ">=20.9.0");
+    assert.equal(parentManifest.dependencies.next, undefined);
+    assert.equal(parentManifest.dependencies.react, undefined);
+    assert.equal(parentManifest.optionalDependencies["@next/swc-darwin-arm64"], undefined);
+    assert.equal(parentManifest.optionalDependencies["@next/swc-linux-x64-gnu"], undefined);
+    assert.equal(parentManifest.optionalDependencies.sharp, "0.34.5");
     assert.deepEqual(parentManifest.bundleDependencies, ["@conductor-oss/core"]);
     assert.equal(bundledManifest.name, "@conductor-oss/core");
     assert.equal(bundledManifest.version, "9.8.7");
+    assert.equal(
+      JSON.parse(readFileSync(
+        join(stageDir, "web", ".next", "standalone", "node_modules", "next", "package.json"),
+        "utf8",
+      )).version,
+      "16.2.10",
+    );
     assert.equal(
       assertBundledDependencyVersionsInTarball(tarballPath, {
         requiredDependencies: ["@conductor-oss/core"],

--- a/scripts/cli-release-stage.test.mjs
+++ b/scripts/cli-release-stage.test.mjs
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { packCliReleasePackage } from "./cli-release-stage.mjs";
+import {
+  assertBundledDependencyVersionsInTarball,
+  assertCliReleaseTarballEquivalence,
+} from "./release-workflow-lib.mjs";
+
+function writeJson(path, value) {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+test("release staging gives bundled private packages the parent release identity", () => {
+  const rootDir = mkdtempSync(join(tmpdir(), "conductor-cli-stage-fixture-"));
+  const stageDir = join(rootDir, "stage");
+  const packDir = join(rootDir, "artifacts");
+
+  try {
+    const cliDir = join(rootDir, "packages", "cli");
+    const coreDir = join(rootDir, "packages", "core");
+    const webDir = join(rootDir, "packages", "web");
+    mkdirSync(join(cliDir, "dist"), { recursive: true });
+    mkdirSync(join(coreDir, "dist"), { recursive: true });
+    mkdirSync(join(webDir, ".next", "standalone"), { recursive: true });
+    mkdirSync(join(webDir, ".next", "static"), { recursive: true });
+
+    writeJson(join(cliDir, "package.json"), {
+      name: "conductor-oss",
+      version: "9.8.7",
+      type: "module",
+      main: "dist/launcher.js",
+      bin: { conductor: "dist/launcher.js" },
+      dependencies: { "@conductor-oss/core": "workspace:*" },
+    });
+    writeFileSync(join(cliDir, "dist", "launcher.js"), "#!/usr/bin/env node\n", "utf8");
+    writeJson(join(coreDir, "package.json"), {
+      name: "@conductor-oss/core",
+      version: "0.2.7",
+      private: true,
+      type: "module",
+      main: "dist/index.js",
+    });
+    writeFileSync(join(coreDir, "dist", "index.js"), "export {};\n", "utf8");
+    writeJson(join(webDir, "package.json"), {
+      name: "@conductor-oss/web",
+      version: "0.2.7",
+      private: true,
+      dependencies: {},
+    });
+
+    const { tarballPath } = packCliReleasePackage({
+      rootDir,
+      stageDir,
+      packDestination: packDir,
+    });
+
+    const parentManifest = JSON.parse(readFileSync(join(stageDir, "package.json"), "utf8"));
+    const bundledManifest = JSON.parse(readFileSync(
+      join(stageDir, "node_modules", "@conductor-oss", "core", "package.json"),
+      "utf8",
+    ));
+    assert.equal(parentManifest.dependencies["@conductor-oss/core"], "9.8.7");
+    assert.deepEqual(parentManifest.bundleDependencies, ["@conductor-oss/core"]);
+    assert.equal(bundledManifest.name, "@conductor-oss/core");
+    assert.equal(bundledManifest.version, "9.8.7");
+    assert.equal(
+      assertBundledDependencyVersionsInTarball(tarballPath, {
+        requiredDependencies: ["@conductor-oss/core"],
+      }).version,
+      "9.8.7",
+    );
+    execFileSync("npm", ["ls", "--all", "--omit=dev", "--omit=optional"], {
+      cwd: stageDir,
+      stdio: "ignore",
+    });
+
+    const githubStageDir = join(rootDir, "github-stage");
+    const { tarballPath: githubTarballPath } = packCliReleasePackage({
+      rootDir,
+      stageDir: githubStageDir,
+      packDestination: packDir,
+      publishedName: "@charannyk06/conductor-oss",
+      publishRegistry: "https://npm.pkg.github.com",
+    });
+    assert.doesNotThrow(() => assertCliReleaseTarballEquivalence({
+      publicTarball: tarballPath,
+      githubTarball: githubTarballPath,
+      version: "9.8.7",
+    }));
+
+    const brokenEquivalenceDir = join(rootDir, "broken-equivalence");
+    mkdirSync(brokenEquivalenceDir, { recursive: true });
+    writeFileSync(join(githubStageDir, "dist", "launcher.js"), "broken launcher\n", "utf8");
+    const brokenGithubTarballName = execFileSync(
+      "npm",
+      ["pack", "--silent", "--pack-destination", brokenEquivalenceDir],
+      { cwd: githubStageDir, encoding: "utf8" },
+    ).trim();
+    assert.throws(
+      () => assertCliReleaseTarballEquivalence({
+        publicTarball: tarballPath,
+        githubTarball: join(brokenEquivalenceDir, brokenGithubTarballName),
+        version: "9.8.7",
+      }),
+      /differ at dist\/launcher\.js/,
+    );
+
+    const brokenPackDir = join(rootDir, "broken-artifacts");
+    mkdirSync(brokenPackDir, { recursive: true });
+    writeJson(
+      join(stageDir, "node_modules", "@conductor-oss", "core", "package.json"),
+      { ...bundledManifest, version: "0.2.7" },
+    );
+    const brokenTarballName = execFileSync(
+      "npm",
+      ["pack", "--silent", "--pack-destination", brokenPackDir],
+      { cwd: stageDir, encoding: "utf8" },
+    ).trim();
+    assert.throws(
+      () => assertBundledDependencyVersionsInTarball(join(brokenPackDir, brokenTarballName), {
+        requiredDependencies: ["@conductor-oss/core"],
+      }),
+      /has version 0\.2\.7; expected 9\.8\.7/,
+    );
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});

--- a/scripts/release-artifact-identity.mjs
+++ b/scripts/release-artifact-identity.mjs
@@ -8,6 +8,7 @@ import { setTimeout as sleep } from "node:timers/promises";
 
 import {
   assertArtifactIntegrity,
+  assertBundledDependencyVersionsInTarball,
   assertTarballFiles,
   isNpmNotFound,
   parseNpmDistMetadata,
@@ -21,6 +22,7 @@ function parseArguments(argv) {
     allowMissing: false,
     onExisting: "verify",
     registry: "https://registry.npmjs.org",
+    requireBundledDependencies: [],
     requireFiles: [],
     waitMs: 0,
   };
@@ -36,6 +38,8 @@ function parseArguments(argv) {
       options.onExisting = argv[++index];
     } else if (argument === "--require-file") {
       options.requireFiles.push(argv[++index]);
+    } else if (argument === "--require-bundled-dependency") {
+      options.requireBundledDependencies.push(argv[++index]);
     } else if (argument === "--wait-ms") {
       options.waitMs = Number(argv[++index]);
     } else {
@@ -95,7 +99,11 @@ async function downloadCanonicalTarball(metadata, destination, registry) {
 
 async function main() {
   const options = parseArguments(process.argv.slice(2));
-  const expectedManifest = readPackageManifestFromTarball(options.tarball);
+  const expectedManifest = options.requireBundledDependencies.length > 0
+    ? assertBundledDependencyVersionsInTarball(options.tarball, {
+      requiredDependencies: options.requireBundledDependencies,
+    })
+    : readPackageManifestFromTarball(options.tarball);
   assertTarballFiles(options.tarball, options.requireFiles);
   const startedAt = Date.now();
 
@@ -146,6 +154,11 @@ async function main() {
         throw new Error("canonical npm tarball package identity does not match the release artifact");
       }
       assertTarballFiles(canonicalPath, options.requireFiles);
+      if (options.requireBundledDependencies.length > 0) {
+        assertBundledDependencyVersionsInTarball(canonicalPath, {
+          requiredDependencies: options.requireBundledDependencies,
+        });
+      }
       copyFileSync(canonicalPath, options.tarball);
     } finally {
       rmSync(directory, { recursive: true, force: true });

--- a/scripts/release-workflow-lib.mjs
+++ b/scripts/release-workflow-lib.mjs
@@ -1,6 +1,15 @@
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const STABLE_VERSION_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 
@@ -91,6 +100,204 @@ export function resolveExistingArtifact(path, expectedIntegrity, mode) {
       throw error;
     }
     return "canonicalize";
+  }
+}
+
+export function assertBundledDependencyVersions(packageManifest, bundledManifests) {
+  const version = packageManifest?.version;
+  if (typeof version !== "string" || version.length === 0) {
+    throw new Error("published package manifest is missing its version");
+  }
+
+  const bundleDependencies = packageManifest.bundleDependencies
+    ?? packageManifest.bundledDependencies
+    ?? [];
+  if (!Array.isArray(bundleDependencies)) {
+    throw new Error("published package bundleDependencies must be an array");
+  }
+
+  for (const dependencyName of bundleDependencies) {
+    const declaredVersion = packageManifest.dependencies?.[dependencyName];
+    if (declaredVersion !== version) {
+      throw new Error(
+        `bundled dependency ${dependencyName} must be declared at ${version} (found ${declaredVersion ?? "missing"})`,
+      );
+    }
+
+    const bundledManifest = bundledManifests?.[dependencyName];
+    if (!bundledManifest) {
+      throw new Error(`bundled dependency ${dependencyName} is missing from the installed package`);
+    }
+    if (bundledManifest.name !== dependencyName) {
+      throw new Error(
+        `bundled dependency ${dependencyName} has package identity ${bundledManifest.name ?? "missing"}`,
+      );
+    }
+    if (bundledManifest.version !== version) {
+      throw new Error(
+        `bundled dependency ${dependencyName} has version ${bundledManifest.version ?? "missing"}; expected ${version}`,
+      );
+    }
+  }
+
+  return bundleDependencies;
+}
+
+function bundledManifestEntry(dependencyName) {
+  if (typeof dependencyName !== "string" || dependencyName.length === 0) {
+    throw new Error("bundled dependency name must be a non-empty string");
+  }
+  const parts = dependencyName.split("/");
+  const validShape = dependencyName.startsWith("@")
+    ? parts.length === 2 && parts[0].length > 1 && parts[1].length > 0
+    : parts.length === 1 && parts[0].length > 0;
+  if (
+    !validShape
+    || parts.some((part) => part === "." || part === ".." || part.includes("\\") || part.includes("\0"))
+  ) {
+    throw new Error(`invalid bundled dependency name: ${dependencyName}`);
+  }
+  return `package/node_modules/${parts.join("/")}/package.json`;
+}
+
+export function assertBundledDependencyVersionsInTarball(path, { requiredDependencies = [] } = {}) {
+  const packageManifest = readPackageManifestFromTarball(path);
+  const bundleDependencies = packageManifest.bundleDependencies
+    ?? packageManifest.bundledDependencies
+    ?? [];
+  if (!Array.isArray(bundleDependencies)) {
+    throw new Error("published package bundleDependencies must be an array");
+  }
+
+  for (const dependencyName of requiredDependencies) {
+    if (!bundleDependencies.includes(dependencyName)) {
+      throw new Error(`published package is missing required bundled dependency ${dependencyName}`);
+    }
+  }
+
+  const bundledManifests = {};
+  for (const dependencyName of bundleDependencies) {
+    const entry = bundledManifestEntry(dependencyName);
+    let raw;
+    try {
+      raw = execFileSync("tar", ["-xOf", path, entry], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch {
+      throw new Error(`tarball ${path} is missing bundled manifest ${entry}`);
+    }
+    try {
+      bundledManifests[dependencyName] = JSON.parse(raw);
+    } catch (error) {
+      throw new Error(`tarball ${path} has invalid JSON in ${entry}: ${error.message}`);
+    }
+  }
+
+  assertBundledDependencyVersions(packageManifest, bundledManifests);
+  return packageManifest;
+}
+
+function validateReleaseTarballPaths(path) {
+  const entries = execFileSync("tar", ["-tzf", path], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).split("\n").filter(Boolean);
+  const seen = new Set();
+  for (const rawEntry of entries) {
+    const entry = rawEntry.replace(/\/$/, "");
+    const parts = entry.split("/");
+    if (
+      (entry !== "package" && !entry.startsWith("package/"))
+      || entry.startsWith("/")
+      || entry.includes("\\")
+      || parts.some((part) => part === ".." || part === ".")
+    ) {
+      throw new Error(`tarball ${path} contains an unsafe entry: ${rawEntry}`);
+    }
+    if (seen.has(entry)) {
+      throw new Error(`tarball ${path} contains duplicate entry ${entry}`);
+    }
+    seen.add(entry);
+  }
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) {
+    return value.map(canonicalJson);
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value).sort().map((key) => [key, canonicalJson(value[key])]),
+    );
+  }
+  return value;
+}
+
+function collectRegularFileDigests(rootDir, relativeDir = "", result = new Map()) {
+  const directory = join(rootDir, relativeDir);
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
+    const path = join(rootDir, relativePath);
+    const stat = lstatSync(path);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`release artifact contains unsupported symbolic link ${relativePath}`);
+    }
+    if (stat.isDirectory()) {
+      collectRegularFileDigests(rootDir, relativePath, result);
+      continue;
+    }
+    if (!stat.isFile()) {
+      throw new Error(`release artifact contains unsupported file type at ${relativePath}`);
+    }
+
+    let contents = readFileSync(path);
+    if (relativePath === "package.json") {
+      const manifest = JSON.parse(contents.toString("utf8"));
+      delete manifest.name;
+      delete manifest.publishConfig;
+      contents = Buffer.from(JSON.stringify(canonicalJson(manifest)));
+    }
+    const digest = createHash("sha256").update(contents).digest("hex");
+    result.set(relativePath, `${(stat.mode & 0o777).toString(8)}:${digest}`);
+  }
+  return result;
+}
+
+export function assertCliReleaseTarballEquivalence({ publicTarball, githubTarball, version }) {
+  const publicManifest = readPackageManifestFromTarball(publicTarball);
+  const githubManifest = readPackageManifestFromTarball(githubTarball);
+  if (publicManifest.name !== "conductor-oss" || publicManifest.version !== version) {
+    throw new Error(`public CLI artifact identity must be conductor-oss@${version}`);
+  }
+  if (githubManifest.name !== "@charannyk06/conductor-oss" || githubManifest.version !== version) {
+    throw new Error(`GitHub CLI artifact identity must be @charannyk06/conductor-oss@${version}`);
+  }
+
+  validateReleaseTarballPaths(publicTarball);
+  validateReleaseTarballPaths(githubTarball);
+  const directory = mkdtempSync(join(tmpdir(), "conductor-cli-equivalence-"));
+  const publicDir = join(directory, "public");
+  const githubDir = join(directory, "github");
+  mkdirSync(publicDir);
+  mkdirSync(githubDir);
+  try {
+    execFileSync("tar", ["-xzf", publicTarball, "-C", publicDir], { stdio: "pipe" });
+    execFileSync("tar", ["-xzf", githubTarball, "-C", githubDir], { stdio: "pipe" });
+    const publicFiles = collectRegularFileDigests(join(publicDir, "package"));
+    const githubFiles = collectRegularFileDigests(join(githubDir, "package"));
+    const publicPaths = [...publicFiles.keys()].sort();
+    const githubPaths = [...githubFiles.keys()].sort();
+    if (JSON.stringify(publicPaths) !== JSON.stringify(githubPaths)) {
+      throw new Error("public and GitHub CLI artifacts contain different file sets");
+    }
+    for (const path of publicPaths) {
+      if (publicFiles.get(path) !== githubFiles.get(path)) {
+        throw new Error(`public and GitHub CLI artifacts differ at ${path}`);
+      }
+    }
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
   }
 }
 

--- a/scripts/release-workflow-lib.test.mjs
+++ b/scripts/release-workflow-lib.test.mjs
@@ -6,6 +6,7 @@ import test from "node:test";
 
 import {
   assertArtifactIntegrity,
+  assertBundledDependencyVersions,
   calculateFileIntegrity,
   detectReleaseBump,
   highestStableRegistryVersion,
@@ -14,6 +15,41 @@ import {
   registryDownloadHeaders,
   resolveExistingArtifact,
 } from "./release-workflow-lib.mjs";
+
+test("bundled package identities match the parent release version", () => {
+  const packageManifest = {
+    name: "conductor-oss",
+    version: "1.2.3",
+    dependencies: { "@conductor-oss/core": "1.2.3" },
+    bundleDependencies: ["@conductor-oss/core"],
+  };
+  const bundledManifests = {
+    "@conductor-oss/core": { name: "@conductor-oss/core", version: "1.2.3" },
+  };
+
+  assert.deepEqual(
+    assertBundledDependencyVersions(packageManifest, bundledManifests),
+    ["@conductor-oss/core"],
+  );
+  assert.throws(
+    () => assertBundledDependencyVersions(
+      packageManifest,
+      { "@conductor-oss/core": { name: "@conductor-oss/core", version: "0.2.7" } },
+    ),
+    /has version 0\.2\.7; expected 1\.2\.3/,
+  );
+  assert.throws(
+    () => assertBundledDependencyVersions(
+      { ...packageManifest, dependencies: { "@conductor-oss/core": "workspace:\*" } },
+      bundledManifests,
+    ),
+    /must be declared at 1\.2\.3/,
+  );
+  assert.throws(
+    () => assertBundledDependencyVersions(packageManifest, {}),
+    /is missing from the installed package/,
+  );
+});
 
 test("highestStableRegistryVersion is strict and compares numeric semver parts", () => {
   assert.equal(highestStableRegistryVersion('["0.9.9","0.10.0","1.0.0-beta.1"]'), "0.10.0");

--- a/scripts/verify-cli-artifact-equivalence.mjs
+++ b/scripts/verify-cli-artifact-equivalence.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+import { assertCliReleaseTarballEquivalence } from "./release-workflow-lib.mjs";
+
+function parseArguments(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--public-tarball") {
+      options.publicTarball = argv[++index];
+    } else if (argument === "--github-tarball") {
+      options.githubTarball = argv[++index];
+    } else if (argument === "--version") {
+      options.version = argv[++index];
+    } else {
+      throw new Error(`unknown argument: ${argument}`);
+    }
+  }
+  for (const name of ["publicTarball", "githubTarball", "version"]) {
+    if (!options[name]) {
+      throw new Error(`missing required ${name}`);
+    }
+  }
+  return options;
+}
+
+const options = parseArguments(process.argv.slice(2));
+assertCliReleaseTarballEquivalence(options);
+console.log(`Verified equivalent public and GitHub CLI artifacts for ${options.version}.`);

--- a/scripts/verify-cli-package.mjs
+++ b/scripts/verify-cli-package.mjs
@@ -1,5 +1,13 @@
 import { execFileSync, spawn } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { createServer } from "node:net";
 import { dirname, join, resolve } from "node:path";
@@ -10,6 +18,10 @@ import {
   findCliNativeTargetById,
   resolveHostCliNativeTargetId,
 } from "./cli-native-packages.mjs";
+import {
+  assertBundledDependencyVersions,
+  readPackageManifestFromTarball,
+} from "./release-workflow-lib.mjs";
 
 const NPM_EXECUTABLE = "npm";
 const CARGO_EXECUTABLE = "cargo";
@@ -18,11 +30,27 @@ function fail(message) {
   throw new Error(`release preflight failed: ${message}`);
 }
 
-function buildHostNativeBinary(rootDir) {
+function buildHostNativeBinary(rootDir, releaseVersion) {
   execFileSync(CARGO_EXECUTABLE, ["build", "-p", "conductor-cli", "--release"], {
     cwd: rootDir,
+    env: { ...process.env, CONDUCTOR_BUILD_VERSION: releaseVersion },
     stdio: "inherit",
   });
+}
+
+function parseArguments(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === "--tarball") {
+      options.tarballPath = argv[++index];
+      continue;
+    }
+    throw new Error(`unknown argument: ${argv[index]}`);
+  }
+  if (Object.hasOwn(options, "tarballPath") && !options.tarballPath) {
+    throw new Error("--tarball requires a path");
+  }
+  return options;
 }
 
 function createTempDir(prefix, tempDirs) {
@@ -278,10 +306,12 @@ function replaceProjectPathInYaml(content, projectId, nextPath) {
 
 function spawnInstalledCli(installDir, args, options = {}) {
   const cliEntry = getInstalledCliEntry(installDir);
+  const detached = process.platform !== "win32";
   const child = spawn("node", [cliEntry, ...args], {
     cwd: installDir,
     stdio: ["ignore", "pipe", "pipe"],
     ...options,
+    detached,
   });
 
   let bufferedStdout = "";
@@ -295,19 +325,107 @@ function spawnInstalledCli(installDir, args, options = {}) {
 
   return {
     child,
+    processGroupId: detached ? child.pid : null,
     getLogs() {
       return `${bufferedStdout}\n${bufferedStderr}`.trim();
     },
   };
 }
 
-async function stopProcess(child) {
-  if (!child || child.exitCode !== null) return;
-  child.kill("SIGTERM");
-  await sleep(1000);
-  if (child.exitCode === null) {
-    child.kill("SIGKILL");
+function processIsAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
   }
+}
+
+function processGroupIsAlive(processGroupId) {
+  if (process.platform === "win32" || !processGroupId) return false;
+  try {
+    process.kill(-processGroupId, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function stopProcess(handle) {
+  const child = handle?.child;
+  if (!child) return;
+  const processGroupId = handle.processGroupId;
+  try {
+    if (processGroupId) {
+      process.kill(-processGroupId, "SIGTERM");
+    } else if (child.exitCode === null) {
+      child.kill("SIGTERM");
+    }
+  } catch {
+    // The process may already have exited.
+  }
+  await sleep(1000);
+  try {
+    if (processGroupIsAlive(processGroupId)) {
+      process.kill(-processGroupId, "SIGKILL");
+    } else if (child.exitCode === null) {
+      child.kill("SIGKILL");
+    }
+  } catch {
+    // The process exited between the liveness check and signal.
+  }
+}
+
+async function terminatePid(pid) {
+  if (!processIsAlive(pid)) return;
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {
+    return;
+  }
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 1500 && processIsAlive(pid)) {
+    await sleep(50);
+  }
+  if (processIsAlive(pid)) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // The process exited between the liveness check and signal.
+    }
+  }
+}
+
+async function cleanupTerminalDaemons(homeDir) {
+  if (process.platform === "win32") return;
+  const runtimeRoot = join(homeDir, ".conductor", "runtime", "terminal-daemon");
+  if (!existsSync(runtimeRoot)) return;
+
+  const sessionPids = new Set();
+  const daemonPids = new Set();
+  for (const entry of readdirSync(runtimeRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const runtimeDir = join(runtimeRoot, entry.name);
+    try {
+      const state = JSON.parse(readTextFile(join(runtimeDir, "state.json")));
+      for (const session of Object.values(state.sessions ?? {})) {
+        if (Number.isInteger(session?.childPid)) sessionPids.add(session.childPid);
+        if (Number.isInteger(session?.hostPid)) sessionPids.add(session.hostPid);
+      }
+    } catch {
+      // No session state was persisted.
+    }
+    try {
+      const info = JSON.parse(readTextFile(join(runtimeDir, "info.json")));
+      if (Number.isInteger(info.pid)) daemonPids.add(info.pid);
+    } catch {
+      // No daemon info was persisted.
+    }
+  }
+
+  for (const pid of sessionPids) await terminatePid(pid);
+  for (const pid of daemonPids) await terminatePid(pid);
 }
 
 async function waitForDashboard(url, timeoutMs) {
@@ -724,11 +842,13 @@ async function verifyBrowserFirstLauncherFlow(installDir, tempDirs) {
       throw new Error(`bare launcher exited early with code ${launcher.child.exitCode}\n${launcher.getLogs()}`);
     }
   } finally {
-    await stopProcess(launcher.child);
+    await stopProcess(launcher);
+    await cleanupTerminalDaemons(homeDir);
   }
 }
 
 async function verifyConfiguredWorkspaceFlow(installDir, tempDirs) {
+  const homeDir = createTempDir("conductor-cli-configured-home-", tempDirs);
   const repoDir = createTempDir("conductor-cli-repo-", tempDirs);
   const baseUrl = "http://127.0.0.1:4111";
 
@@ -785,6 +905,7 @@ async function verifyConfiguredWorkspaceFlow(installDir, tempDirs) {
   ], {
     env: {
       ...process.env,
+      HOME: homeDir,
       CONDUCTOR_WORKSPACE: repoDir,
       CO_CONFIG_PATH: configPath,
     },
@@ -843,7 +964,8 @@ async function verifyConfiguredWorkspaceFlow(installDir, tempDirs) {
       throw new Error(`configured-workspace dashboard exited early with code ${dashboard.child.exitCode}\n${dashboard.getLogs()}`);
     }
   } finally {
-    await stopProcess(dashboard.child);
+    await stopProcess(dashboard);
+    await cleanupTerminalDaemons(homeDir);
   }
 }
 
@@ -867,6 +989,7 @@ async function verifyPackagedTmuxStructuredStreaming(installDir, tempDirs) {
   }
 
   const { binDir, fixtures } = createFakeAgentBinDir(tempDirs);
+  const homeDir = createTempDir("conductor-cli-streaming-home-", tempDirs);
   const repoDir = createTempDir("conductor-cli-streaming-", tempDirs);
   const baseUrl = "http://127.0.0.1:4113";
   const configPath = join(repoDir, "conductor.yaml");
@@ -901,6 +1024,7 @@ async function verifyPackagedTmuxStructuredStreaming(installDir, tempDirs) {
   ], {
     env: {
       ...process.env,
+      HOME: homeDir,
       PATH: `${binDir}:${process.env.PATH ?? ""}`,
       CONDUCTOR_WORKSPACE: repoDir,
       CO_CONFIG_PATH: configPath,
@@ -1010,11 +1134,13 @@ async function verifyPackagedTmuxStructuredStreaming(installDir, tempDirs) {
         // Best-effort cleanup.
       });
     }
-    await stopProcess(dashboard.child);
+    await stopProcess(dashboard);
+    await cleanupTerminalDaemons(homeDir);
   }
 }
 
 async function verifyLegacyProjectArrayOnboardingFlow(installDir, tempDirs) {
+  const homeDir = createTempDir("conductor-cli-legacy-home-", tempDirs);
   const legacyWorkspace = createTempDir("conductor-cli-legacy-", tempDirs);
   const baseUrl = "http://127.0.0.1:4112";
   const configPath = join(legacyWorkspace, "conductor.yaml");
@@ -1045,6 +1171,7 @@ async function verifyLegacyProjectArrayOnboardingFlow(installDir, tempDirs) {
   ], {
     env: {
       ...process.env,
+      HOME: homeDir,
       CONDUCTOR_WORKSPACE: legacyWorkspace,
       CO_CONFIG_PATH: configPath,
     },
@@ -1076,18 +1203,31 @@ async function verifyLegacyProjectArrayOnboardingFlow(installDir, tempDirs) {
       throw new Error(`legacy project-array dashboard exited early with code ${dashboard.child.exitCode}\n${dashboard.getLogs()}`);
     }
   } finally {
-    await stopProcess(dashboard.child);
+    await stopProcess(dashboard);
+    await cleanupTerminalDaemons(homeDir);
   }
 }
 
 const rootDir = resolve(process.cwd());
+const options = parseArguments(process.argv.slice(2));
 const tempDirs = [];
 const packDir = createTempDir("conductor-cli-pack-", tempDirs);
 const installDir = createTempDir("conductor-cli-install-", tempDirs);
 const npmCacheDir = createTempDir("conductor-cli-npm-cache-", tempDirs);
 let exitCode = 0;
 try {
-  const { tarballPath } = packCliReleasePackage({ rootDir, packDestination: packDir });
+  const packedRelease = options.tarballPath
+    ? { tarballPath: resolve(rootDir, options.tarballPath) }
+    : packCliReleasePackage({ rootDir, packDestination: packDir });
+  const { tarballPath } = packedRelease;
+  if (!existsSync(tarballPath)) {
+    fail(`CLI release tarball does not exist: ${tarballPath}`);
+  }
+  const releaseVersion = readPackageManifestFromTarball(tarballPath).version;
+  const sourceCliVersion = JSON.parse(readTextFile(join(rootDir, "packages", "cli", "package.json"))).version;
+  if (releaseVersion !== sourceCliVersion) {
+    fail(`CLI tarball version is ${releaseVersion}; checked-out release source is ${sourceCliVersion}`);
+  }
   const hostNativeTargetId = resolveHostCliNativeTargetId();
   if (!hostNativeTargetId) {
     fail(`release preflight does not support packaged native verification on ${process.platform}-${process.arch}`);
@@ -1101,7 +1241,7 @@ try {
   const hostBinaryPath = process.platform === "win32"
     ? resolve(rootDir, "target", "release", "conductor.exe")
     : resolve(rootDir, "target", "release", "conductor");
-  buildHostNativeBinary(rootDir);
+  buildHostNativeBinary(rootDir, releaseVersion);
   const { stageDir: nativeStageDir } = createCliNativeReleaseStage({
     rootDir,
     targetId: hostNativeTargetId,
@@ -1119,6 +1259,8 @@ try {
     stdio: "inherit",
     shell: true,
   });
+  const installedCliRoot = join(installDir, "node_modules", "conductor-oss");
+  const installedCliManifest = JSON.parse(readTextFile(join(installedCliRoot, "package.json")));
   verifyNodeShebang(getInstalledCliEntry(installDir), "installed CLI entrypoint");
   execFileSync("node", [getInstalledCliEntry(installDir), "--version"], {
     cwd: installDir,
@@ -1140,6 +1282,25 @@ try {
   if (!existsSync(installedNativeBackend)) {
     fail("installed CLI package is missing the host native runtime package");
   }
+  const installedNativeManifest = JSON.parse(readTextFile(join(
+    installDir,
+    "node_modules",
+    ...hostNativeTarget.packageName.split("/"),
+    "package.json",
+  )));
+  if (installedNativeManifest.name !== hostNativeTarget.packageName) {
+    fail(`installed native package identity is ${installedNativeManifest.name ?? "missing"}; expected ${hostNativeTarget.packageName}`);
+  }
+  if (installedNativeManifest.version !== installedCliManifest.version) {
+    fail(`installed native package version is ${installedNativeManifest.version ?? "missing"}; expected ${installedCliManifest.version}`);
+  }
+  if (installedCliManifest.optionalDependencies?.[hostNativeTarget.packageName] !== installedCliManifest.version) {
+    fail(`CLI optional dependency ${hostNativeTarget.packageName} does not match release version ${installedCliManifest.version}`);
+  }
+  const nativeVersion = execFileSync(installedNativeBackend, ["--version"], { encoding: "utf8" }).trim();
+  if (nativeVersion !== `conductor ${installedCliManifest.version}`) {
+    fail(`installed native binary reports ${nativeVersion || "no version"}; expected conductor ${installedCliManifest.version}`);
+  }
 
   const installedDashboardServer = join(
     installDir,
@@ -1156,17 +1317,29 @@ try {
     fail("installed CLI package is missing the dashboard server entrypoint");
   }
 
-  const bundledCorePackage = join(
-    installDir,
-    "node_modules",
-    "conductor-oss",
-    "node_modules",
-    "@conductor-oss",
-    "core",
-    "package.json",
-  );
-  if (!existsSync(bundledCorePackage)) {
-    fail("installed CLI package is missing bundled internal runtime packages");
+  const bundledDependencyNames = installedCliManifest.bundleDependencies
+    ?? installedCliManifest.bundledDependencies
+    ?? [];
+  if (!bundledDependencyNames.includes("@conductor-oss/core")) {
+    fail("installed CLI package is missing the bundled @conductor-oss/core runtime");
+  }
+  const bundledManifests = {};
+  for (const dependencyName of bundledDependencyNames) {
+    const manifestPath = join(installedCliRoot, "node_modules", ...dependencyName.split("/"), "package.json");
+    if (existsSync(manifestPath)) {
+      bundledManifests[dependencyName] = JSON.parse(readTextFile(manifestPath));
+    }
+  }
+  assertBundledDependencyVersions(installedCliManifest, bundledManifests);
+  try {
+    execFileSync(
+      NPM_EXECUTABLE,
+      ["ls", "--all", "--omit=dev"],
+      { cwd: installDir, encoding: "utf8", stdio: ["ignore", "ignore", "pipe"], shell: true },
+    );
+  } catch (error) {
+    const diagnostic = error?.stderr?.toString().trim() || error?.message || String(error);
+    fail(`installed npm dependency graph is invalid: ${diagnostic}`);
   }
 
   await verifyBrowserFirstLauncherFlow(installDir, tempDirs);

--- a/scripts/verify-cli-package.mjs
+++ b/scripts/verify-cli-package.mjs
@@ -90,7 +90,9 @@ const TMUX_STREAM_AGENT_FIXTURES = [
   },
   {
     agent: "cursor-cli",
-    binary: "cursor",
+    // Match the executor's preferred discovery order so an installed
+    // cursor-agent cannot bypass the fixture through a later alias.
+    binary: "cursor-agent",
     expectedPrefix: [],
     requiredArgs: [],
     forbiddenArgs: ["--output-format", "stream-json"],
@@ -245,6 +247,14 @@ async function allocatePort() {
       });
     });
   });
+}
+
+async function allocateDistinctPorts(count) {
+  const ports = new Set();
+  while (ports.size < count) {
+    ports.add(await allocatePort());
+  }
+  return [...ports];
 }
 
 function getInstalledCliEntry(installDir) {
@@ -463,8 +473,18 @@ async function waitForCondition(description, check, timeoutMs = 20_000) {
 
 async function fetchJson(url, init) {
   const response = await fetch(url, init);
-  const payload = await response.json().catch(() => null);
-  return { response, payload };
+  const bodyText = await response.text();
+  let payload = null;
+  try {
+    payload = JSON.parse(bodyText);
+  } catch {
+    // Preserve a bounded diagnostic for unexpected HTML/text proxy responses.
+  }
+  return {
+    response,
+    payload,
+    diagnosticBody: payload === null ? bodyText.slice(0, 500) : null,
+  };
 }
 
 const SPAWN_AGENT_PRIORITY = [
@@ -520,6 +540,32 @@ async function verifyDashboardAssets(baseUrl) {
       const assetResponse = await fetch(new URL(assetPath, baseUrl));
       return assetResponse.ok;
     }, 10_000);
+  }
+}
+
+async function verifyDashboardImageOptimization(baseUrl) {
+  const imageUrl = new URL("/_next/image", baseUrl);
+  imageUrl.searchParams.set("url", "/brand/conductor-wordmark-dark.png");
+  imageUrl.searchParams.set("w", "64");
+  imageUrl.searchParams.set("q", "75");
+
+  const response = await fetch(imageUrl, {
+    headers: { Accept: "image/webp" },
+  });
+  const body = Buffer.from(await response.arrayBuffer());
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!response.ok) {
+    throw new Error(`dashboard image optimizer returned ${response.status}`);
+  }
+  if (!contentType.startsWith("image/webp")) {
+    throw new Error(`dashboard image optimizer returned ${contentType || "no content type"}; expected image/webp`);
+  }
+  if (
+    body.length < 12
+    || body.subarray(0, 4).toString("ascii") !== "RIFF"
+    || body.subarray(8, 12).toString("ascii") !== "WEBP"
+  ) {
+    throw new Error("dashboard image optimizer did not return a valid WebP payload");
   }
 }
 
@@ -597,8 +643,7 @@ async function verifyBrowserFirstLauncherFlow(installDir, tempDirs) {
   const homeDir = createTempDir("conductor-cli-home-", tempDirs);
   const projectDir = createTempDir("conductor-cli-project-", tempDirs);
   const canonicalProjectDir = realpathSync.native(projectDir);
-  const dashboardPort = await allocatePort();
-  const backendPort = await allocatePort();
+  const [dashboardPort, backendPort] = await allocateDistinctPorts(2);
   const baseUrl = `http://127.0.0.1:${dashboardPort}`;
 
   const launcher = spawnInstalledCli(installDir, [
@@ -617,6 +662,7 @@ async function verifyBrowserFirstLauncherFlow(installDir, tempDirs) {
   try {
     await waitForDashboard(`${baseUrl}/api/config`, 25_000);
     await verifyDashboardAssets(baseUrl);
+    await verifyDashboardImageOptimization(baseUrl);
     await verifyFirstRunOnboarding(baseUrl);
 
     const bootstrapWorkspace = join(homeDir, ".openclaw", "workspace");
@@ -991,7 +1037,9 @@ async function verifyPackagedTmuxStructuredStreaming(installDir, tempDirs) {
   const { binDir, fixtures } = createFakeAgentBinDir(tempDirs);
   const homeDir = createTempDir("conductor-cli-streaming-home-", tempDirs);
   const repoDir = createTempDir("conductor-cli-streaming-", tempDirs);
-  const baseUrl = "http://127.0.0.1:4113";
+  const [dashboardPort, backendPort] = await allocateDistinctPorts(2);
+  const baseUrl = `http://127.0.0.1:${dashboardPort}`;
+  const backendBaseUrl = `http://127.0.0.1:${backendPort}`;
   const configPath = join(repoDir, "conductor.yaml");
   const boardPath = join(repoDir, "CONDUCTOR.md");
 
@@ -1018,7 +1066,9 @@ async function verifyPackagedTmuxStructuredStreaming(installDir, tempDirs) {
     "start",
     "--no-watcher",
     "--port",
-    "4113",
+    String(dashboardPort),
+    "--backend-port",
+    String(backendPort),
     "--workspace",
     repoDir,
   ], {
@@ -1077,7 +1127,7 @@ async function verifyPackagedTmuxStructuredStreaming(installDir, tempDirs) {
       try {
         await waitForCondition(`packaged tmux structured streaming feed for ${fixture.agent}`, async () => {
           const [feedResult, outputResult] = await Promise.all([
-            fetchJson(`${baseUrl}/api/sessions/${createdSessionId}/feed`),
+            fetchJson(`${backendBaseUrl}/api/sessions/${createdSessionId}/feed`),
             fetchJson(`${baseUrl}/api/sessions/${createdSessionId}/output`).catch(() => ({ payload: null, response: { ok: false } })),
           ]);
           if (!feedResult.response.ok) {
@@ -1095,14 +1145,17 @@ async function verifyPackagedTmuxStructuredStreaming(installDir, tempDirs) {
         }, 20_000);
       } catch (error) {
         const [feedResult, outputResult] = await Promise.all([
-          fetchJson(`${baseUrl}/api/sessions/${createdSessionId}/feed`).catch(() => ({ payload: null })),
+          fetchJson(`${backendBaseUrl}/api/sessions/${createdSessionId}/feed`).catch(() => ({ payload: null })),
           fetchJson(`${baseUrl}/api/sessions/${createdSessionId}/output`).catch(() => ({ payload: null })),
         ]);
         throw new Error(
           [
             error instanceof Error ? error.message : String(error),
             `agent: ${fixture.agent}`,
+            `feed status: ${feedResult.response?.status ?? "unavailable"}`,
+            `feed content-type: ${feedResult.response?.headers?.get?.("content-type") ?? "unavailable"}`,
             `feed: ${JSON.stringify(feedResult.payload)}`,
+            `feed body: ${feedResult.diagnosticBody ?? ""}`,
             `output: ${outputResult.payload?.output ?? ""}`,
             `logs: ${dashboard.getLogs()}`,
           ].join("\n"),
@@ -1254,7 +1307,7 @@ try {
     stdio: "ignore",
     shell: true,
   });
-  execFileSync(NPM_EXECUTABLE, ["install", "--cache", npmCacheDir, "--omit=optional", tarballPath, nativeStageDir], {
+  execFileSync(NPM_EXECUTABLE, ["install", "--cache", npmCacheDir, tarballPath, nativeStageDir], {
     cwd: installDir,
     stdio: "inherit",
     shell: true,
@@ -1270,6 +1323,17 @@ try {
   const installedDashboardRoot = join(installDir, "node_modules", "conductor-oss", "web", ".next", "standalone");
   if (!existsSync(installedDashboardRoot)) {
     fail("installed CLI package is missing the dashboard standalone directory");
+  }
+
+  const installedSharpManifestPath = join(installDir, "node_modules", "sharp", "package.json");
+  if (!existsSync(installedSharpManifestPath)) {
+    fail("installed CLI package is missing the host image optimization runtime");
+  }
+  const installedSharpManifest = JSON.parse(readTextFile(installedSharpManifestPath));
+  if (installedSharpManifest.version !== installedCliManifest.optionalDependencies?.sharp) {
+    fail(
+      `installed sharp version is ${installedSharpManifest.version ?? "missing"}; expected ${installedCliManifest.optionalDependencies?.sharp ?? "an exact optional dependency"}`,
+    );
   }
 
   const installedNativeBackend = join(
@@ -1340,6 +1404,19 @@ try {
   } catch (error) {
     const diagnostic = error?.stderr?.toString().trim() || error?.message || String(error);
     fail(`installed npm dependency graph is invalid: ${diagnostic}`);
+  }
+  try {
+    execFileSync(
+      NPM_EXECUTABLE,
+      ["audit", "--omit=dev", "--audit-level=low"],
+      { cwd: installDir, encoding: "utf8", stdio: ["ignore", "ignore", "pipe"], shell: true },
+    );
+  } catch (error) {
+    const diagnostic = error?.stdout?.toString().trim()
+      || error?.stderr?.toString().trim()
+      || error?.message
+      || String(error);
+    fail(`installed npm dependency audit is not clean: ${diagnostic}`);
   }
 
   await verifyBrowserFirstLauncherFlow(installDir, tempDirs);

--- a/scripts/verify-native-package.mjs
+++ b/scripts/verify-native-package.mjs
@@ -59,15 +59,15 @@ try {
   if (!existsSync(binaryPath)) {
     throw new Error(`native package is missing bin/${target.binaryName}`);
   }
+  if (target.id === "darwin-universal" && process.platform !== "darwin") {
+    throw new Error("darwin-universal artifacts must be verified on macOS");
+  }
   const actualVersion = execFileSync(binaryPath, ["--version"], { encoding: "utf8" }).trim();
   const expectedVersion = `conductor ${options.version}`;
   if (actualVersion !== expectedVersion) {
     throw new Error(`native package binary reports ${actualVersion || "no version"}; expected ${expectedVersion}`);
   }
   if (target.id === "darwin-universal") {
-    if (process.platform !== "darwin") {
-      throw new Error("darwin-universal artifacts must be verified on macOS");
-    }
     execFileSync("lipo", [binaryPath, "-verify_arch", "x86_64", "arm64"], { stdio: "pipe" });
   }
 } finally {

--- a/scripts/verify-native-package.mjs
+++ b/scripts/verify-native-package.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { findCliNativeTargetById } from "./cli-native-packages.mjs";
+import { readPackageManifestFromTarball } from "./release-workflow-lib.mjs";
+
+function parseArguments(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--tarball") {
+      options.tarball = argv[++index];
+    } else if (argument === "--target") {
+      options.targetId = argv[++index];
+    } else if (argument === "--version") {
+      options.version = argv[++index];
+    } else {
+      throw new Error(`unknown argument: ${argument}`);
+    }
+  }
+  for (const name of ["tarball", "targetId", "version"]) {
+    if (!options[name]) {
+      throw new Error(`missing required --${name === "targetId" ? "target" : name}`);
+    }
+  }
+  return options;
+}
+
+const options = parseArguments(process.argv.slice(2));
+const target = findCliNativeTargetById(options.targetId);
+if (!target) {
+  throw new Error(`unknown native target: ${options.targetId}`);
+}
+
+const tarball = resolve(options.tarball);
+const manifest = readPackageManifestFromTarball(tarball);
+if (manifest.name !== target.packageName) {
+  throw new Error(`native package name is ${manifest.name}; expected ${target.packageName}`);
+}
+if (manifest.version !== options.version) {
+  throw new Error(`native package version is ${manifest.version}; expected ${options.version}`);
+}
+for (const field of ["os", "cpu"]) {
+  if (JSON.stringify(manifest[field]) !== JSON.stringify(target[field])) {
+    throw new Error(
+      `native package ${field} metadata is ${JSON.stringify(manifest[field])}; expected ${JSON.stringify(target[field])}`,
+    );
+  }
+}
+
+const extractDir = mkdtempSync(join(tmpdir(), `conductor-native-verify-${options.targetId}-`));
+try {
+  execFileSync("tar", ["-xzf", tarball, "-C", extractDir], { stdio: "pipe" });
+  const binaryPath = join(extractDir, "package", "bin", target.binaryName);
+  if (!existsSync(binaryPath)) {
+    throw new Error(`native package is missing bin/${target.binaryName}`);
+  }
+  const actualVersion = execFileSync(binaryPath, ["--version"], { encoding: "utf8" }).trim();
+  const expectedVersion = `conductor ${options.version}`;
+  if (actualVersion !== expectedVersion) {
+    throw new Error(`native package binary reports ${actualVersion || "no version"}; expected ${expectedVersion}`);
+  }
+  if (target.id === "darwin-universal") {
+    if (process.platform !== "darwin") {
+      throw new Error("darwin-universal artifacts must be verified on macOS");
+    }
+    execFileSync("lipo", [binaryPath, "-verify_arch", "x86_64", "arm64"], { stdio: "pipe" });
+  }
+} finally {
+  rmSync(extractDir, { recursive: true, force: true });
+}
+
+console.log(`Verified ${target.packageName}@${options.version} and its packaged binary.`);

--- a/scripts/verify-npm-publication.mjs
+++ b/scripts/verify-npm-publication.mjs
@@ -4,11 +4,15 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 
-import { assertArtifactIntegrity } from "./release-workflow-lib.mjs";
+import {
+  assertArtifactIntegrity,
+  assertBundledDependencyVersionsInTarball,
+} from "./release-workflow-lib.mjs";
 
 function parseArgs(argv) {
   const options = {
     packageName: "",
+    requireBundledDependencies: [],
     version: "",
     requireFiles: [],
     timeoutMs: 600_000,
@@ -38,6 +42,12 @@ function parseArgs(argv) {
 
     if (arg === "--require-file") {
       options.requireFiles.push(argv[index + 1] ?? "");
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--require-bundled-dependency") {
+      options.requireBundledDependencies.push(argv[index + 1] ?? "");
       index += 1;
       continue;
     }
@@ -187,6 +197,11 @@ async function main() {
     const metadata = await waitForPublication(options);
     if (options.localTarball) {
       assertArtifactIntegrity(options.localTarball, metadata.dist?.integrity);
+      if (options.requireBundledDependencies.length > 0) {
+        assertBundledDependencyVersionsInTarball(options.localTarball, {
+          requiredDependencies: options.requireBundledDependencies,
+        });
+      }
     }
     const tarballPath = await downloadPublishedTarball({
       packageName: options.packageName,
@@ -194,6 +209,12 @@ async function main() {
       tarballUrl: metadata.dist.tarball,
       destinationDir: tempDir,
     });
+    assertArtifactIntegrity(tarballPath, metadata.dist?.integrity);
+    if (options.requireBundledDependencies.length > 0) {
+      assertBundledDependencyVersionsInTarball(tarballPath, {
+        requiredDependencies: options.requireBundledDependencies,
+      });
+    }
     unpackTarball(tarballPath, tempDir);
     verifyExtractedPackage({
       packageName: options.packageName,


### PR DESCRIPTION
## Summary

Fix npm release staging so bundled private workspace packages carry the same immutable version as the parent CLI. Harden recovery and publication around the exact canonical artifacts: validate bundled and native identities, dependency graphs, platform metadata, target-native execution, registry integrity, public/GitHub equivalence, and detached-process cleanup.

The follow-up hardening also removes an unused duplicate web dependency tree from installed CLIs while retaining exact host-native image optimization, restores the guarded session send route used by Project Notes, and makes the packaged dashboard contract explicit across operating systems and web-mode overrides.

## User-Facing Release Notes

- Global Conductor installs now have a valid npm dependency graph and matching CLI, core, and native runtime versions.
- Installed dashboards use the verified standalone runtime with host-native image optimization and a clean production dependency audit.
- Sending a note or message to an existing session works again from Project Notes.
- Release recovery rejects altered, mismatched, or incomplete npm artifacts before publication.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Agent or integration addition / modification
- [x] Documentation update
- [ ] Refactor / chore

## Checklist

- [x] `bun run build:frontend` passes for frontend changes
- [x] `bun run typecheck` passes for TypeScript changes
- [x] `bun run test:packages` passes for package changes
- [x] `cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` pass for Rust changes (not applicable; no Rust source changed)
- [x] `cd bridge-cmd && go test ./...` passes for bridge changes (not applicable; no bridge source changed)
- [x] No `any` types introduced without justification
- [x] No secrets or credentials committed
- [x] Security boundaries, authentication, persistence, and network behavior have regression tests when changed
- [x] User-facing release notes are filled in plain English or marked internal-only
- [x] PR title follows conventional commits (`feat:`, `fix:`, `chore:`, etc.)

## Testing

```bash
PATH="$HOME/.bun/bin:$PATH" bun run build:frontend
PATH="$HOME/.bun/bin:$PATH" bun run --cwd packages/cli build
PATH="$HOME/.bun/bin:$PATH" bun run test:packages
go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.10
node scripts/verify-cli-package.mjs
```

The full release preflight installs the exact tarball plus the host native package, validates `npm ls`, requires a zero-finding production `npm audit`, executes the native binary, starts the browser-first dashboard, exercises a real host-native WebP optimization request, and runs the real tmux + ttyd structured-streaming flow. It also verifies cleanup leaves no detached daemon behind.

Additional artifact checks prove public/GitHub tarball equivalence including file modes, validate downloaded SRI, execute every native artifact on its target OS, verify both slices of the universal Darwin binary, and reject the known-invalid v0.61.13 nested package identity.

## Screenshots / Demo

N/A - release pipeline, package runtime, and API route fixes.
