### PR TITLE
fix: harden terminal and repository security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       day: monday
       time: "08:00"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     groups:
       compatible-minor-and-patch:
         update-types:
@@ -25,6 +27,8 @@ updates:
       day: monday
       time: "08:00"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     groups:
       compatible-minor-and-patch:
         update-types:
@@ -41,6 +45,8 @@ updates:
       day: monday
       time: "08:00"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     groups:
       compatible-minor-and-patch:
         update-types:
@@ -57,6 +63,8 @@ updates:
       day: monday
       time: "08:00"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 
   # Strix scanner requirements used by CI
   - package-ecosystem: pip
@@ -66,6 +74,8 @@ updates:
       day: monday
       time: "08:00"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 
   # GitHub Actions
   - package-ecosystem: github-actions
@@ -75,3 +85,5 @@ updates:
       day: monday
       time: "08:00"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,12 +119,26 @@ jobs:
 
           echo "Tag: $tag_ver | Package: $pkg_ver | npm-highest: $npm_highest"
 
-          base=$(node -e "
-            const vs=['$tag_ver','$pkg_ver','$npm_highest'];
-            const p=v=>v.split('.').map(Number);
-            vs.sort((a,b)=>{const pa=p(a),pb=p(b);for(let i=0;i<3;i++)if((pa[i]||0)!==(pb[i]||0))return(pa[i]||0)-(pb[i]||0);return 0});
-            console.log(vs[vs.length-1]);
-          ")
+          base=$(TAG_VERSION="$tag_ver" PACKAGE_VERSION="$pkg_ver" NPM_HIGHEST="$npm_highest" node <<'NODE'
+          const versions = [
+            process.env.TAG_VERSION,
+            process.env.PACKAGE_VERSION,
+            process.env.NPM_HIGHEST,
+          ];
+          const parse = (version) => version.split('.').map(Number);
+          versions.sort((left, right) => {
+            const leftParts = parse(left);
+            const rightParts = parse(right);
+            for (let index = 0; index < 3; index += 1) {
+              if ((leftParts[index] || 0) !== (rightParts[index] || 0)) {
+                return (leftParts[index] || 0) - (rightParts[index] || 0);
+              }
+            }
+            return 0;
+          });
+          console.log(versions.at(-1));
+          NODE
+          )
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             bump="${{ inputs.version_type }}"
@@ -137,12 +151,20 @@ jobs:
             bump=$(node scripts/release-version.mjs bump < /tmp/release-commits)
           fi
 
-          next=$(node -e "
-            const [M,m,p]='$base'.split('.').map(Number);
-            if('$bump'==='major')console.log((M+1)+'.0.0');
-            else if('$bump'==='minor')console.log(M+'.'+(m+1)+'.0');
-            else console.log(M+'.'+m+'.'+(p+1));
-          ")
+          next=$(BASE_VERSION="$base" BUMP_KIND="$bump" node <<'NODE'
+          const [major, minor, patch] = process.env.BASE_VERSION.split('.').map(Number);
+          switch (process.env.BUMP_KIND) {
+            case 'major':
+              console.log(`${major + 1}.0.0`);
+              break;
+            case 'minor':
+              console.log(`${major}.${minor + 1}.0`);
+              break;
+            default:
+              console.log(`${major}.${minor}.${patch + 1}`);
+          }
+          NODE
+          )
 
           echo "Bump: $bump | $base -> $next"
           echo "new_version=$next" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -76,7 +76,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Gitleaks
-        run: go install github.com/gitleaks/gitleaks/v8@v8.24.2
+        run: go install github.com/zricethezav/gitleaks/v8@v8.24.2
 
       - name: Gitleaks full-history scan
         run: ~/go/bin/gitleaks detect --source . --redact --no-banner --config .gitleaks.toml

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,10 +29,10 @@ jobs:
           bun-version-file: package.json
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --minimum-release-age=604800
 
       - name: Install preview-worker dependencies
-        run: bun install --cwd preview-worker --frozen-lockfile
+        run: bun install --cwd preview-worker --frozen-lockfile --minimum-release-age=604800
 
       - name: Audit workspace dependencies
         run: bun audit --audit-level=high
@@ -48,11 +48,12 @@ jobs:
           cache-dependency-path: .github/requirements/strix-security-scan.txt
 
       - name: Audit Strix scanner dependencies
-        run: |
-          python -m pip install --disable-pip-version-check pip-audit==2.10.1
-          python -m pip_audit \
-            --requirement .github/requirements/strix-security-scan.txt \
-            --disable-pip
+        uses: pypa/gh-action-pip-audit@1220774d901786e6f652ae159f7b6bc8fea6d266 # v1.1.0
+        with:
+          inputs: .github/requirements/strix-security-scan.txt
+          require-hashes: true
+          no-deps: true
+          disable-pip: true
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -67,7 +68,6 @@ jobs:
   secret-scan:
     name: Secret Scanning
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -75,7 +75,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Gitleaks
+        run: go install github.com/gitleaks/gitleaks/v8@v8.24.2
+
+      - name: Gitleaks full-history scan
+        run: ~/go/bin/gitleaks detect --source . --redact --no-banner --config .gitleaks.toml
+
       - name: TruffleHog OSS
+        if: github.event_name == 'pull_request'
         uses: trufflesecurity/trufflehog@30d5bb91af1a771378349dbbb0c82129392acf70 # v3.95.6
         with:
           extra_args: --only-verified

--- a/.github/workflows/strix-scan.yml
+++ b/.github/workflows/strix-scan.yml
@@ -55,28 +55,37 @@ jobs:
               exit 1
               ;;
           esac
-          echo "scan_mode=$scan_mode" >> "$GITHUB_OUTPUT"
+          printf 'scan_mode=%s\n' "$scan_mode" >> "$GITHUB_OUTPUT"
 
           target_url="${INPUT_TARGET_URL:-}"
-          if [ -n "$target_url" ] && ! printf '%s' "$target_url" | grep -Eq '^https?://'; then
-            echo "::error::target_url must start with http:// or https:// when provided."
-            exit 1
+          if [ -n "$target_url" ]; then
+            case "$target_url" in
+              *$'\r'*|*$'\n'*)
+                echo "::error::target_url must be a single line when provided."
+                exit 1
+                ;;
+              http://*|https://*) ;;
+              *)
+                echo "::error::target_url must start with http:// or https:// when provided."
+                exit 1
+                ;;
+            esac
           fi
-          echo "target_url=$target_url" >> "$GITHUB_OUTPUT"
+          printf 'target_url=%s\n' "$target_url" >> "$GITHUB_OUTPUT"
 
           if [ -z "${STRIX_LLM:-}" ]; then
-            echo "run_scan=false" >> "$GITHUB_OUTPUT"
+            printf 'run_scan=%s\n' "false" >> "$GITHUB_OUTPUT"
             echo "::error::STRIX_LLM is required; refusing to report a successful security workflow without a scan."
             exit 1
           fi
 
           if [ -z "${LLM_API_KEY:-}" ]; then
-            echo "run_scan=false" >> "$GITHUB_OUTPUT"
+            printf 'run_scan=%s\n' "false" >> "$GITHUB_OUTPUT"
             echo "::error::LLM_API_KEY is required for the configured Strix model; refusing to start the scan."
             exit 1
           fi
 
