### PR TITLE
fix: handle Windows release tarball paths

### DIFF
--- a/scripts/cli-release-stage.mjs
+++ b/scripts/cli-release-stage.mjs
@@ -14,6 +14,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { CLI_NATIVE_TARGETS } from "./cli-native-packages.mjs";
+import { execTarArchiveSync } from "./release-workflow-lib.mjs";
 
 const NPM_EXECUTABLE = "npm";
 
@@ -443,7 +444,7 @@ export function createCliReleaseStage({
         const tarPath = spec.replace("file:", "");
         const depDir = join(outputDir, "node_modules", ...depName.split("/"));
         mkdirSync(depDir, { recursive: true });
-        execFileSync("tar", ["xzf", tarPath, "--strip-components=1", "-C", depDir], {
+        execTarArchiveSync(tarPath, ["-xzf"], ["--strip-components=1", "-C", depDir], {
           stdio: "inherit",
         });
       }

--- a/scripts/release-workflow-lib.mjs
+++ b/scripts/release-workflow-lib.mjs
@@ -9,9 +9,36 @@ import {
   rmSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, posix, win32 } from "node:path";
 
 const STABLE_VERSION_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+export function tarArchiveInvocation(
+  archivePath,
+  beforeArchiveArgs,
+  afterArchiveArgs = [],
+  platform = process.platform,
+) {
+  // A drive-letter colon can be interpreted as remote-archive syntax. Run tar
+  // from the archive directory and pass only its basename instead. This works
+  // with both GNU tar from Git Bash and Windows' bsdtar.
+  const pathApi = platform === "win32" ? win32 : posix;
+  const resolvedArchivePath = pathApi.resolve(archivePath);
+  return {
+    args: [...beforeArchiveArgs, pathApi.basename(resolvedArchivePath), ...afterArchiveArgs],
+    cwd: pathApi.dirname(resolvedArchivePath),
+  };
+}
+
+export function execTarArchiveSync(
+  archivePath,
+  beforeArchiveArgs,
+  afterArchiveArgs = [],
+  options = {},
+) {
+  const invocation = tarArchiveInvocation(archivePath, beforeArchiveArgs, afterArchiveArgs);
+  return execFileSync("tar", invocation.args, { ...options, cwd: invocation.cwd });
+}
 
 function compareStableVersions(left, right) {
   const leftParts = left.split(".").map(BigInt);
@@ -180,7 +207,7 @@ export function assertBundledDependencyVersionsInTarball(path, { requiredDepende
     const entry = bundledManifestEntry(dependencyName);
     let raw;
     try {
-      raw = execFileSync("tar", ["-xOf", path, entry], {
+      raw = execTarArchiveSync(path, ["-xOf"], [entry], {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
       });
@@ -199,7 +226,7 @@ export function assertBundledDependencyVersionsInTarball(path, { requiredDepende
 }
 
 function validateReleaseTarballPaths(path) {
-  const entries = execFileSync("tar", ["-tzf", path], {
+  const entries = execTarArchiveSync(path, ["-tzf"], [], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
   }).split("\n").filter(Boolean);
@@ -282,8 +309,8 @@ export function assertCliReleaseTarballEquivalence({ publicTarball, githubTarbal
   mkdirSync(publicDir);
   mkdirSync(githubDir);
   try {
-    execFileSync("tar", ["-xzf", publicTarball, "-C", publicDir], { stdio: "pipe" });
-    execFileSync("tar", ["-xzf", githubTarball, "-C", githubDir], { stdio: "pipe" });
+    execTarArchiveSync(publicTarball, ["-xzf"], ["-C", publicDir], { stdio: "pipe" });
+    execTarArchiveSync(githubTarball, ["-xzf"], ["-C", githubDir], { stdio: "pipe" });
     const publicFiles = collectRegularFileDigests(join(publicDir, "package"));
     const githubFiles = collectRegularFileDigests(join(githubDir, "package"));
     const publicPaths = [...publicFiles.keys()].sort();
@@ -302,7 +329,7 @@ export function assertCliReleaseTarballEquivalence({ publicTarball, githubTarbal
 }
 
 export function readPackageManifestFromTarball(path) {
-  const raw = execFileSync("tar", ["-xOf", path, "package/package.json"], {
+  const raw = execTarArchiveSync(path, ["-xOf"], ["package/package.json"], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -318,7 +345,7 @@ export function assertTarballFiles(path, requiredFiles) {
     return;
   }
   const entries = new Set(
-    execFileSync("tar", ["-tzf", path], {
+    execTarArchiveSync(path, ["-tzf"], [], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
     })

--- a/scripts/release-workflow-lib.test.mjs
+++ b/scripts/release-workflow-lib.test.mjs
@@ -14,7 +14,30 @@ import {
   parseNpmDistMetadata,
   registryDownloadHeaders,
   resolveExistingArtifact,
+  tarArchiveInvocation,
 } from "./release-workflow-lib.mjs";
+
+test("tar commands localize Windows drive-letter archives for GNU tar and bsdtar", () => {
+  assert.deepEqual(
+    tarArchiveInvocation(
+      "D:\\a\\conductor-oss\\package.tgz",
+      ["-xOf"],
+      ["package/package.json"],
+      "win32",
+    ),
+    {
+      args: ["-xOf", "package.tgz", "package/package.json"],
+      cwd: "D:\\a\\conductor-oss",
+    },
+  );
+  assert.deepEqual(
+    tarArchiveInvocation("/tmp/conductor/package.tgz", ["-xzf"], ["-C", "/tmp/out"], "darwin"),
+    {
+      args: ["-xzf", "package.tgz", "-C", "/tmp/out"],
+      cwd: "/tmp/conductor",
+    },
+  );
+});
 
 test("bundled package identities match the parent release version", () => {
   const packageManifest = {

--- a/scripts/verify-native-package.mjs
+++ b/scripts/verify-native-package.mjs
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 import { findCliNativeTargetById } from "./cli-native-packages.mjs";
-import { readPackageManifestFromTarball } from "./release-workflow-lib.mjs";
+import { execTarArchiveSync, readPackageManifestFromTarball } from "./release-workflow-lib.mjs";
 
 function parseArguments(argv) {
   const options = {};
@@ -54,7 +54,7 @@ for (const field of ["os", "cpu"]) {
 
 const extractDir = mkdtempSync(join(tmpdir(), `conductor-native-verify-${options.targetId}-`));
 try {
-  execFileSync("tar", ["-xzf", tarball, "-C", extractDir], { stdio: "pipe" });
+  execTarArchiveSync(tarball, ["-xzf"], ["-C", extractDir], { stdio: "pipe" });
   const binaryPath = join(extractDir, "package", "bin", target.binaryName);
   if (!existsSync(binaryPath)) {
     throw new Error(`native package is missing bin/${target.binaryName}`);

--- a/scripts/verify-npm-publication.mjs
+++ b/scripts/verify-npm-publication.mjs
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -7,6 +6,7 @@ import { setTimeout as sleep } from "node:timers/promises";
 import {
   assertArtifactIntegrity,
   assertBundledDependencyVersionsInTarball,
+  execTarArchiveSync,
 } from "./release-workflow-lib.mjs";
 
 function parseArgs(argv) {
@@ -156,7 +156,7 @@ async function downloadPublishedTarball({ packageName, version, tarballUrl, dest
 }
 
 function unpackTarball(tarballPath, destinationDir) {
-  execFileSync("tar", ["-xzf", tarballPath, "-C", destinationDir], {
+  execTarArchiveSync(tarballPath, ["-xzf"], ["-C", destinationDir], {
     stdio: "pipe",
   });
 }


### PR DESCRIPTION
## Summary

Fix the Windows native release verifier after run `29145910267` proved that tar interprets an absolute `D:\\...` package path as remote archive syntax.

All Node-based release tar operations now run from the archive directory and pass only the archive basename. This is portable across Git-for-Windows GNU tar, Windows bsdtar, Linux GNU tar, and macOS BSD tar. The sibling CLI-stage extraction also uses the unambiguous `-xzf` option form.

## User-Facing Release Notes

Internal-only release fix: Windows artifacts can now pass identity and binary verification, allowing the interrupted `v0.61.14` recovery release to continue.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Agent or integration addition / modification
- [ ] Documentation update
- [ ] Refactor / chore

## Checklist

- [x] `bun run build:frontend` passes for frontend changes (not applicable; no frontend source changed)
- [x] `bun run typecheck` passes for TypeScript changes (not applicable; release JavaScript only)
- [x] `bun run test:packages` passes for package changes (release script suite and full package preflight run directly)
- [x] `cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` pass for Rust changes (not applicable; no Rust source changed)
- [x] `cd bridge-cmd && go test ./...` passes for bridge changes (not applicable; no bridge source changed)
- [x] No `any` types introduced without justification
- [x] No secrets or credentials committed
- [x] Security boundaries, authentication, persistence, and network behavior have regression tests when changed
- [x] User-facing release notes are filled in plain English or marked internal-only
- [x] PR title follows conventional commits (`feat:`, `fix:`, `chore:`, etc.)

## Testing

```bash
node --check scripts/release-workflow-lib.mjs
node --check scripts/cli-release-stage.mjs
node --check scripts/verify-native-package.mjs
node --check scripts/verify-npm-publication.mjs
node --test scripts/*.test.mjs
node scripts/verify-cli-package.mjs
```

Results: 15/15 release-script tests passed, the full installed-package preflight passed with a clean npm graph/audit and real tmux + ttyd flow, and regression coverage asserts both Windows drive-letter localization and unchanged Darwin-style arguments.

## Screenshots / Demo

N/A - release portability fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release and package verification workflows when handling archives on Windows and other platforms.
  * Fixed extraction of internal packages and artifacts whose paths include drive letters.
  * Standardized archive handling across release, verification, and publication checks.

* **Tests**
  * Added coverage for platform-specific archive path handling, including Windows drive-letter paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->