### PR TITLE
fix: invoke npm safely on Windows releases

### DIFF
--- a/scripts/release-artifact-identity.mjs
+++ b/scripts/release-artifact-identity.mjs
@@ -11,6 +11,7 @@ import {
   assertBundledDependencyVersionsInTarball,
   assertTarballFiles,
   isNpmNotFound,
+  npmCliInvocation,
   parseNpmDistMetadata,
   readPackageManifestFromTarball,
   registryDownloadHeaders,
@@ -65,15 +66,18 @@ function parseArguments(argv) {
 }
 
 function queryDist(packageName, version, registry) {
+  const npm = npmCliInvocation();
   const result = spawnSync(
-    "npm",
-    ["view", `${packageName}@${version}`, "dist", "--json", "--registry", registry],
+    npm.command,
+    [...npm.argsPrefix, "view", `${packageName}@${version}`, "dist", "--json", "--registry", registry],
     { encoding: "utf8", env: process.env },
   );
   if (result.status === 0) {
     return { status: "found", metadata: parseNpmDistMetadata(result.stdout) };
   }
-  const diagnostic = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+  const diagnostic = [result.error?.message, result.stdout, result.stderr]
+    .filter(Boolean)
+    .join("\n");
   if (isNpmNotFound(diagnostic)) {
     return { status: "missing" };
   }

--- a/scripts/release-workflow-lib.mjs
+++ b/scripts/release-workflow-lib.mjs
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import {
+  existsSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
@@ -38,6 +39,35 @@ export function execTarArchiveSync(
 ) {
   const invocation = tarArchiveInvocation(archivePath, beforeArchiveArgs, afterArchiveArgs);
   return execFileSync("tar", invocation.args, { ...options, cwd: invocation.cwd });
+}
+
+export function npmCliInvocation({
+  platform = process.platform,
+  nodeExecutable = process.execPath,
+  npmExecPath = process.env.npm_execpath,
+  pathExists = existsSync,
+} = {}) {
+  if (platform !== "win32") {
+    return { command: "npm", argsPrefix: [] };
+  }
+
+  // npm is exposed as a .cmd shim on Windows, which cannot be executed by
+  // spawnSync without a shell. Invoke npm-cli.js with the current Node binary
+  // instead, keeping registry arguments out of shell parsing entirely.
+  const colocatedNpmCli = win32.join(
+    win32.dirname(nodeExecutable),
+    "node_modules",
+    "npm",
+    "bin",
+    "npm-cli.js",
+  );
+  const npmCli = [npmExecPath, colocatedNpmCli]
+    .filter((candidate) => typeof candidate === "string" && /(?:^|[\\/])npm-cli\.js$/i.test(candidate))
+    .find((candidate) => pathExists(candidate));
+  if (!npmCli) {
+    throw new Error(`unable to locate npm-cli.js for ${nodeExecutable}`);
+  }
+  return { command: nodeExecutable, argsPrefix: [npmCli] };
 }
 
 function compareStableVersions(left, right) {

--- a/scripts/release-workflow-lib.test.mjs
+++ b/scripts/release-workflow-lib.test.mjs
@@ -11,11 +11,39 @@ import {
   detectReleaseBump,
   highestStableRegistryVersion,
   isNpmNotFound,
+  npmCliInvocation,
   parseNpmDistMetadata,
   registryDownloadHeaders,
   resolveExistingArtifact,
   tarArchiveInvocation,
 } from "./release-workflow-lib.mjs";
+
+test("npm CLI invocation bypasses Windows command shims without a shell", () => {
+  const nodeExecutable = "C:\\hostedtoolcache\\windows\\node\\22.23.1\\x64\\node.exe";
+  const npmCli = "C:\\hostedtoolcache\\windows\\node\\22.23.1\\x64\\node_modules\\npm\\bin\\npm-cli.js";
+  assert.deepEqual(
+    npmCliInvocation({
+      platform: "win32",
+      nodeExecutable,
+      npmExecPath: undefined,
+      pathExists: (candidate) => candidate === npmCli,
+    }),
+    { command: nodeExecutable, argsPrefix: [npmCli] },
+  );
+  assert.deepEqual(npmCliInvocation({ platform: "linux" }), {
+    command: "npm",
+    argsPrefix: [],
+  });
+  assert.throws(
+    () => npmCliInvocation({
+      platform: "win32",
+      nodeExecutable,
+      npmExecPath: "C:\\Program Files\\nodejs\\npm.cmd",
+      pathExists: () => false,
+    }),
+    /unable to locate npm-cli\.js/,
+  );
+});
 
 test("tar commands localize Windows drive-letter archives for GNU tar and bsdtar", () => {
   assert.deepEqual(


### PR DESCRIPTION
## Summary

Fix the next Windows release edge exposed by run `29146541462`: after tarball localization succeeded, `spawnSync("npm", ...)` could not execute Windows' `npm.cmd` shim and returned `status: null`.

The release identity verifier now runs the real `npm-cli.js` through the current Node executable on Windows, preserving argument boundaries without invoking a shell. It accepts only an actual `npm-cli.js`, uses the setup-node colocated path as a deterministic fallback, fails clearly when the CLI is unavailable, and includes child-process spawn errors in diagnostics.

## User-Facing Release Notes

Internal-only release fix: Windows native artifact identity checks can query the registry safely so the interrupted `v0.61.14` release can continue.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Agent or integration addition / modification
- [ ] Documentation update
- [ ] Refactor / chore

## Checklist

- [x] `bun run build:frontend` passes for frontend changes (not applicable; no frontend source changed)
- [x] `bun run typecheck` passes for TypeScript changes (not applicable; release JavaScript only)
- [x] `bun run test:packages` passes for package changes (focused script suite and full package preflight run directly)
- [x] `cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` pass for Rust changes (not applicable; no Rust source changed)
- [x] `cd bridge-cmd && go test ./...` passes for bridge changes (not applicable; no bridge source changed)
- [x] No `any` types introduced without justification
- [x] No secrets or credentials committed
- [x] Security boundaries, authentication, persistence, and network behavior have regression tests when changed
- [x] User-facing release notes are filled in plain English or marked internal-only
- [x] PR title follows conventional commits (`feat:`, `fix:`, `chore:`, etc.)

## Testing

```bash
node --check scripts/release-workflow-lib.mjs
node --check scripts/release-artifact-identity.mjs
node --test scripts/*.test.mjs
node scripts/verify-cli-package.mjs
```

Results: 16/16 release-script tests passed and the full installed-package preflight passed. Regression coverage verifies shell-free setup-node path resolution, Unix behavior, invalid Windows shims, and missing-CLI failure.

## Screenshots / Demo

N/A - release portability fix.