-          echo "run_scan=true" >> "$GITHUB_OUTPUT"
+          printf 'run_scan=%s\n' "true" >> "$GITHUB_OUTPUT"
 
   security-scan:
     name: Strix security scan

--- a/.github/workflows/strix-scan.yml
+++ b/.github/workflows/strix-scan.yml
@@ -34,22 +34,49 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run_scan: ${{ steps.config.outputs.run_scan }}
+      scan_mode: ${{ steps.config.outputs.scan_mode }}
+      target_url: ${{ steps.config.outputs.target_url }}
     steps:
       - name: Check scanner configuration
         id: config
         env:
           STRIX_LLM: ${{ secrets.STRIX_LLM }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          INPUT_SCAN_MODE: ${{ github.event.inputs.scan_mode }}
+          INPUT_TARGET_URL: ${{ github.event.inputs.target_url }}
         shell: bash
         run: |
           set -euo pipefail
-          if [ -n "${STRIX_LLM:-}" ]; then
-            echo "run_scan=true" >> "$GITHUB_OUTPUT"
-            exit 0
+          scan_mode="${INPUT_SCAN_MODE:-quick}"
+          case "$scan_mode" in
+            quick|standard|deep) ;;
+            *)
+              echo "::error::Invalid scan_mode '$scan_mode'. Expected quick, standard, or deep."
+              exit 1
+              ;;
+          esac
+          echo "scan_mode=$scan_mode" >> "$GITHUB_OUTPUT"
+
+          target_url="${INPUT_TARGET_URL:-}"
+          if [ -n "$target_url" ] && ! printf '%s' "$target_url" | grep -Eq '^https?://'; then
+            echo "::error::target_url must start with http:// or https:// when provided."
+            exit 1
+          fi
+          echo "target_url=$target_url" >> "$GITHUB_OUTPUT"
+
+          if [ -z "${STRIX_LLM:-}" ]; then
+            echo "run_scan=false" >> "$GITHUB_OUTPUT"
+            echo "::error::STRIX_LLM is required; refusing to report a successful security workflow without a scan."
+            exit 1
           fi
 
-          echo "run_scan=false" >> "$GITHUB_OUTPUT"
-          echo "::error::STRIX_LLM is required; refusing to report a successful security workflow without a scan."
-          exit 1
+          if [ -z "${LLM_API_KEY:-}" ]; then
+            echo "run_scan=false" >> "$GITHUB_OUTPUT"
+            echo "::error::LLM_API_KEY is required for the configured Strix model; refusing to start the scan."
+            exit 1
+          fi
+
+          echo "run_scan=true" >> "$GITHUB_OUTPUT"
 
   security-scan:
     name: Strix security scan
@@ -79,8 +106,8 @@ jobs:
         env:
           STRIX_LLM: ${{ secrets.STRIX_LLM }}
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
-          TARGET_URL: ${{ inputs.target_url }}
-          SCAN_MODE: ${{ inputs.scan_mode || 'quick' }}
+          TARGET_URL: ${{ needs.preflight.outputs.target_url }}
+          SCAN_MODE: ${{ needs.preflight.outputs.scan_mode }}
         run: |
           set -uo pipefail
           status=0

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,28 @@
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Reviewed Clerk test placeholders"
+paths = [
+  '''packages/web/src/lib/auth.test.ts''',
+  '''packages/web/src/lib/clerkConfig.test.ts''',
+]
+targetRules = ['''generic-api-key''']
+
+[[allowlists]]
+description = "Reviewed static ttyd frontend bundle false positives"
+paths = [
+  '''crates/conductor-server/src/routes/ttyd_frontend_v1.7.7.html''',
+  '''packages/web/src/lib/ttyd_frontend_v1.7.7.html''',
+]
+targetRules = ['''generic-api-key''']
+
+[[allowlists]]
+description = "Reviewed API label copy false positive"
+paths = ['''packages/core/src/types.ts''']
+targetRules = ['''generic-api-key''']
+
+[[allowlists]]
+description = "Reviewed ephemeral test key generation path"
+paths = ['''crates/conductor-server/src/routes/config.rs''']
+targetRules = ['''private-key''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,28 +1,15 @@
 [extend]
 useDefault = true
 
-[[allowlists]]
-description = "Reviewed Clerk test placeholders"
+# Gitleaks v8.24 supports one global allowlist. Every path below was manually
+# reviewed, is an exact anchored path, and contains only test fixtures, vendored
+# static assets, or non-secret UI label text.
+[allowlist]
+description = "Reviewed non-secret scanner false positives"
 paths = [
-  '''packages/web/src/lib/auth.test.ts''',
-  '''packages/web/src/lib/clerkConfig.test.ts''',
+  '''^packages/web/src/lib/auth\.test\.ts$''',
+  '''^packages/web/src/lib/clerkConfig\.test\.ts$''',
+  '''^crates/conductor-server/src/routes/ttyd_frontend_v1\.7\.7\.html$''',
+  '''^packages/web/src/lib/ttyd_frontend_v1\.7\.7\.html$''',
+  '''^packages/core/src/types\.ts$''',
 ]
-targetRules = ['''generic-api-key''']
-
-[[allowlists]]
-description = "Reviewed static ttyd frontend bundle false positives"
-paths = [
-  '''crates/conductor-server/src/routes/ttyd_frontend_v1.7.7.html''',
-  '''packages/web/src/lib/ttyd_frontend_v1.7.7.html''',
-]
-targetRules = ['''generic-api-key''']
-
-[[allowlists]]
-description = "Reviewed API label copy false positive"
-paths = ['''packages/core/src/types.ts''']
-targetRules = ['''generic-api-key''']
-
-[[allowlists]]
-description = "Reviewed ephemeral test key generation path"
-paths = ['''crates/conductor-server/src/routes/config.rs''']
-targetRules = ['''private-key''']

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,3 @@
+# Synthetic runtime-generated Cloudflare Access private-key test fixture.
+# Exact historical Gitleaks fingerprint, not a path- or rule-level suppression.
+d85d15704e5c12191398cbafed900c952fc88032:crates/conductor-server/src/routes/config.rs:private-key:1486

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,5 @@
 registry=https://registry.npmjs.org/
+# Legacy npm releases safely ignore minimum-release-age. Modern npm recognizes
+# min-release-age, while Bun and policy scanners consume the long-form setting.
+min-release-age=7
+minimum-release-age=604800

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2645,9 +2645,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]

--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ The dashboard only offers agents it can discover on your machine.
 | `attachments/` | Uploaded files and generated session artifacts |
 | `~/.conductor/` | Launcher runtime state and optional bridge state |
 
+The filesystem picker defaults to the current workspace, configured project roots, and any explicit `preferences.filesystemBrowseRoots` entries. Broad home-directory browsing stays off unless an operator or admin explicitly enables `preferences.allowHomeBrowse: true`.
+
 ## Ports
 
 ### Launcher defaults

--- a/crates/conductor-core/src/config.rs
+++ b/crates/conductor-core/src/config.rs
@@ -536,6 +536,8 @@ pub struct PreferencesConfig {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub filesystem_browse_roots: Vec<String>,
     #[serde(default)]
+    pub allow_home_browse: bool,
+    #[serde(default)]
     pub model_access: ModelAccessPreferences,
     #[serde(default)]
     pub notifications: NotificationPreferences,
@@ -550,6 +552,7 @@ impl Default for PreferencesConfig {
             markdown_editor: default_markdown_editor(),
             markdown_editor_path: String::new(),
             filesystem_browse_roots: Vec::new(),
+            allow_home_browse: false,
             model_access: ModelAccessPreferences::default(),
             notifications: NotificationPreferences::default(),
         }
@@ -904,6 +907,26 @@ preferences:
             config.preferences.filesystem_browse_roots,
             vec!["/Users".to_string(), "/Volumes/projects".to_string()]
         );
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn test_load_preserves_allow_home_browse() {
+        let root = std::env::temp_dir().join(format!("conductor-config-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).unwrap();
+        let path = root.join("conductor.yaml");
+        std::fs::write(
+            &path,
+            r#"
+preferences:
+  allowHomeBrowse: true
+"#,
+        )
+        .unwrap();
+
+        let config = ConductorConfig::load(&path).unwrap();
+        assert!(config.preferences.allow_home_browse);
 
         std::fs::remove_dir_all(root).unwrap();
     }

--- a/crates/conductor-core/src/scaffold.rs
+++ b/crates/conductor-core/src/scaffold.rs
@@ -28,6 +28,7 @@ pub struct ScaffoldPreferencesConfig {
     pub markdown_editor: Option<String>,
     pub markdown_editor_path: Option<String>,
     pub filesystem_browse_roots: Option<Vec<String>>,
+    pub allow_home_browse: Option<bool>,
     pub model_access: Option<ModelAccessPreferences>,
     pub notifications: Option<ScaffoldNotificationPreferences>,
 }
@@ -164,6 +165,8 @@ struct ScaffoldPreferencesRecord {
     markdown_editor_path: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     filesystem_browse_roots: Vec<String>,
+    #[serde(skip_serializing_if = "is_false")]
+    allow_home_browse: bool,
     model_access: ModelAccessPreferences,
     notifications: NotificationPreferences,
 }
@@ -508,6 +511,9 @@ fn build_preferences_record(
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty())
             .collect(),
+        allow_home_browse: config
+            .and_then(|value| value.allow_home_browse)
+            .unwrap_or(false),
         model_access: config
             .and_then(|value| value.model_access.clone())
             .unwrap_or_default(),

--- a/crates/conductor-core/src/support.rs
+++ b/crates/conductor-core/src/support.rs
@@ -81,6 +81,8 @@ struct MirrorPreferences {
     markdown_editor_path: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     filesystem_browse_roots: Vec<String>,
+    #[serde(skip_serializing_if = "is_false")]
+    allow_home_browse: bool,
     model_access: ModelAccessPreferences,
     notifications: NotificationPreferences,
 }
@@ -291,6 +293,7 @@ fn build_preferences(preferences: &PreferencesConfig) -> MirrorPreferences {
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty())
             .collect(),
+        allow_home_browse: preferences.allow_home_browse,
         model_access: preferences.model_access.clone(),
         notifications: preferences.notifications.clone(),
     }

--- a/crates/conductor-executors/src/process.rs
+++ b/crates/conductor-executors/src/process.rs
@@ -1019,20 +1019,28 @@ mod tests {
         .await
         .expect("headless process should spawn with clean env");
 
-        let first = timeout(Duration::from_secs(5), handle.output_rx.recv())
-            .await
-            .expect("timed out waiting for env report")
-            .expect("output channel closed before env report");
-        let second = timeout(Duration::from_secs(5), handle.output_rx.recv())
-            .await
-            .expect("timed out waiting for completion")
-            .expect("output channel closed before completion");
+        let mut env_json = None;
+        let mut completed = None;
+
+        for _ in 0..4 {
+            let output = timeout(Duration::from_secs(5), handle.output_rx.recv())
+                .await
+                .expect("timed out waiting for process output")
+                .expect("output channel closed before completion");
+            match output {
+                ExecutorOutput::Stdout(stdout) => env_json = Some(stdout),
+                ExecutorOutput::Completed { exit_code } => completed = Some(exit_code),
+                ExecutorOutput::Stderr(_) => {}
+                other => panic!("unexpected process output while reading env report: {other:?}"),
+            }
+            if env_json.is_some() && completed.is_some() {
+                break;
+            }
+        }
 
         std::env::remove_var(noisy_key);
 
-        let ExecutorOutput::Stdout(env_json) = first else {
-            panic!("expected stdout env report, got {first:?}");
-        };
+        let env_json = env_json.expect("expected stdout env report before process completion");
         let env_report: serde_json::Value =
             serde_json::from_str(&env_json).expect("env report should parse");
 
@@ -1045,8 +1053,8 @@ mod tests {
             "clean-env spawn should not inherit parent env noise: {env_report:?}"
         );
         assert!(
-            matches!(second, ExecutorOutput::Completed { exit_code: 0 }),
-            "expected completion after env report, got {second:?}"
+            completed == Some(0),
+            "expected completion after env report, got {completed:?}"
         );
     }
 

--- a/crates/conductor-server/src/lib.rs
+++ b/crates/conductor-server/src/lib.rs
@@ -222,7 +222,7 @@ fn ensure_terminal_token_secret(workspace_path: &Path) -> Result<()> {
 
     let secret = if secret_path.exists() {
         harden_terminal_secret_permissions(&secret_path)?;
-        let existing = fs::read_to_string(&secret_path).unwrap_or_default();
+        let existing = fs::read_to_string(&secret_path)?;
         let trimmed = existing.trim();
         if trimmed.is_empty() {
             let generated = Uuid::new_v4().to_string();

--- a/crates/conductor-server/src/lib.rs
+++ b/crates/conductor-server/src/lib.rs
@@ -19,6 +19,7 @@ use axum::Router;
 use conductor_core::{ConductorConfig, EventBus};
 use conductor_db::Database;
 use std::fs;
+use std::io::Write;
 use std::net::{IpAddr, SocketAddr};
 use std::path::Path;
 use std::time::Duration;
@@ -29,6 +30,9 @@ use uuid::Uuid;
 use crate::state::AppState;
 
 const TERMINAL_TOKEN_SECRET_ENV: &str = "CONDUCTOR_TERMINAL_SESSION_SECRET";
+
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
 pub async fn serve(config: &ConductorConfig, db: Database, _event_bus: EventBus) -> Result<()> {
     let config_path = config
@@ -213,19 +217,184 @@ fn ensure_terminal_token_secret(workspace_path: &Path) -> Result<()> {
         .join("terminal-session-secret");
     if let Some(parent) = secret_path.parent() {
         fs::create_dir_all(parent)?;
+        harden_terminal_secret_dir(parent)?;
     }
 
-    let secret = match fs::read_to_string(&secret_path) {
-        Ok(existing) if !existing.trim().is_empty() => existing.trim().to_string(),
-        _ => {
+    let secret = if secret_path.exists() {
+        harden_terminal_secret_permissions(&secret_path)?;
+        let existing = fs::read_to_string(&secret_path).unwrap_or_default();
+        let trimmed = existing.trim();
+        if trimmed.is_empty() {
             let generated = Uuid::new_v4().to_string();
-            fs::write(&secret_path, format!("{generated}\n"))?;
+            overwrite_terminal_token_secret(&secret_path, &generated)?;
             generated
+        } else {
+            trimmed.to_string()
         }
+    } else {
+        let generated = Uuid::new_v4().to_string();
+        create_terminal_token_secret(&secret_path, &generated)?;
+        generated
     };
 
     unsafe {
         std::env::set_var(TERMINAL_TOKEN_SECRET_ENV, secret);
     }
     Ok(())
+}
+
+fn create_terminal_token_secret(secret_path: &Path, secret: &str) -> Result<()> {
+    let temp_path = secret_path.with_extension(format!("{}.tmp", Uuid::new_v4().simple()));
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        options.mode(0o600);
+    }
+
+    let mut file = options.open(&temp_path)?;
+    let write_result = (|| -> Result<()> {
+        file.write_all(format!("{secret}\n").as_bytes())?;
+        file.flush()?;
+        file.sync_data()?;
+        Ok(())
+    })();
+    drop(file);
+
+    if let Err(err) = write_result {
+        let _ = fs::remove_file(&temp_path);
+        return Err(err);
+    }
+
+    if let Err(err) = fs::rename(&temp_path, secret_path) {
+        let _ = fs::remove_file(&temp_path);
+        return Err(err.into());
+    }
+
+    harden_terminal_secret_permissions(secret_path)?;
+    Ok(())
+}
+
+fn overwrite_terminal_token_secret(secret_path: &Path, secret: &str) -> Result<()> {
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(secret_path)?;
+    file.write_all(format!("{secret}\n").as_bytes())?;
+    file.flush()?;
+    file.sync_data()?;
+    harden_terminal_secret_permissions(secret_path)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn harden_terminal_secret_dir(path: &Path) -> Result<()> {
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn harden_terminal_secret_dir(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn harden_terminal_secret_permissions(path: &Path) -> Result<()> {
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn harden_terminal_secret_permissions(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ensure_terminal_token_secret, TERMINAL_TOKEN_SECRET_ENV};
+    use std::fs;
+
+    struct TerminalSecretEnvScope {
+        _guard: tokio::sync::MutexGuard<'static, ()>,
+    }
+
+    impl TerminalSecretEnvScope {
+        fn new() -> Self {
+            let guard = crate::routes::TEST_ENV_LOCK.blocking_lock();
+            unsafe {
+                std::env::remove_var(TERMINAL_TOKEN_SECRET_ENV);
+            }
+            Self { _guard: guard }
+        }
+    }
+
+    impl Drop for TerminalSecretEnvScope {
+        fn drop(&mut self) {
+            unsafe {
+                std::env::remove_var(TERMINAL_TOKEN_SECRET_ENV);
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_terminal_token_secret_creates_private_secret_and_directory() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _env = TerminalSecretEnvScope::new();
+        let workspace_path = std::env::temp_dir().join(format!(
+            "conductor-terminal-secret-{}",
+            uuid::Uuid::new_v4()
+        ));
+        fs::create_dir_all(&workspace_path).unwrap();
+
+        ensure_terminal_token_secret(&workspace_path).unwrap();
+
+        let secret_dir = workspace_path.join(".conductor");
+        let secret_path = secret_dir.join("terminal-session-secret");
+        let secret = fs::read_to_string(&secret_path).unwrap();
+
+        assert!(!secret.trim().is_empty());
+        assert_eq!(
+            fs::metadata(&secret_dir).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+        assert_eq!(
+            fs::metadata(&secret_path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+
+        fs::remove_dir_all(workspace_path).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_terminal_token_secret_hardens_existing_insecure_secret() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _env = TerminalSecretEnvScope::new();
+        let workspace_path = std::env::temp_dir().join(format!(
+            "conductor-terminal-secret-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let secret_dir = workspace_path.join(".conductor");
+        let secret_path = secret_dir.join("terminal-session-secret");
+        fs::create_dir_all(&secret_dir).unwrap();
+        fs::write(&secret_path, "existing-secret\n").unwrap();
+        fs::set_permissions(&secret_dir, fs::Permissions::from_mode(0o755)).unwrap();
+        fs::set_permissions(&secret_path, fs::Permissions::from_mode(0o644)).unwrap();
+
+        ensure_terminal_token_secret(&workspace_path).unwrap();
+
+        assert_eq!(
+            fs::metadata(&secret_dir).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+        assert_eq!(
+            fs::metadata(&secret_path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+
+        fs::remove_dir_all(workspace_path).unwrap();
+    }
 }

--- a/crates/conductor-server/src/routes/config.rs
+++ b/crates/conductor-server/src/routes/config.rs
@@ -1483,7 +1483,7 @@ mod tests {
         // committed private key material in the repository.
         let temp_dir =
             std::env::temp_dir().join(format!("conductor-cf-test-key-{}", Uuid::new_v4()));
-        fs::create_dir_all(&temp_dir).unwrap();
+        fs::create_dir_all(&temp_dir).unwrap(); // gitleaks:allow test-only runtime-generated private-key fixture
         let private_key_path = temp_dir.join("private.pem");
 
         let generate = StdCommand::new("openssl")

--- a/crates/conductor-server/src/routes/config.rs
+++ b/crates/conductor-server/src/routes/config.rs
@@ -80,6 +80,7 @@ struct PreferencesBody {
     markdown_editor: Option<String>,
     markdown_editor_path: Option<String>,
     filesystem_browse_roots: Option<Vec<String>>,
+    allow_home_browse: Option<bool>,
     notifications: Option<NotificationsBody>,
     model_access: Option<HashMap<String, String>>,
 }
@@ -158,6 +159,7 @@ async fn update_preferences(
         filesystem_browse_roots: body
             .filesystem_browse_roots
             .unwrap_or(current.filesystem_browse_roots),
+        allow_home_browse: body.allow_home_browse.unwrap_or(current.allow_home_browse),
         model_access: merge_model_access_preferences(
             &current.model_access,
             body.model_access.as_ref(),

--- a/crates/conductor-server/src/routes/filesystem.rs
+++ b/crates/conductor-server/src/routes/filesystem.rs
@@ -136,10 +136,18 @@ pub(crate) fn allowed_browse_roots(
     config: &ConductorConfig,
 ) -> Vec<PathBuf> {
     let mut roots = Vec::new();
-    if let Some(home) = resolve_user_home_dir() {
-        roots.push(home);
+    if config.preferences.allow_home_browse {
+        if let Some(home) = resolve_user_home_dir() {
+            roots.push(home);
+        }
     }
     roots.push(workspace_path.to_path_buf());
+    roots.extend(
+        config
+            .projects
+            .values()
+            .map(|project| expand_path(&project.path, workspace_path)),
+    );
     roots.extend(
         config
             .preferences
@@ -387,6 +395,68 @@ mod tests {
         assert!(!roots
             .iter()
             .any(|entry| entry == std::path::Path::new("/opt")));
+
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn default_browse_roots_do_not_include_home_directory() {
+        let root =
+            std::env::temp_dir().join(format!("conductor-filesystem-{}", uuid::Uuid::new_v4()));
+        let workspace_path = root.join("workspace");
+        fs::create_dir_all(&workspace_path).unwrap();
+
+        let roots = allowed_browse_roots(&workspace_path, &ConductorConfig::default());
+
+        if let Some(home) = super::resolve_user_home_dir() {
+            let canonical_home = std::fs::canonicalize(&home).unwrap_or(home);
+            assert!(!roots.iter().any(|entry| entry == &canonical_home));
+        }
+
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn opt_in_home_browse_adds_home_directory_root() {
+        let root =
+            std::env::temp_dir().join(format!("conductor-filesystem-{}", uuid::Uuid::new_v4()));
+        let workspace_path = root.join("workspace");
+        fs::create_dir_all(&workspace_path).unwrap();
+
+        let mut config = ConductorConfig::default();
+        config.preferences.allow_home_browse = true;
+        let roots = allowed_browse_roots(&workspace_path, &config);
+
+        if let Some(home) = super::resolve_user_home_dir() {
+            let canonical_home = std::fs::canonicalize(&home).unwrap_or(home);
+            assert!(roots.iter().any(|entry| entry == &canonical_home));
+        }
+
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn default_browse_roots_include_explicit_project_paths() {
+        let root =
+            std::env::temp_dir().join(format!("conductor-filesystem-{}", uuid::Uuid::new_v4()));
+        let workspace_path = root.join("workspace");
+        let project_path = root.join("projects").join("demo");
+        fs::create_dir_all(&workspace_path).unwrap();
+        fs::create_dir_all(&project_path).unwrap();
+
+        let mut config = ConductorConfig::default();
+        config.projects.insert(
+            "demo".to_string(),
+            conductor_core::config::ProjectConfig {
+                path: project_path.to_string_lossy().to_string(),
+                ..Default::default()
+            },
+        );
+
+        let roots = allowed_browse_roots(&workspace_path, &config);
+        let canonical_project = std::fs::canonicalize(&project_path).unwrap();
+
+        assert!(roots.iter().any(|entry| entry == &canonical_project));
 
         fs::remove_dir_all(&root).unwrap();
     }

--- a/crates/conductor-server/src/routes/middleware.rs
+++ b/crates/conductor-server/src/routes/middleware.rs
@@ -196,6 +196,10 @@ fn required_access_role(method: &Method, path: &str) -> Option<AccessRole> {
         return Some(AccessRole::Operator);
     }
 
+    if path.starts_with("/api/filesystem/") {
+        return Some(AccessRole::Operator);
+    }
+
     if path.starts_with("/api/access") {
         return Some(AccessRole::Admin);
     }
@@ -344,6 +348,14 @@ mod tests {
         );
         assert_eq!(
             required_access_role(&Method::GET, "/api/workspaces/branches"),
+            Some(AccessRole::Operator)
+        );
+        assert_eq!(
+            required_access_role(&Method::GET, "/api/filesystem/directory"),
+            Some(AccessRole::Operator)
+        );
+        assert_eq!(
+            required_access_role(&Method::HEAD, "/api/filesystem/directory"),
             Some(AccessRole::Operator)
         );
         assert_eq!(

--- a/docs/STRIX-SETUP.md
+++ b/docs/STRIX-SETUP.md
@@ -6,6 +6,10 @@ STRIX_LLM=openai/gpt-5.4
 LLM_API_KEY=sk-...
 ```
 
+The CI workflow fails in preflight if either secret is missing or if a manual
+`target_url` is not an `http://` or `https://` URL. It does not silently skip a
+requested scan.
+
 ### Local Run (no Docker required for source scans)
 ```bash
 # Install Strix (one-time)

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -191,6 +191,8 @@ const UserPreferencesSchema = z.object({
   ide: z.string().optional(),
   markdownEditor: z.string().optional(),
   markdownEditorPath: z.string().optional(),
+  filesystemBrowseRoots: z.array(z.string()).optional(),
+  allowHomeBrowse: z.boolean().default(false),
   modelAccess: ModelAccessPreferencesSchema.default(getDefaultModelAccessPreferences()),
   notifications: NotificationPreferencesSchema.default({
     soundEnabled: true,
@@ -248,6 +250,7 @@ const ConductorConfigSchema = z.object({
   access: DashboardAccessConfigSchema.optional(),
   preferences: UserPreferencesSchema.default({
     onboardingAcknowledged: false,
+    allowHomeBrowse: false,
     modelAccess: getDefaultModelAccessPreferences(),
     notifications: {
       soundEnabled: true,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1368,6 +1368,10 @@ export interface UserPreferences {
   markdownEditor?: string;
   /** Local root path for the markdown editor's notes workspace or vault. */
   markdownEditorPath?: string;
+  /** Extra absolute roots that stay visible in the filesystem picker. */
+  filesystemBrowseRoots?: string[];
+  /** Allow operator or admin sessions to browse the full local home directory. */
+  allowHomeBrowse?: boolean;
   /** Preferred account/access mode used to filter agent model choices in the UI. */
   modelAccess?: ModelAccessPreferences;
   notifications: NotificationPreferences;

--- a/packages/web/src/app/api/workspaces/branches/route.ts
+++ b/packages/web/src/app/api/workspaces/branches/route.ts
@@ -2,4 +2,4 @@ import { guardedProxyRoute } from "@/lib/proxyRoutes";
 
 export const dynamic = "force-dynamic";
 
-export const GET = guardedProxyRoute("/api/workspaces/branches", { role: "viewer", bridgeAware: true });
+export const GET = guardedProxyRoute("/api/workspaces/branches", { role: "operator", bridgeAware: true });

--- a/packages/web/src/features/dashboard/DashboardClient.tsx
+++ b/packages/web/src/features/dashboard/DashboardClient.tsx
@@ -412,6 +412,7 @@ type PreferencesPayload = {
   markdownEditor: string;
   markdownEditorPath: string;
   filesystemBrowseRoots: string[];
+  allowHomeBrowse: boolean;
   modelAccess: ModelAccessPreferences;
   notifications: {
     soundEnabled: boolean;
@@ -592,6 +593,7 @@ function normalizePreferences(value: unknown, fallbackAgent: string): Preference
         .map((item) => item.trim())
         .filter(Boolean)
     : [];
+  const allowHomeBrowse = payload["allowHomeBrowse"] === true;
 
   return {
     onboardingAcknowledged: payload["onboardingAcknowledged"] === true,
@@ -600,6 +602,7 @@ function normalizePreferences(value: unknown, fallbackAgent: string): Preference
     markdownEditor,
     markdownEditorPath,
     filesystemBrowseRoots,
+    allowHomeBrowse,
     modelAccess: normalizeModelAccessPreferences(payload["modelAccess"]),
     notifications: {
       soundEnabled: notifications["soundEnabled"] !== false,

--- a/packages/web/src/features/dashboard/components/DashboardDialogs.tsx
+++ b/packages/web/src/features/dashboard/components/DashboardDialogs.tsx
@@ -261,6 +261,7 @@ type PreferencesPayload = {
   markdownEditor: string;
   markdownEditorPath: string;
   filesystemBrowseRoots: string[];
+  allowHomeBrowse: boolean;
   modelAccess: ModelAccessPreferences;
   notifications: {
     soundEnabled: boolean;
@@ -434,6 +435,7 @@ function normalizePreferences(value: unknown, fallbackAgent: string): Preference
         .map((item) => item.trim())
         .filter(Boolean)
     : [];
+  const allowHomeBrowse = payload["allowHomeBrowse"] === true;
 
   return {
     onboardingAcknowledged: payload["onboardingAcknowledged"] === true,
@@ -442,6 +444,7 @@ function normalizePreferences(value: unknown, fallbackAgent: string): Preference
     markdownEditor,
     markdownEditorPath,
     filesystemBrowseRoots,
+    allowHomeBrowse,
     modelAccess: normalizeModelAccessPreferences(payload["modelAccess"]),
     notifications: {
       soundEnabled: notifications["soundEnabled"] !== false,
@@ -2167,6 +2170,7 @@ export function SettingsDialog({
   const [markdownEditor, setMarkdownEditor] = useState(current.markdownEditor);
   const [markdownEditorPath, setMarkdownEditorPath] = useState<string>(current.markdownEditorPath ?? "");
   const [filesystemBrowseRootsInput, setFilesystemBrowseRootsInput] = useState(() => current.filesystemBrowseRoots.join("\n"));
+  const [allowHomeBrowse, setAllowHomeBrowse] = useState(current.allowHomeBrowse === true);
   const [modelAccess, setModelAccess] = useState<ModelAccessPreferences>(current.modelAccess);
   const [soundEnabled, setSoundEnabled] = useState(current.notifications.soundEnabled);
   const [soundFile, setSoundFile] = useState<string | null>(current.notifications.soundFile);
@@ -2467,6 +2471,7 @@ function hydrateRepositoryDraft(value: RepositorySettingsPayload): RepositorySet
     setMarkdownEditor(current.markdownEditor);
     setMarkdownEditorPath(current.markdownEditorPath ?? "");
     setFilesystemBrowseRootsInput(current.filesystemBrowseRoots.join("\n"));
+    setAllowHomeBrowse(current.allowHomeBrowse === true);
     setModelAccess(current.modelAccess);
     setSoundEnabled(current.notifications.soundEnabled);
     setSoundFile(current.notifications.soundFile);
@@ -2656,6 +2661,7 @@ function hydrateRepositoryDraft(value: RepositorySettingsPayload): RepositorySet
       markdownEditor: markdownEditor.trim(),
       markdownEditorPath: (markdownEditorPath ?? "").trim(),
       filesystemBrowseRoots,
+      allowHomeBrowse,
       modelAccess,
       notifications: {
         soundEnabled,
@@ -3035,8 +3041,29 @@ function hydrateRepositoryDraft(value: RepositorySettingsPayload): RepositorySet
                               </button>
                             </div>
                             <p className="mt-1 text-[12px] text-[var(--vk-text-muted)]">
-                              Conductor already includes sensible defaults for each OS. Add extra roots here when you want the folder picker to expose more locations on macOS, Linux, or Windows.
+                              Conductor exposes the current workspace, configured project roots, and any extra roots listed here by default. Add another root only when the operator folder picker should expose that explicit location on this machine.
                             </p>
+                          </label>
+                        </div>
+                        <div className="rounded-[4px] border border-[var(--vk-border)] px-3 py-3">
+                          <label className="flex items-start gap-3">
+                            <input
+                              type="checkbox"
+                              checked={allowHomeBrowse}
+                              onChange={(event) => setAllowHomeBrowse(event.target.checked)}
+                              className="mt-0.5 h-4 w-4 rounded border border-[var(--vk-border)] bg-transparent"
+                            />
+                            <span className="block">
+                              <span className="block text-[12px] font-medium text-[var(--vk-text-normal)]">
+                                Allow full home-directory browse
+                              </span>
+                              <span className="mt-1 block text-[12px] text-[var(--vk-text-muted)]">
+                                Off by default. Enable this only when operator or admin sessions need to browse the full local home directory. Viewer sessions never get this access.
+                              </span>
+                              <span className="mt-1 block text-[11px] text-[var(--vk-text-dim)]">
+                                Saved as <code>preferences.allowHomeBrowse</code> in <code>conductor.yaml</code>.
+                              </span>
+                            </span>
                           </label>
                         </div>
                       </section>

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,8 @@
 packages:
   - "packages/*"
+
+# Supply-chain controls for contributors who use pnpm. Bun remains the primary
+# package manager and enforces the matching seven-day minimum in CI.
+minimumReleaseAge: 10080
+trustPolicy: no-downgrade
+blockExoticSubdeps: true

--- a/scripts/cli-native-packages.mjs
+++ b/scripts/cli-native-packages.mjs
@@ -1,7 +1,7 @@
 import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { execFileSync } from "node:child_process";
+import { execNpmCommandSync } from "./npm-exec.mjs";
 
 const NPM_EXECUTABLE = "npm";
 
@@ -139,10 +139,9 @@ export function packCliNativeReleasePackage({
   const destinationDir = packDestination ? resolve(packDestination) : stage.stageDir;
   mkdirSync(destinationDir, { recursive: true });
 
-  const tarballName = execFileSync(NPM_EXECUTABLE, ["pack", "--silent", "--pack-destination", destinationDir], {
+  const tarballName = execNpmCommandSync(NPM_EXECUTABLE, ["pack", "--silent", "--pack-destination", destinationDir], {
     cwd: stage.stageDir,
     encoding: "utf8",
-    shell: true,
   }).trim();
 
   return {

--- a/scripts/cli-release-stage.mjs
+++ b/scripts/cli-release-stage.mjs
@@ -14,6 +14,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { CLI_NATIVE_TARGETS } from "./cli-native-packages.mjs";
+import { execNpmCommandSync } from "./npm-exec.mjs";
 import { execTarArchiveSync } from "./release-workflow-lib.mjs";
 
 const NPM_EXECUTABLE = "npm";
@@ -295,10 +296,9 @@ function buildInternalPackageTarballs({ rootDir, cliVersion, tarballRoot, stagin
     writeJson(join(packageStageDir, "package.json"), sanitizedManifest);
     copyDistDirectory(sourceDistDir, join(packageStageDir, "dist"));
 
-    const tarballName = execFileSync(NPM_EXECUTABLE, ["pack", "--silent", "--pack-destination", tarballRoot], {
+    const tarballName = execNpmCommandSync(NPM_EXECUTABLE, ["pack", "--silent", "--pack-destination", tarballRoot], {
       cwd: packageStageDir,
       encoding: "utf8",
-      shell: true,
     }).trim();
 
     tarballs.set(packageName, join(tarballRoot, tarballName));
@@ -409,10 +409,9 @@ export function createCliReleaseStage({
   // If that still attempts to resolve unpublished internal versions, fall back to
   // installing only external deps and unpack internal tarballs manually.
   try {
-    execFileSync(NPM_EXECUTABLE, ["install", "--silent", "--omit=dev", "--omit=optional", "--no-package-lock", "--install-strategy=shallow"], {
+    execNpmCommandSync(NPM_EXECUTABLE, ["install", "--silent", "--omit=dev", "--omit=optional", "--no-package-lock", "--install-strategy=shallow"], {
       cwd: outputDir,
       stdio: ["ignore", "ignore", "pipe"],
-      shell: true,
     });
   } catch {
     // If shallow install fails (pre-publish), fall back to installing only external deps
@@ -429,10 +428,9 @@ export function createCliReleaseStage({
     manifest.dependencies = externalDeps;
     writeJson(join(outputDir, "package.json"), manifest);
 
-    execFileSync(NPM_EXECUTABLE, ["install", "--silent", "--omit=dev", "--omit=optional", "--no-package-lock"], {
+    execNpmCommandSync(NPM_EXECUTABLE, ["install", "--silent", "--omit=dev", "--omit=optional", "--no-package-lock"], {
       cwd: outputDir,
       stdio: "inherit",
-      shell: true,
     });
 
     // Restore full deps and manually unpack internal tarballs into node_modules
@@ -493,10 +491,9 @@ export function packCliReleasePackage({
   const destinationDir = packDestination ? resolve(packDestination) : stage.stageDir;
   mkdirSync(destinationDir, { recursive: true });
 
-  const tarballName = execFileSync(NPM_EXECUTABLE, ["pack", "--silent", "--pack-destination", destinationDir], {
+  const tarballName = execNpmCommandSync(NPM_EXECUTABLE, ["pack", "--silent", "--pack-destination", destinationDir], {
     cwd: stage.stageDir,
     encoding: "utf8",
-    shell: true,
   }).trim();
 
   return {

--- a/scripts/npm-exec.mjs
+++ b/scripts/npm-exec.mjs
@@ -1,0 +1,176 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, delimiter, dirname, join } from "node:path";
+
+const WINDOWS_PATH_EXTENSIONS = [".cmd", ".exe", ".bat", ".com"];
+
+function isBareCommand(command) {
+  return !command.includes("/") && !command.includes("\\");
+}
+
+function normalizeWindowsPathExtensions(pathExt) {
+  const normalized = [];
+  const seen = new Set();
+
+  for (const extension of pathExt.split(";").map((value) => value.trim()).filter(Boolean)) {
+    const candidate = extension.startsWith(".")
+      ? extension.toLowerCase()
+      : `.${extension.toLowerCase()}`;
+    if (!seen.has(candidate)) {
+      seen.add(candidate);
+      normalized.push(candidate);
+    }
+  }
+
+  return normalized;
+}
+
+function commandPathCandidates(
+  executable,
+  { platform = process.platform, pathExt = process.env.PATHEXT ?? WINDOWS_PATH_EXTENSIONS.join(";") } = {},
+) {
+  if (platform !== "win32" || !isBareCommand(executable)) {
+    return [executable];
+  }
+
+  const lowerExecutable = executable.toLowerCase();
+  const extensions = normalizeWindowsPathExtensions(pathExt);
+  if (extensions.some((extension) => lowerExecutable.endsWith(extension))) {
+    return [executable];
+  }
+
+  return extensions.map((extension) => `${executable}${extension}`);
+}
+
+function findCommandOnPath(
+  executable,
+  {
+    platform = process.platform,
+    pathValue = process.env.PATH ?? "",
+    pathExt = process.env.PATHEXT ?? WINDOWS_PATH_EXTENSIONS.join(";"),
+    pathExists = existsSync,
+  } = {},
+) {
+  const candidates = commandPathCandidates(executable, { platform, pathExt });
+  for (const entry of pathValue.split(delimiter).filter(Boolean)) {
+    for (const candidateName of candidates) {
+      const candidate = join(entry, candidateName);
+      if (pathExists(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return null;
+}
+
+function safeRealpath(path, realpath = realpathSync) {
+  try {
+    return realpath(path);
+  } catch {
+    return path;
+  }
+}
+
+function resolveNpmCliPath(
+  npmCommandPath,
+  {
+    pathExists = existsSync,
+    realpath = realpathSync,
+  } = {},
+) {
+  const candidatePaths = [safeRealpath(npmCommandPath, realpath), npmCommandPath];
+  const visited = new Set();
+
+  for (const candidatePath of candidatePaths) {
+    if (visited.has(candidatePath)) {
+      continue;
+    }
+    visited.add(candidatePath);
+
+    if (basename(candidatePath).toLowerCase() === "npm-cli.js" && pathExists(candidatePath)) {
+      return candidatePath;
+    }
+
+    const candidateDir = dirname(candidatePath);
+    for (const relativePath of [
+      join("node_modules", "npm", "bin", "npm-cli.js"),
+      join("..", "lib", "node_modules", "npm", "bin", "npm-cli.js"),
+    ]) {
+      const npmCliPath = join(candidateDir, relativePath);
+      if (pathExists(npmCliPath)) {
+        return safeRealpath(npmCliPath, realpath);
+      }
+    }
+  }
+
+  return null;
+}
+
+export function resolveNpmCommand(
+  executable = "npm",
+  {
+    platform = process.platform,
+    pathValue = process.env.PATH ?? "",
+    pathExt = process.env.PATHEXT ?? WINDOWS_PATH_EXTENSIONS.join(";"),
+    pathExists = existsSync,
+    realpath = realpathSync,
+  } = {},
+) {
+  if (isBareCommand(executable) && executable === "npm") {
+    const npmPath = findCommandOnPath(executable, {
+      platform,
+      pathValue,
+      pathExt,
+      pathExists,
+    });
+    const npmCliPath = npmPath
+      ? resolveNpmCliPath(npmPath, {
+        pathExists,
+        realpath,
+      })
+      : null;
+    if (npmCliPath) {
+      return {
+        command: process.execPath,
+        argsPrefix: [npmCliPath],
+      };
+    }
+  }
+
+  return {
+    command: executable,
+    argsPrefix: [],
+  };
+}
+
+export function execNpmCommandSync(
+  executable,
+  args,
+  options = {},
+) {
+  const {
+    env: optionEnv,
+    platform,
+    pathValue,
+    pathExt,
+    pathExists,
+    realpath,
+    ...execOptions
+  } = options;
+  const { command, argsPrefix } = resolveNpmCommand(executable, {
+    platform,
+    pathValue,
+    pathExt,
+    pathExists,
+    realpath,
+  });
+  const npmCacheDir = join(tmpdir(), "conductor-npm-cache");
+  mkdirSync(npmCacheDir, { recursive: true });
+  const env = {
+    ...process.env,
+    ...optionEnv,
+    npm_config_cache: optionEnv?.npm_config_cache ?? npmCacheDir,
+  };
+  return execFileSync(command, [...argsPrefix, ...args], { ...execOptions, env });
+}

--- a/scripts/npm-exec.test.mjs
+++ b/scripts/npm-exec.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { mkdirSync, realpathSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { resolveNpmCommand } from "./npm-exec.mjs";
+
+function createFixturePath(name) {
+  return join(tmpdir(), `npm-exec-${name}-${process.pid}-${Date.now()}`);
+}
+
+test("resolveNpmCommand avoids shell invocation on Unix-like platforms", () => {
+  const rootDir = createFixturePath("unix");
+  const binDir = join(rootDir, "bin");
+  const npmCliPath = join(rootDir, "lib", "node_modules", "npm", "bin", "npm-cli.js");
+  mkdirSync(binDir, { recursive: true });
+  mkdirSync(join(rootDir, "lib", "node_modules", "npm", "bin"), { recursive: true });
+  writeFileSync(join(binDir, "npm"), "#!/bin/sh\n");
+  writeFileSync(npmCliPath, "console.log('npm');\n");
+
+  const resolved = resolveNpmCommand("npm", {
+    platform: "darwin",
+    pathValue: binDir,
+  });
+  assert.equal(resolved.command, process.execPath);
+  assert.deepEqual(resolved.argsPrefix, [realpathSync(npmCliPath)]);
+});
+
+test("resolveNpmCommand resolves the Windows npm shim to npm-cli.js", () => {
+  const rootDir = createFixturePath("win32");
+  const npmCmdPath = join(rootDir, "npm.cmd");
+  const npmCliPath = join(rootDir, "node_modules", "npm", "bin", "npm-cli.js");
+  mkdirSync(join(rootDir, "node_modules", "npm", "bin"), { recursive: true });
+  writeFileSync(npmCmdPath, "@ECHO OFF\r\n");
+  writeFileSync(npmCliPath, "console.log('npm');\n");
+
+  const resolved = resolveNpmCommand("npm", {
+    platform: "win32",
+    pathValue: rootDir,
+    pathExt: ".CMD;.EXE",
+  });
+  assert.equal(resolved.command, process.execPath);
+  assert.deepEqual(resolved.argsPrefix, [realpathSync(npmCliPath)]);
+});
+
+test("resolveNpmCommand preserves explicit command paths", () => {
+  assert.deepEqual(resolveNpmCommand("/custom/npm", { platform: "win32" }), {
+    command: "/custom/npm",
+    argsPrefix: [],
+  });
+});

--- a/scripts/verify-cli-package.mjs
+++ b/scripts/verify-cli-package.mjs
@@ -18,6 +18,7 @@ import {
   findCliNativeTargetById,
   resolveHostCliNativeTargetId,
 } from "./cli-native-packages.mjs";
+import { execNpmCommandSync } from "./npm-exec.mjs";
 import {
   assertBundledDependencyVersions,
   readPackageManifestFromTarball,
@@ -1302,15 +1303,13 @@ try {
   });
   tempDirs.push(nativeStageDir);
 
-  execFileSync(NPM_EXECUTABLE, ["init", "-y"], {
+  execNpmCommandSync(NPM_EXECUTABLE, ["init", "-y"], {
     cwd: installDir,
     stdio: "ignore",
-    shell: true,
   });
-  execFileSync(NPM_EXECUTABLE, ["install", "--cache", npmCacheDir, tarballPath, nativeStageDir], {
+  execNpmCommandSync(NPM_EXECUTABLE, ["install", "--cache", npmCacheDir, tarballPath, nativeStageDir], {
     cwd: installDir,
     stdio: "inherit",
-    shell: true,
   });
   const installedCliRoot = join(installDir, "node_modules", "conductor-oss");
   const installedCliManifest = JSON.parse(readTextFile(join(installedCliRoot, "package.json")));
@@ -1396,20 +1395,20 @@ try {
   }
   assertBundledDependencyVersions(installedCliManifest, bundledManifests);
   try {
-    execFileSync(
+    execNpmCommandSync(
       NPM_EXECUTABLE,
       ["ls", "--all", "--omit=dev"],
-      { cwd: installDir, encoding: "utf8", stdio: ["ignore", "ignore", "pipe"], shell: true },
+      { cwd: installDir, encoding: "utf8", stdio: ["ignore", "ignore", "pipe"] },
     );
   } catch (error) {
     const diagnostic = error?.stderr?.toString().trim() || error?.message || String(error);
     fail(`installed npm dependency graph is invalid: ${diagnostic}`);
   }
   try {
-    execFileSync(
+    execNpmCommandSync(
       NPM_EXECUTABLE,
       ["audit", "--omit=dev", "--audit-level=low"],
-      { cwd: installDir, encoding: "utf8", stdio: ["ignore", "ignore", "pipe"], shell: true },
+      { cwd: installDir, encoding: "utf8", stdio: ["ignore", "ignore", "pipe"] },
     );
   } catch (error) {
     const diagnostic = error?.stdout?.toString().trim()

--- a/scripts/verify-cli-package.mjs
+++ b/scripts/verify-cli-package.mjs
@@ -1398,17 +1398,20 @@ try {
     execNpmCommandSync(
       NPM_EXECUTABLE,
       ["ls", "--all", "--omit=dev"],
-      { cwd: installDir, encoding: "utf8", stdio: ["ignore", "ignore", "pipe"] },
+      { cwd: installDir, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
     );
   } catch (error) {
-    const diagnostic = error?.stderr?.toString().trim() || error?.message || String(error);
+    const diagnostic = error?.stdout?.toString().trim()
+      || error?.stderr?.toString().trim()
+      || error?.message
+      || String(error);
     fail(`installed npm dependency graph is invalid: ${diagnostic}`);
   }
   try {
     execNpmCommandSync(
       NPM_EXECUTABLE,
       ["audit", "--omit=dev", "--audit-level=low"],
-      { cwd: installDir, encoding: "utf8", stdio: ["ignore", "ignore", "pipe"] },
+      { cwd: installDir, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
     );
   } catch (error) {
     const diagnostic = error?.stdout?.toString().trim()


### PR DESCRIPTION
## Summary

Hardens terminal-session secret storage, restricts filesystem browsing to operator-approved roots, and closes the audited CI and supply-chain gaps. Adds deterministic secret scanning, pinned security tooling, a fail-closed Strix preflight, safer release command execution, and an update from yanked `spin` 0.9.8 to 0.9.9.

## User-Facing Release Notes

- Terminal session credentials are now stored with owner-only permissions and automatically repaired on startup.
- Remote folder browsing is limited to configured workspace and project roots, with operator access required.
- Dependency and secret scanning now fail closed when their security controls are unavailable.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [x] Refactor / Chore

## Testing

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -q`
- `go test ./... && go vet ./...` in `bridge-cmd`
- `bun run typecheck && bun run test:packages && bun run build:frontend`
- `cargo audit` with the three documented upstream advisory exceptions
- Bun audits for root, web, and preview worker
- Gitleaks full-history scan and TruffleHog verified-secret scan
- Semgrep, frozen Bun install with seven-day release-age policy, YAML parsing, and release-version logic verification


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an administrator-controlled option to allow full home-directory browsing in the filesystem picker (off by default).
  * Added support for configuring additional filesystem browsing roots.
  * Tightened access so filesystem-related routes and workspace branch listing require operator permissions.
* **Security**
  * Hardened terminal session secret handling and permissions.
  * Strengthened CI security checks with enforced minimum dependency release age and stricter secret/scan validation.
* **Documentation**
  * Updated guidance on filesystem picker defaults and scan preflight/validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->