### PR TITLE
fix(terminal): restore hosted agent sessions

### DIFF
--- a/bridge-cmd/relay/client.go
+++ b/bridge-cmd/relay/client.go
@@ -629,14 +629,38 @@ func runSession(ctx context.Context, opts sessionOptions) (bool, error) {
 
 				go func(terminalID string, sessionID string) {
 					defer activeTerminals.Delete(terminalID)
-					if err := proxyTerminalSession(
+					startedAt := time.Now()
+					fmt.Fprintf(
+						opts.stderr,
+						"terminal proxy lifecycle event=start terminal_id=%s session_id=%s\n",
+						terminalID,
+						sessionID,
+					)
+					err := proxyTerminalSession(
 						ctx,
 						opts.relayURL,
 						opts.refreshToken,
 						terminalID,
 						sessionID,
-					); err != nil && ctx.Err() == nil {
-						fmt.Fprintf(opts.stderr, "terminal proxy %s ended: %v\n", terminalID, err)
+						opts.stderr,
+					)
+					if err != nil && ctx.Err() == nil {
+						fmt.Fprintf(
+							opts.stderr,
+							"terminal proxy lifecycle event=end terminal_id=%s session_id=%s duration_ms=%d outcome=error error=%v\n",
+							terminalID,
+							sessionID,
+							time.Since(startedAt).Milliseconds(),
+							err,
+						)
+					} else {
+						fmt.Fprintf(
+							opts.stderr,
+							"terminal proxy lifecycle event=end terminal_id=%s session_id=%s duration_ms=%d outcome=closed\n",
+							terminalID,
+							sessionID,
+							time.Since(startedAt).Milliseconds(),
+						)
 					}
 				}(terminalID, sessionID)
 
@@ -864,7 +888,12 @@ func shouldRetryTerminalAttach(err error) bool {
 	return false
 }
 
-func connectBackendTerminal(ctx context.Context, sessionID string) (*websocket.Conn, backendTerminalProtocol, error) {
+func connectBackendTerminal(
+	ctx context.Context,
+	sessionID string,
+	terminalID string,
+	stderr io.Writer,
+) (*websocket.Conn, backendTerminalProtocol, error) {
 	var lastErr error
 	backoff := 250 * time.Millisecond
 
@@ -873,17 +902,43 @@ func connectBackendTerminal(ctx context.Context, sessionID string) (*websocket.C
 			return nil, "", ctx.Err()
 		}
 
+		fmt.Fprintf(
+			stderr,
+			"terminal proxy lifecycle event=backend_attach_attempt terminal_id=%s session_id=%s attempt=%d max_attempts=%d\n",
+			terminalID,
+			sessionID,
+			attempt+1,
+			terminalAttachMaxAttempts,
+		)
 		backendEndpoint, protocol, err := fetchSessionTerminalWSURL(sessionID)
 		if err == nil {
 			conn, _, dialErr := websocket.DefaultDialer.DialContext(ctx, backendEndpoint, nil)
 			if dialErr == nil {
+				fmt.Fprintf(
+					stderr,
+					"terminal proxy lifecycle event=backend_attached terminal_id=%s session_id=%s attempt=%d protocol=%s\n",
+					terminalID,
+					sessionID,
+					attempt+1,
+					protocol,
+				)
 				return conn, protocol, nil
 			}
 			err = &terminalAttachError{err: fmt.Errorf("connect backend terminal socket: %w", dialErr)}
 		}
 
 		lastErr = err
-		if !shouldRetryTerminalAttach(err) || attempt == terminalAttachMaxAttempts-1 {
+		willRetry := shouldRetryTerminalAttach(err) && attempt < terminalAttachMaxAttempts-1
+		fmt.Fprintf(
+			stderr,
+			"terminal proxy lifecycle event=backend_attach_failed terminal_id=%s session_id=%s attempt=%d retry=%t error=%v\n",
+			terminalID,
+			sessionID,
+			attempt+1,
+			willRetry,
+			err,
+		)
+		if !willRetry {
 			break
 		}
 
@@ -1114,8 +1169,9 @@ func proxyTerminalSession(
 	refreshToken string,
 	terminalID string,
 	sessionID string,
+	stderr io.Writer,
 ) error {
-	backendConn, protocol, err := connectBackendTerminal(ctx, sessionID)
+	backendConn, protocol, err := connectBackendTerminal(ctx, sessionID, terminalID, stderr)
 	if err != nil {
 		return err
 	}
@@ -1133,6 +1189,13 @@ func proxyTerminalSession(
 	}
 	defer relayConn.Close()
 	relayConn.SetReadLimit(maxBridgeWebSocketMessageBytes)
+	fmt.Fprintf(
+		stderr,
+		"terminal proxy lifecycle event=relay_attached terminal_id=%s session_id=%s protocol=%s\n",
+		terminalID,
+		sessionID,
+		protocol,
+	)
 
 	if protocol == backendTerminalProtocolTTYD {
 		return proxyTTYDTerminalSession(ctx, backendConn, relayConn)

--- a/bridge-cmd/relay/client.go
+++ b/bridge-cmd/relay/client.go
@@ -987,6 +987,18 @@ func parseRelayResizeMessage(payload []byte) (int, int, error) {
 	return resize.Columns, resize.Rows, nil
 }
 
+func terminalWebSocketReadError(peer string, err error) error {
+	if websocket.IsCloseError(
+		err,
+		websocket.CloseNormalClosure,
+		websocket.CloseGoingAway,
+		websocket.CloseNoStatusReceived,
+	) {
+		return io.EOF
+	}
+	return fmt.Errorf("%s read: %w", peer, err)
+}
+
 func proxyTTYDTerminalSession(ctx context.Context, backendConn *websocket.Conn, relayConn *websocket.Conn) error {
 	errCh := make(chan error, 2)
 
@@ -995,7 +1007,7 @@ func proxyTTYDTerminalSession(ctx context.Context, backendConn *websocket.Conn, 
 			for {
 				msgType, data, err := src.ReadMessage()
 				if err != nil {
-					errCh <- fmt.Errorf("%s read: %w", srcName, err)
+					errCh <- terminalWebSocketReadError(srcName, err)
 					return
 				}
 				switch msgType {
@@ -1037,7 +1049,7 @@ func proxyNativeTerminalSession(ctx context.Context, backendConn *websocket.Conn
 		for {
 			msgType, data, err := relayConn.ReadMessage()
 			if err != nil {
-				errCh <- fmt.Errorf("relay terminal read: %w", err)
+				errCh <- terminalWebSocketReadError("relay terminal", err)
 				return
 			}
 			switch msgType {
@@ -1127,7 +1139,7 @@ func proxyNativeTerminalSession(ctx context.Context, backendConn *websocket.Conn
 		for {
 			msgType, data, err := backendConn.ReadMessage()
 			if err != nil {
-				errCh <- fmt.Errorf("backend terminal read: %w", err)
+				errCh <- terminalWebSocketReadError("backend terminal", err)
 				return
 			}
 			switch msgType {

--- a/bridge-cmd/relay/client_test.go
+++ b/bridge-cmd/relay/client_test.go
@@ -3,11 +3,14 @@ package relay
 import (
 	"encoding/base64"
 	"errors"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/gorilla/websocket"
 )
 
 func TestRelayAuthHeadersUsesAuthorizationBearer(t *testing.T) {
@@ -81,6 +84,29 @@ func TestShouldRetryTerminalAttach(t *testing.T) {
 				t.Fatalf("shouldRetryTerminalAttach(%v) = %v, want %v", tc.err, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestTerminalWebSocketReadErrorTreatsExpectedClosesAsEOF(t *testing.T) {
+	t.Parallel()
+
+	for _, code := range []int{
+		websocket.CloseNormalClosure,
+		websocket.CloseGoingAway,
+		websocket.CloseNoStatusReceived,
+	} {
+		err := terminalWebSocketReadError("relay terminal", &websocket.CloseError{Code: code})
+		if !errors.Is(err, io.EOF) {
+			t.Fatalf("close code %d returned %v, want io.EOF", code, err)
+		}
+	}
+
+	err := terminalWebSocketReadError(
+		"relay terminal",
+		&websocket.CloseError{Code: websocket.CloseAbnormalClosure},
+	)
+	if err == nil || errors.Is(err, io.EOF) {
+		t.Fatalf("abnormal close returned %v, want a diagnostic error", err)
 	}
 }
 

--- a/crates/conductor-relay/src/relay.rs
+++ b/crates/conductor-relay/src/relay.rs
@@ -418,6 +418,26 @@ impl TerminalSessionRecord {
                 .is_some_and(|record| record.id == connection_id),
         }
     }
+
+    fn buffer_terminal_message(&mut self, message: Message) -> bool {
+        let message_bytes = websocket_message_size(&message);
+        if message_bytes > TERMINAL_PAUSE_BUFFER_BYTE_CAPACITY {
+            return false;
+        }
+        while !self.pause_buffer.is_empty()
+            && (self.pause_buffer.len() >= TERMINAL_PAUSE_BUFFER_CAPACITY
+                || self.pause_buffer_bytes.saturating_add(message_bytes)
+                    > TERMINAL_PAUSE_BUFFER_BYTE_CAPACITY)
+        {
+            let removed = self.pause_buffer.remove(0);
+            self.pause_buffer_bytes = self
+                .pause_buffer_bytes
+                .saturating_sub(websocket_message_size(&removed));
+        }
+        self.pause_buffer_bytes = self.pause_buffer_bytes.saturating_add(message_bytes);
+        self.pause_buffer.push(message);
+        true
+    }
 }
 
 #[derive(Debug)]
@@ -2021,6 +2041,7 @@ async fn handle_terminal_connection(
     peer_kind: TerminalPeerKind,
     socket: WebSocket,
 ) -> Result<()> {
+    let connected_at = Instant::now();
     let (mut outbound, mut inbound) = socket.split();
     let budget_scope = state.terminal_queue_budget_scope(&terminal_id).await?;
     let (tx, mut rx) = message_channel(
@@ -2033,41 +2054,71 @@ async fn handle_terminal_connection(
         .register_terminal_connection(&terminal_id, peer_kind, tx.clone())
         .await?;
 
+    info!(
+        event = "relay_terminal_connection",
+        action = "attached",
+        %terminal_id,
+        connection_id,
+        peer = ?peer_kind,
+        "relay terminal peer attached"
+    );
+
+    let outbound_messages = Arc::new(AtomicUsize::new(0));
+    let outbound_bytes = Arc::new(AtomicUsize::new(0));
+    let writer_messages = Arc::clone(&outbound_messages);
+    let writer_bytes = Arc::clone(&outbound_bytes);
+
     let writer = tokio::spawn(async move {
         while let Some(queued) = rx.recv_queued().await {
             let QueuedMessage {
                 message,
                 _reservation: reservation,
             } = queued;
+            let message_bytes = websocket_message_size(&message);
             let send_result = outbound.send(message).await;
             drop(reservation);
             if send_result.is_err() {
-                break;
+                return true;
             }
+            writer_messages.fetch_add(1, Ordering::Relaxed);
+            writer_bytes.fetch_add(message_bytes, Ordering::Relaxed);
         }
+        false
     });
 
+    let mut inbound_messages = 0_usize;
+    let mut inbound_bytes = 0_usize;
+    let mut resize_messages = 0_usize;
+    let mut close_reason = "peer_closed";
+    let mut connection_error = None;
     while let Some(message) = inbound.next().await {
         let message = match message {
             Ok(message) => message,
             Err(err) => {
-                drop(tx);
-                state
-                    .unregister_terminal_connection(&terminal_id, peer_kind, connection_id)
-                    .await;
-                let _ = writer.await;
-                return Err(err.into());
+                close_reason = "read_error";
+                connection_error = Some(anyhow::Error::from(err));
+                break;
             }
         };
+
+        inbound_messages = inbound_messages.saturating_add(1);
+        inbound_bytes = inbound_bytes.saturating_add(websocket_message_size(&message));
+        if peer_kind == TerminalPeerKind::Browser
+            && RelayState::extract_ttyd_command(&message) == Some(TTYD_CMD_RESIZE)
+        {
+            resize_messages = resize_messages.saturating_add(1);
+        }
 
         if !state
             .forward_terminal_message(&terminal_id, peer_kind, connection_id, &message)
             .await
         {
+            close_reason = "forward_rejected";
             break;
         }
 
         if matches!(message, Message::Close(_)) {
+            close_reason = "close_frame";
             break;
         }
     }
@@ -2076,7 +2127,27 @@ async fn handle_terminal_connection(
     state
         .unregister_terminal_connection(&terminal_id, peer_kind, connection_id)
         .await;
-    let _ = writer.await;
+    let writer_failed = writer.await.unwrap_or(true);
+    info!(
+        event = "relay_terminal_connection",
+        action = "detached",
+        %terminal_id,
+        connection_id,
+        peer = ?peer_kind,
+        close_reason,
+        duration_ms = connected_at.elapsed().as_millis() as u64,
+        inbound_messages,
+        inbound_bytes,
+        outbound_messages = outbound_messages.load(Ordering::Relaxed),
+        outbound_bytes = outbound_bytes.load(Ordering::Relaxed),
+        resize_messages,
+        writer_failed,
+        error = connection_error.as_ref().map(ToString::to_string),
+        "relay terminal peer detached"
+    );
+    if let Some(err) = connection_error {
+        return Err(err);
+    }
     Ok(())
 }
 
@@ -2230,14 +2301,42 @@ impl RelayState {
         };
 
         let terminal_id = match start {
-            TerminalSessionStart::Reuse { terminal_id } => terminal_id,
+            TerminalSessionStart::Reuse { terminal_id } => {
+                info!(
+                    event = "relay_terminal_session",
+                    action = "reuse",
+                    %terminal_id,
+                    %device_id,
+                    session_id = normalized_session_id,
+                    "reusing attached relay terminal session"
+                );
+                terminal_id
+            }
             TerminalSessionStart::StartOrRetry {
                 terminal_id,
                 attach_generation,
                 bridge_tx,
                 payload,
             } => {
+                info!(
+                    event = "relay_terminal_session",
+                    action = "start_or_retry",
+                    %terminal_id,
+                    %device_id,
+                    session_id = normalized_session_id,
+                    attach_generation,
+                    "requesting bridge terminal proxy"
+                );
                 if bridge_tx.try_send(Message::Text(payload.into())).is_err() {
+                    warn!(
+                        event = "relay_terminal_session",
+                        action = "bridge_start_queue_failed",
+                        %terminal_id,
+                        %device_id,
+                        session_id = normalized_session_id,
+                        attach_generation,
+                        "bridge disconnected before terminal proxy request could be queued"
+                    );
                     let mut inner = self.inner.lock().await;
                     if inner
                         .terminal_sessions
@@ -2295,6 +2394,13 @@ impl RelayState {
         };
 
         if let Some(browser) = browser {
+            warn!(
+                event = "relay_terminal_session",
+                action = "attach_timeout",
+                %terminal_id,
+                attach_generation,
+                "bridge did not attach the relay terminal before the deadline"
+            );
             let _ = browser.try_send(Message::Close(Some(CloseFrame {
                 code: 1013,
                 reason: "Paired device failed to attach the relay terminal.".into(),
@@ -2357,7 +2463,8 @@ impl RelayState {
         peer_kind: TerminalPeerKind,
         tx: MessageSender,
     ) -> Result<u64> {
-        let (connection_id, replaced) = {
+        let pending_tx = tx.clone();
+        let (connection_id, replaced, pending_browser_messages) = {
             let mut inner = self.inner.lock().await;
             let connection_id = inner.next_terminal_connection_id;
             inner.next_terminal_connection_id = inner.next_terminal_connection_id.saturating_add(1);
@@ -2377,22 +2484,58 @@ impl RelayState {
                 id: connection_id,
                 tx,
             };
-            let replaced = match peer_kind {
+            let (replaced, pending_browser_messages) = match peer_kind {
                 TerminalPeerKind::Browser => {
                     session.browser_disconnected_at = None;
-                    session.browser.replace(record).map(|record| record.tx)
+                    (
+                        session.browser.replace(record).map(|record| record.tx),
+                        Vec::new(),
+                    )
                 }
                 TerminalPeerKind::Bridge => {
                     let replaced = session.bridge.replace(record).map(|record| record.tx);
                     session.attach_deadline = None;
-                    replaced
+                    // The browser is intentionally allowed to connect while the bridge
+                    // catches up. Preserve its ttyd handshake/input until the bridge
+                    // socket exists so the first readiness frame cannot be lost.
+                    let pending = if session.browser_paused {
+                        Vec::new()
+                    } else {
+                        session.pause_buffer_bytes = 0;
+                        std::mem::take(&mut session.pause_buffer)
+                    };
+                    (replaced, pending)
                 }
             };
-            (connection_id, replaced)
+            (connection_id, replaced, pending_browser_messages)
         };
 
         if let Some(previous) = replaced {
             let _ = previous.try_send(Message::Close(None));
+        }
+        if !pending_browser_messages.is_empty() {
+            let pending_count = pending_browser_messages.len();
+            for message in pending_browser_messages {
+                if pending_tx.try_send(message).is_err() {
+                    warn!(
+                        event = "relay_terminal_connection",
+                        action = "pending_browser_replay_failed",
+                        %terminal_id,
+                        connection_id,
+                        pending_count,
+                        "failed to replay browser terminal frames after bridge attach"
+                    );
+                    break;
+                }
+            }
+            info!(
+                event = "relay_terminal_connection",
+                action = "pending_browser_replayed",
+                %terminal_id,
+                connection_id,
+                pending_count,
+                "replayed browser terminal frames after bridge attach"
+            );
         }
         Ok(connection_id)
     }
@@ -2587,22 +2730,54 @@ impl RelayState {
                         return true;
                     }
                     TTYD_CMD_RESIZE => {
-                        // Log and forward RESIZE frames from browser to bridge.
-                        info!(%terminal_id, "relay terminal browser sent RESIZE");
-                        let bridge_tx = {
-                            let inner = self.inner.lock().await;
-                            inner
-                                .terminal_sessions
-                                .get(terminal_id)
-                                .filter(|session| {
-                                    session.connection_is_current(peer_kind, connection_id)
-                                })
-                                .and_then(|s| s.bridge.as_ref().map(|r| r.tx.clone()))
+                        let (bridge_tx, buffered) = {
+                            let mut inner = self.inner.lock().await;
+                            let Some(session) = inner.terminal_sessions.get_mut(terminal_id) else {
+                                return false;
+                            };
+                            if !session.connection_is_current(peer_kind, connection_id) {
+                                return false;
+                            }
+                            let bridge_tx = session.bridge.as_ref().map(|record| record.tx.clone());
+                            let buffered = if bridge_tx.is_none() {
+                                clone_websocket_message(message)
+                                    .is_some_and(|cloned| session.buffer_terminal_message(cloned))
+                            } else {
+                                false
+                            };
+                            (bridge_tx, buffered)
                         };
+                        if buffered {
+                            return true;
+                        }
                         if let (Some(tx), Some(cloned)) =
                             (bridge_tx, clone_websocket_message(message))
                         {
-                            let _ = tx.try_send(cloned);
+                            match tx.try_send(cloned) {
+                                Ok(()) => {}
+                                Err(mpsc::error::TrySendError::Full(_)) => {
+                                    warn!(
+                                        event = "relay_terminal_forward_failed",
+                                        %terminal_id,
+                                        connection_id,
+                                        direction = "browser_to_bridge",
+                                        reason = "queue_full",
+                                        "terminal resize could not be forwarded"
+                                    );
+                                    return false;
+                                }
+                                Err(mpsc::error::TrySendError::Closed(_)) => {
+                                    warn!(
+                                        event = "relay_terminal_forward_failed",
+                                        %terminal_id,
+                                        connection_id,
+                                        direction = "browser_to_bridge",
+                                        reason = "queue_closed",
+                                        "terminal resize could not be forwarded"
+                                    );
+                                    return false;
+                                }
+                            }
                         }
                         return true;
                     }
@@ -2624,23 +2799,7 @@ impl RelayState {
             }
             if session.browser_paused {
                 if let Some(cloned) = clone_websocket_message(message) {
-                    let message_bytes = websocket_message_size(&cloned);
-                    if message_bytes > TERMINAL_PAUSE_BUFFER_BYTE_CAPACITY {
-                        return true;
-                    }
-                    while !session.pause_buffer.is_empty()
-                        && (session.pause_buffer.len() >= TERMINAL_PAUSE_BUFFER_CAPACITY
-                            || session.pause_buffer_bytes.saturating_add(message_bytes)
-                                > TERMINAL_PAUSE_BUFFER_BYTE_CAPACITY)
-                    {
-                        let removed = session.pause_buffer.remove(0);
-                        session.pause_buffer_bytes = session
-                            .pause_buffer_bytes
-                            .saturating_sub(websocket_message_size(&removed));
-                    }
-                    session.pause_buffer_bytes =
-                        session.pause_buffer_bytes.saturating_add(message_bytes);
-                    session.pause_buffer.push(cloned);
+                    let _ = session.buffer_terminal_message(cloned);
                 }
                 return true;
             }
@@ -2660,8 +2819,47 @@ impl RelayState {
                 .map(|record| record.tx.clone())
         };
 
+        if counterpart.is_none() && peer_kind == TerminalPeerKind::Browser {
+            let mut inner = self.inner.lock().await;
+            let Some(session) = inner.terminal_sessions.get_mut(terminal_id) else {
+                return false;
+            };
+            if !session.connection_is_current(peer_kind, connection_id) {
+                return false;
+            }
+            if let Some(cloned) = clone_websocket_message(message) {
+                return session.buffer_terminal_message(cloned);
+            }
+        }
+
         if let (Some(counterpart), Some(cloned)) = (counterpart, clone_websocket_message(message)) {
-            let _ = counterpart.try_send(cloned);
+            match counterpart.try_send(cloned) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    warn!(
+                        event = "relay_terminal_forward_failed",
+                        %terminal_id,
+                        connection_id,
+                        peer = ?peer_kind,
+                        reason = "queue_full",
+                        message_bytes = websocket_message_size(message),
+                        "terminal frame could not be forwarded"
+                    );
+                    return false;
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    warn!(
+                        event = "relay_terminal_forward_failed",
+                        %terminal_id,
+                        connection_id,
+                        peer = ?peer_kind,
+                        reason = "queue_closed",
+                        message_bytes = websocket_message_size(message),
+                        "terminal frame could not be forwarded"
+                    );
+                    return false;
+                }
+            }
         }
         true
     }
@@ -5345,6 +5543,45 @@ mod tests {
             .authorize_terminal_session_browser(&terminal_id, "user@example.com")
             .await
             .expect("browser should be able to attach before the bridge terminal is ready");
+    }
+
+    #[tokio::test]
+    async fn browser_handshake_is_replayed_when_bridge_attaches_late() {
+        let state = RelayState::default();
+        state.inner.lock().await.terminal_sessions.insert(
+            "terminal-1".to_string(),
+            detached_terminal("terminal-1", "session-1", "device-1", "owner-a"),
+        );
+
+        let (browser_tx, _browser_rx) = test_message_channel(TERMINAL_WS_QUEUE_CAPACITY);
+        let browser_connection_id = state
+            .register_terminal_connection("terminal-1", TerminalPeerKind::Browser, browser_tx)
+            .await
+            .expect("browser connection");
+        let handshake = Message::Binary(br#"{"columns":120,"rows":40}"#.to_vec().into());
+        assert!(
+            state
+                .forward_terminal_message(
+                    "terminal-1",
+                    TerminalPeerKind::Browser,
+                    browser_connection_id,
+                    &handshake,
+                )
+                .await,
+            "browser handshake should be retained while the bridge catches up"
+        );
+
+        let (bridge_tx, mut bridge_rx) = test_message_channel(TERMINAL_WS_QUEUE_CAPACITY);
+        state
+            .register_terminal_connection("terminal-1", TerminalPeerKind::Bridge, bridge_tx)
+            .await
+            .expect("bridge connection");
+
+        assert_eq!(
+            bridge_rx.recv().await,
+            Some(handshake),
+            "the ttyd readiness handshake must reach the late bridge connection"
+        );
     }
 
     #[tokio::test]

--- a/crates/conductor-relay/src/relay.rs
+++ b/crates/conductor-relay/src/relay.rs
@@ -131,6 +131,9 @@ struct TerminalSessionRecord {
     /// Buffered output chunks received while the browser was paused, replayed on resume.
     pause_buffer: Vec<Message>,
     pause_buffer_bytes: usize,
+    /// Browser-to-bridge frames received before the bridge proxy attaches.
+    pending_browser_frames: Vec<Message>,
+    pending_browser_frame_bytes: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -419,25 +422,54 @@ impl TerminalSessionRecord {
         }
     }
 
-    fn buffer_terminal_message(&mut self, message: Message) -> bool {
+    fn buffer_paused_output(&mut self, message: Message) -> bool {
+        buffer_terminal_message(
+            &mut self.pause_buffer,
+            &mut self.pause_buffer_bytes,
+            TERMINAL_PAUSE_BUFFER_CAPACITY,
+            TERMINAL_PAUSE_BUFFER_BYTE_CAPACITY,
+            message,
+        )
+    }
+
+    fn buffer_pending_browser_frame(&mut self, message: Message) -> bool {
         let message_bytes = websocket_message_size(&message);
-        if message_bytes > TERMINAL_PAUSE_BUFFER_BYTE_CAPACITY {
+        if self.pending_browser_frames.len() >= TERMINAL_PENDING_BROWSER_FRAME_CAPACITY
+            || self
+                .pending_browser_frame_bytes
+                .saturating_add(message_bytes)
+                > TERMINAL_PENDING_BROWSER_FRAME_BYTE_CAPACITY
+        {
             return false;
         }
-        while !self.pause_buffer.is_empty()
-            && (self.pause_buffer.len() >= TERMINAL_PAUSE_BUFFER_CAPACITY
-                || self.pause_buffer_bytes.saturating_add(message_bytes)
-                    > TERMINAL_PAUSE_BUFFER_BYTE_CAPACITY)
-        {
-            let removed = self.pause_buffer.remove(0);
-            self.pause_buffer_bytes = self
-                .pause_buffer_bytes
-                .saturating_sub(websocket_message_size(&removed));
-        }
-        self.pause_buffer_bytes = self.pause_buffer_bytes.saturating_add(message_bytes);
-        self.pause_buffer.push(message);
+        self.pending_browser_frame_bytes = self
+            .pending_browser_frame_bytes
+            .saturating_add(message_bytes);
+        self.pending_browser_frames.push(message);
         true
     }
+}
+
+fn buffer_terminal_message(
+    buffer: &mut Vec<Message>,
+    buffer_bytes: &mut usize,
+    capacity: usize,
+    byte_capacity: usize,
+    message: Message,
+) -> bool {
+    let message_bytes = websocket_message_size(&message);
+    if message_bytes > byte_capacity {
+        return false;
+    }
+    while !buffer.is_empty()
+        && (buffer.len() >= capacity || buffer_bytes.saturating_add(message_bytes) > byte_capacity)
+    {
+        let removed = buffer.remove(0);
+        *buffer_bytes = buffer_bytes.saturating_sub(websocket_message_size(&removed));
+    }
+    *buffer_bytes = buffer_bytes.saturating_add(message_bytes);
+    buffer.push(message);
+    true
 }
 
 #[derive(Debug)]
@@ -471,6 +503,9 @@ struct ProxiedPreviewResponse {
 const TERMINAL_PAUSE_BUFFER_CAPACITY: usize = 256;
 /// Maximum aggregate bytes buffered while a browser terminal is paused.
 const TERMINAL_PAUSE_BUFFER_BYTE_CAPACITY: usize = 2 * 1024 * 1024;
+/// Browser input/handshake frames held while the paired bridge proxy catches up.
+const TERMINAL_PENDING_BROWSER_FRAME_CAPACITY: usize = 256;
+const TERMINAL_PENDING_BROWSER_FRAME_BYTE_CAPACITY: usize = 2 * 1024 * 1024;
 /// Per-connection outbound queue bounds. A slow peer may drop traffic, but cannot grow memory
 /// without limit.
 const CONTROL_WS_QUEUE_CAPACITY: usize = 128;
@@ -2282,6 +2317,8 @@ impl RelayState {
                         browser_paused: false,
                         pause_buffer: Vec::new(),
                         pause_buffer_bytes: 0,
+                        pending_browser_frames: Vec::new(),
+                        pending_browser_frame_bytes: 0,
                     },
                 );
 
@@ -2487,6 +2524,8 @@ impl RelayState {
             let (replaced, pending_browser_messages) = match peer_kind {
                 TerminalPeerKind::Browser => {
                     session.browser_disconnected_at = None;
+                    session.pending_browser_frames.clear();
+                    session.pending_browser_frame_bytes = 0;
                     (
                         session.browser.replace(record).map(|record| record.tx),
                         Vec::new(),
@@ -2498,12 +2537,8 @@ impl RelayState {
                     // The browser is intentionally allowed to connect while the bridge
                     // catches up. Preserve its ttyd handshake/input until the bridge
                     // socket exists so the first readiness frame cannot be lost.
-                    let pending = if session.browser_paused {
-                        Vec::new()
-                    } else {
-                        session.pause_buffer_bytes = 0;
-                        std::mem::take(&mut session.pause_buffer)
-                    };
+                    session.pending_browser_frame_bytes = 0;
+                    let pending = std::mem::take(&mut session.pending_browser_frames);
                     (replaced, pending)
                 }
             };
@@ -2515,18 +2550,39 @@ impl RelayState {
         }
         if !pending_browser_messages.is_empty() {
             let pending_count = pending_browser_messages.len();
+            let mut replayed_count = 0_usize;
+            let mut replay_failure = None;
             for message in pending_browser_messages {
-                if pending_tx.try_send(message).is_err() {
-                    warn!(
-                        event = "relay_terminal_connection",
-                        action = "pending_browser_replay_failed",
-                        %terminal_id,
-                        connection_id,
-                        pending_count,
-                        "failed to replay browser terminal frames after bridge attach"
-                    );
-                    break;
+                match pending_tx.try_send(message) {
+                    Ok(()) => replayed_count = replayed_count.saturating_add(1),
+                    Err(mpsc::error::TrySendError::Full(_)) => {
+                        replay_failure = Some("queue_full");
+                        break;
+                    }
+                    Err(mpsc::error::TrySendError::Closed(_)) => {
+                        replay_failure = Some("queue_closed");
+                        break;
+                    }
                 }
+            }
+            if let Some(reason) = replay_failure {
+                warn!(
+                    event = "relay_terminal_connection",
+                    action = "pending_browser_replay_failed",
+                    %terminal_id,
+                    connection_id,
+                    pending_count,
+                    replayed_count,
+                    reason,
+                    "failed to replay browser terminal frames after bridge attach"
+                );
+                self.unregister_terminal_connection(
+                    terminal_id,
+                    TerminalPeerKind::Bridge,
+                    connection_id,
+                )
+                .await;
+                anyhow::bail!("failed to replay pending browser terminal frames: {reason}");
             }
             info!(
                 event = "relay_terminal_connection",
@@ -2534,6 +2590,7 @@ impl RelayState {
                 %terminal_id,
                 connection_id,
                 pending_count,
+                replayed_count,
                 "replayed browser terminal frames after bridge attach"
             );
         }
@@ -2740,15 +2797,16 @@ impl RelayState {
                             }
                             let bridge_tx = session.bridge.as_ref().map(|record| record.tx.clone());
                             let buffered = if bridge_tx.is_none() {
-                                clone_websocket_message(message)
-                                    .is_some_and(|cloned| session.buffer_terminal_message(cloned))
+                                clone_websocket_message(message).is_some_and(|cloned| {
+                                    session.buffer_pending_browser_frame(cloned)
+                                })
                             } else {
                                 false
                             };
                             (bridge_tx, buffered)
                         };
-                        if buffered {
-                            return true;
+                        if bridge_tx.is_none() {
+                            return buffered;
                         }
                         if let (Some(tx), Some(cloned)) =
                             (bridge_tx, clone_websocket_message(message))
@@ -2799,7 +2857,7 @@ impl RelayState {
             }
             if session.browser_paused {
                 if let Some(cloned) = clone_websocket_message(message) {
-                    let _ = session.buffer_terminal_message(cloned);
+                    let _ = session.buffer_paused_output(cloned);
                 }
                 return true;
             }
@@ -2828,7 +2886,7 @@ impl RelayState {
                 return false;
             }
             if let Some(cloned) = clone_websocket_message(message) {
-                return session.buffer_terminal_message(cloned);
+                return session.buffer_pending_browser_frame(cloned);
             }
         }
 
@@ -5055,6 +5113,8 @@ mod tests {
             browser_paused: false,
             pause_buffer: Vec::new(),
             pause_buffer_bytes: 0,
+            pending_browser_frames: Vec::new(),
+            pending_browser_frame_bytes: 0,
         }
     }
 
@@ -5546,7 +5606,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn browser_handshake_is_replayed_when_bridge_attaches_late() {
+    async fn browser_handshake_survives_pause_before_bridge_attaches() {
         let state = RelayState::default();
         state.inner.lock().await.terminal_sessions.insert(
             "terminal-1".to_string(),
@@ -5570,6 +5630,18 @@ mod tests {
                 .await,
             "browser handshake should be retained while the bridge catches up"
         );
+        let pause = Message::Binary(vec![TTYD_CMD_PAUSE].into());
+        assert!(
+            state
+                .forward_terminal_message(
+                    "terminal-1",
+                    TerminalPeerKind::Browser,
+                    browser_connection_id,
+                    &pause,
+                )
+                .await,
+            "pause should not erase browser-to-bridge frames"
+        );
 
         let (bridge_tx, mut bridge_rx) = test_message_channel(TERMINAL_WS_QUEUE_CAPACITY);
         state
@@ -5582,6 +5654,72 @@ mod tests {
             Some(handshake),
             "the ttyd readiness handshake must reach the late bridge connection"
         );
+    }
+
+    #[test]
+    fn pending_browser_frame_overflow_preserves_the_initial_handshake() {
+        let mut session = detached_terminal("terminal-1", "session-1", "device-1", "owner-a");
+        let handshake = Message::Binary(br#"{"columns":120,"rows":40}"#.to_vec().into());
+        assert!(session.buffer_pending_browser_frame(handshake.clone()));
+        for _ in 1..TERMINAL_PENDING_BROWSER_FRAME_CAPACITY {
+            assert!(session.buffer_pending_browser_frame(Message::Binary(vec![b'0'].into())));
+        }
+
+        assert!(!session.buffer_pending_browser_frame(Message::Binary(vec![b'0'].into())));
+        assert_eq!(session.pending_browser_frames.first(), Some(&handshake));
+        assert_eq!(
+            session.pending_browser_frames.len(),
+            TERMINAL_PENDING_BROWSER_FRAME_CAPACITY
+        );
+    }
+
+    #[tokio::test]
+    async fn incomplete_pending_browser_replay_rolls_back_bridge_registration() {
+        let state = RelayState::default();
+        state.inner.lock().await.terminal_sessions.insert(
+            "terminal-1".to_string(),
+            detached_terminal("terminal-1", "session-1", "device-1", "owner-a"),
+        );
+
+        let (browser_tx, mut browser_rx) = test_message_channel(TERMINAL_WS_QUEUE_CAPACITY);
+        let browser_connection_id = state
+            .register_terminal_connection("terminal-1", TerminalPeerKind::Browser, browser_tx)
+            .await
+            .expect("browser connection");
+        let handshake = Message::Binary(br#"{"columns":120,"rows":40}"#.to_vec().into());
+        assert!(
+            state
+                .forward_terminal_message(
+                    "terminal-1",
+                    TerminalPeerKind::Browser,
+                    browser_connection_id,
+                    &handshake,
+                )
+                .await
+        );
+
+        let (bridge_tx, mut bridge_rx) = test_message_channel(1);
+        bridge_tx
+            .try_send(Message::Ping(Vec::new().into()))
+            .expect("bridge queue should be full before replay");
+        let err = state
+            .register_terminal_connection("terminal-1", TerminalPeerKind::Bridge, bridge_tx)
+            .await
+            .expect_err("partial pending-frame replay must reject the bridge connection");
+        assert!(err
+            .to_string()
+            .contains("failed to replay pending browser terminal frames"));
+
+        assert!(matches!(browser_rx.recv().await, Some(Message::Close(_))));
+        assert!(matches!(bridge_rx.recv().await, Some(Message::Ping(_))));
+        let inner = state.inner.lock().await;
+        let session = inner
+            .terminal_sessions
+            .get("terminal-1")
+            .expect("browser-owned relay terminal should remain reconnectable");
+        assert!(session.bridge.is_none());
+        assert!(session.pending_browser_frames.is_empty());
+        assert_eq!(session.pending_browser_frame_bytes, 0);
     }
 
     #[tokio::test]
@@ -5631,6 +5769,8 @@ mod tests {
                     browser_paused: false,
                     pause_buffer: Vec::new(),
                     pause_buffer_bytes: 0,
+                    pending_browser_frames: Vec::new(),
+                    pending_browser_frame_bytes: 0,
                 },
             );
         }
@@ -5714,6 +5854,8 @@ mod tests {
                     browser_paused: false,
                     pause_buffer: Vec::new(),
                     pause_buffer_bytes: 0,
+                    pending_browser_frames: Vec::new(),
+                    pending_browser_frame_bytes: 0,
                 },
             );
         }
@@ -5786,6 +5928,8 @@ mod tests {
                     browser_paused: false,
                     pause_buffer: Vec::new(),
                     pause_buffer_bytes: 0,
+                    pending_browser_frames: Vec::new(),
+                    pending_browser_frame_bytes: 0,
                 },
             );
         }
@@ -5860,6 +6004,8 @@ mod tests {
                     browser_paused: false,
                     pause_buffer: Vec::new(),
                     pause_buffer_bytes: 0,
+                    pending_browser_frames: Vec::new(),
+                    pending_browser_frame_bytes: 0,
                 },
             );
         }
@@ -5925,6 +6071,8 @@ mod tests {
                     browser_paused: false,
                     pause_buffer: Vec::new(),
                     pause_buffer_bytes: 0,
+                    pending_browser_frames: Vec::new(),
+                    pending_browser_frame_bytes: 0,
                 },
             );
         }
@@ -6134,6 +6282,8 @@ mod tests {
                     browser_paused: false,
                     pause_buffer: Vec::new(),
                     pause_buffer_bytes: 0,
+                    pending_browser_frames: Vec::new(),
+                    pending_browser_frame_bytes: 0,
                 },
             );
         }

--- a/crates/conductor-relay/src/relay.rs
+++ b/crates/conductor-relay/src/relay.rs
@@ -502,7 +502,7 @@ struct ProxiedPreviewResponse {
 /// Maximum number of output chunks buffered while the browser peer is paused.
 const TERMINAL_PAUSE_BUFFER_CAPACITY: usize = 256;
 /// Maximum aggregate bytes buffered while a browser terminal is paused.
-const TERMINAL_PAUSE_BUFFER_BYTE_CAPACITY: usize = 2 * 1024 * 1024;
+const TERMINAL_PAUSE_BUFFER_BYTE_CAPACITY: usize = MAX_TERMINAL_BRIDGE_WS_MESSAGE_BYTES;
 /// Browser input/handshake frames held while the paired bridge proxy catches up.
 const TERMINAL_PENDING_BROWSER_FRAME_CAPACITY: usize = 256;
 const TERMINAL_PENDING_BROWSER_FRAME_BYTE_CAPACITY: usize = 2 * 1024 * 1024;
@@ -518,6 +518,10 @@ const GLOBAL_WS_QUEUE_BYTE_CAPACITY: usize = 128 * 1024 * 1024;
 const USER_WS_QUEUE_BYTE_CAPACITY: usize = 32 * 1024 * 1024;
 const CHANNEL_WS_QUEUE_BYTE_CAPACITY: usize = 16 * 1024 * 1024;
 const MAX_WS_MESSAGE_BYTES: usize = 1024 * 1024;
+/// The backend retains up to 2 MiB of terminal history and replays it as one ttyd output
+/// message. Account for the ttyd command byte while keeping every other relay WebSocket at the
+/// tighter general-purpose limit above.
+const MAX_TERMINAL_BRIDGE_WS_MESSAGE_BYTES: usize = 2 * 1024 * 1024 + 1;
 /// ttyd protocol command bytes (first byte of binary WebSocket message).
 const TTYD_CMD_RESIZE: u8 = b'1';
 const TTYD_CMD_PAUSE: u8 = b'2';
@@ -1744,8 +1748,8 @@ async fn bridge_terminal_ws(
         .await
     {
         Ok(()) => ws
-            .max_message_size(MAX_WS_MESSAGE_BYTES)
-            .max_frame_size(MAX_WS_MESSAGE_BYTES)
+            .max_message_size(MAX_TERMINAL_BRIDGE_WS_MESSAGE_BYTES)
+            .max_frame_size(MAX_TERMINAL_BRIDGE_WS_MESSAGE_BYTES)
             .on_upgrade(move |socket| async move {
                 if let Err(err) =
                     handle_terminal_connection(state, terminal_id, TerminalPeerKind::Bridge, socket)
@@ -2717,7 +2721,21 @@ impl RelayState {
         let Some(current_sender) = current_sender else {
             return false;
         };
-        if websocket_message_size(message) > MAX_WS_MESSAGE_BYTES {
+        let message_bytes = websocket_message_size(message);
+        let message_limit = match peer_kind {
+            TerminalPeerKind::Browser => MAX_WS_MESSAGE_BYTES,
+            TerminalPeerKind::Bridge => MAX_TERMINAL_BRIDGE_WS_MESSAGE_BYTES,
+        };
+        if message_bytes > message_limit {
+            warn!(
+                event = "relay_terminal_message",
+                action = "rejected_oversized",
+                %terminal_id,
+                ?peer_kind,
+                message_bytes,
+                message_limit,
+                "relay terminal message exceeded its directional byte limit"
+            );
             let _ = current_sender.try_send(Message::Close(Some(CloseFrame {
                 code: 1009,
                 reason: "Relay WebSocket message exceeded the byte limit.".into(),
@@ -6358,6 +6376,72 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn terminal_bridge_output_accepts_backend_snapshot_above_control_limit() {
+        let state = RelayState::default();
+        state.inner.lock().await.terminal_sessions.insert(
+            "terminal-1".to_string(),
+            detached_terminal("terminal-1", "session-1", "device-1", "owner-a"),
+        );
+        let (browser_tx, mut browser_rx) = test_message_channel(TERMINAL_WS_QUEUE_CAPACITY);
+        state
+            .register_terminal_connection("terminal-1", TerminalPeerKind::Browser, browser_tx)
+            .await
+            .expect("browser connection");
+        let (bridge_tx, _bridge_rx) = test_message_channel(TERMINAL_WS_QUEUE_CAPACITY);
+        let bridge_connection_id = state
+            .register_terminal_connection("terminal-1", TerminalPeerKind::Bridge, bridge_tx)
+            .await
+            .expect("bridge connection");
+
+        // This is the exact retained-screen frame size observed in production. It is larger than
+        // the general relay limit but remains below the backend's bounded 2 MiB snapshot ceiling.
+        let snapshot_bytes = MAX_WS_MESSAGE_BYTES + 4096;
+        let output = Message::Binary(vec![b'0'; snapshot_bytes].into());
+        assert!(
+            state
+                .forward_terminal_message(
+                    "terminal-1",
+                    TerminalPeerKind::Bridge,
+                    bridge_connection_id,
+                    &output,
+                )
+                .await
+        );
+        let forwarded = browser_rx
+            .recv()
+            .await
+            .expect("snapshot should be forwarded");
+        assert_eq!(websocket_message_size(&forwarded), snapshot_bytes);
+    }
+
+    #[tokio::test]
+    async fn terminal_browser_input_keeps_the_general_message_limit() {
+        let state = RelayState::default();
+        state.inner.lock().await.terminal_sessions.insert(
+            "terminal-1".to_string(),
+            detached_terminal("terminal-1", "session-1", "device-1", "owner-a"),
+        );
+        let (browser_tx, mut browser_rx) = test_message_channel(TERMINAL_WS_QUEUE_CAPACITY);
+        let browser_connection_id = state
+            .register_terminal_connection("terminal-1", TerminalPeerKind::Browser, browser_tx)
+            .await
+            .expect("browser connection");
+        let oversized_input = Message::Binary(vec![b'0'; MAX_WS_MESSAGE_BYTES + 1].into());
+
+        assert!(
+            !state
+                .forward_terminal_message(
+                    "terminal-1",
+                    TerminalPeerKind::Browser,
+                    browser_connection_id,
+                    &oversized_input,
+                )
+                .await
+        );
+        assert!(matches!(browser_rx.recv().await, Some(Message::Close(_))));
+    }
+
+    #[tokio::test]
     async fn device_channel_registration_rejects_a_different_owner() {
         let state = RelayState::default();
         {
@@ -6598,6 +6682,30 @@ mod tests {
             .await
             .terminal_sessions
             .insert("terminal-1".to_string(), terminal);
+
+        let retained_snapshot =
+            Message::Binary(vec![0_u8; MAX_TERMINAL_BRIDGE_WS_MESSAGE_BYTES].into());
+        assert!(
+            state
+                .forward_terminal_message(
+                    "terminal-1",
+                    TerminalPeerKind::Bridge,
+                    7,
+                    &retained_snapshot,
+                )
+                .await
+        );
+        assert_eq!(
+            state
+                .inner
+                .lock()
+                .await
+                .terminal_sessions
+                .get("terminal-1")
+                .expect("terminal remains active")
+                .pause_buffer_bytes,
+            MAX_TERMINAL_BRIDGE_WS_MESSAGE_BYTES
+        );
 
         let chunk = Message::Binary(vec![0_u8; 700 * 1024].into());
         for _ in 0..4 {

--- a/crates/conductor-server/src/routes/terminal.rs
+++ b/crates/conductor-server/src/routes/terminal.rs
@@ -1500,8 +1500,30 @@ async fn build_terminal_token_response(
     request_headers: &HeaderMap,
 ) -> Response {
     let Some(initial_session) = state.get_session(&id).await else {
+        tracing::warn!(
+            event = "terminal_token_request",
+            session_id = %id,
+            scope = scope.as_str(),
+            decision = "session_not_found",
+            "Terminal token request rejected"
+        );
         return error(StatusCode::NOT_FOUND, format!("Session {id} not found")).into_response();
     };
+
+    tracing::info!(
+        event = "terminal_token_request",
+        session_id = %id,
+        scope = scope.as_str(),
+        session_status = ?initial_session.status,
+        runtime_mode = initial_session
+            .metadata
+            .get(RUNTIME_MODE_METADATA_KEY)
+            .map(String::as_str)
+            .unwrap_or("unknown"),
+        ttyd_pid_present = initial_session.metadata.contains_key(TTYD_PID_METADATA_KEY),
+        ttyd_ws_present = ttyd_session_ws_url(&initial_session).is_some(),
+        "Resolving terminal transport for a session"
+    );
 
     if ttyd_session_ws_url(&initial_session).is_some()
         && initial_session.metadata.contains_key(TTYD_PID_METADATA_KEY)
@@ -1539,6 +1561,18 @@ async fn build_terminal_token_response(
         None
     };
     let Some(_ttyd_ws_url) = ttyd_session_ws_url(&session) else {
+        tracing::warn!(
+            event = "terminal_token_request",
+            session_id = %id,
+            scope = scope.as_str(),
+            decision = "ttyd_unavailable",
+            runtime_mode = session
+                .metadata
+                .get(RUNTIME_MODE_METADATA_KEY)
+                .map(String::as_str)
+                .unwrap_or("unknown"),
+            "Session does not expose a ttyd terminal"
+        );
         return error(
             StatusCode::BAD_REQUEST,
             format!("Session {id} does not expose a ttyd terminal"),
@@ -1553,6 +1587,15 @@ async fn build_terminal_token_response(
     };
     let ttyd_http_url = ttyd_frontend_proxy_path(&id, url_token);
     let ttyd_ws_url = ttyd_frontend_proxy_ws_path(&id, url_token);
+    tracing::info!(
+        event = "terminal_token_request",
+        session_id = %id,
+        scope = scope.as_str(),
+        decision = "issued",
+        token_required,
+        token_embedded_in_url = embed_token_in_urls,
+        "Terminal transport resolved"
+    );
     let mut response = Json(json!({
         "token": token,
         "required": token_required,
@@ -1988,6 +2031,15 @@ async fn handle_ttyd_frontend_socket(
     session_id: String,
     mut client_socket: WebSocket,
 ) {
+    let connected_at = Instant::now();
+    let mut inbound_messages = 0_u64;
+    let mut inbound_bytes = 0_u64;
+    tracing::info!(
+        event = "terminal_websocket_attached",
+        session_id = %session_id,
+        transport = "ttyd_frontend",
+        "Browser terminal websocket attached"
+    );
     if let Err(err) = state.ensure_session_live(&session_id).await {
         tracing::warn!(session_id = %session_id, error = %err, "failed to ensure ttyd session live before frontend attach");
     }
@@ -2006,6 +2058,8 @@ async fn handle_ttyd_frontend_socket(
             client_message = client_socket.recv() => {
                 match client_message {
                     Some(Ok(Message::Binary(data))) => {
+                        inbound_messages = inbound_messages.saturating_add(1);
+                        inbound_bytes = inbound_bytes.saturating_add(data.len() as u64);
                         if data.len() > MAX_TTYD_BROWSER_WS_FRAME_BYTES {
                             tracing::warn!(
                                 session_id = %session_id,
@@ -2032,6 +2086,8 @@ async fn handle_ttyd_frontend_socket(
                         }
                     }
                     Some(Ok(Message::Text(text))) => {
+                        inbound_messages = inbound_messages.saturating_add(1);
+                        inbound_bytes = inbound_bytes.saturating_add(text.len() as u64);
                         if text.len() > MAX_TTYD_BROWSER_WS_FRAME_BYTES {
                             tracing::warn!(
                                 session_id = %session_id,
@@ -2128,6 +2184,20 @@ async fn handle_ttyd_frontend_socket(
             }
         }
     }
+
+    tracing::info!(
+        event = "terminal_websocket_closed",
+        session_id = %session_id,
+        transport = "ttyd_frontend",
+        duration_ms = connected_at.elapsed().as_millis() as u64,
+        inbound_messages,
+        inbound_bytes,
+        client_ready,
+        paused,
+        buffered_chunks = pause_buffer.len(),
+        last_sequence_sent,
+        "Browser terminal websocket detached"
+    );
 }
 
 fn render_restore_snapshot_bytes(
@@ -2165,7 +2235,8 @@ async fn handle_ttyd_frontend_client_message(
     match message {
         Some(ttyd_protocol::ClientMessage::Handshake(value)) => {
             *client_ready = true;
-            if let Some((columns, rows)) = parse_handshake_dimensions(&value) {
+            let dimensions = parse_handshake_dimensions(&value);
+            if let Some((columns, rows)) = dimensions {
                 let _ = state.resize_live_terminal(session_id, columns, rows).await;
             }
             client_socket
@@ -2180,6 +2251,16 @@ async fn handle_ttyd_frontend_client_message(
             // behavior without replaying the whole raw stream.
             let bytes =
                 render_current_restore_snapshot_bytes(state, session_id, last_sequence_sent).await;
+            tracing::info!(
+                event = "terminal_websocket_ready",
+                session_id = %session_id,
+                transport = "ttyd_frontend",
+                columns = dimensions.map(|(columns, _)| columns),
+                rows = dimensions.map(|(_, rows)| rows),
+                snapshot_bytes = bytes.len(),
+                snapshot_sequence = *last_sequence_sent,
+                "Browser terminal handshake completed"
+            );
             if !bytes.is_empty() {
                 client_socket
                     .send(Message::Binary(ttyd_protocol::encode_output(&bytes).into()))

--- a/crates/conductor-server/src/state/session_manager.rs
+++ b/crates/conductor-server/src/state/session_manager.rs
@@ -928,6 +928,12 @@ impl AppState {
         drop(sessions);
         self.persist_session(&updated).await?;
         self.publish_snapshot().await;
+        tracing::info!(
+            event = "session_launch_stage",
+            session_id = %session_id,
+            stage = %summary,
+            "Agent launch advanced to the next stage"
+        );
         Ok(())
     }
 
@@ -1093,6 +1099,19 @@ impl AppState {
         let is_orchestration_session =
             is_orchestration_session_kind(request.session_kind.as_deref());
         let is_acp_dispatcher = is_acp_dispatcher_session_kind(request.session_kind.as_deref());
+        tracing::info!(
+            event = "session_launch_start",
+            session_id = %session_id,
+            project_id = %request.project_id,
+            agent = %project_agent,
+            source = %request.source,
+            worktree_requested = request.use_worktree.unwrap_or(true),
+            orchestration_session = is_orchestration_session,
+            acp_dispatcher = is_acp_dispatcher,
+            has_prompt = !request.prompt.trim().is_empty(),
+            attachment_count = request.attachments.len(),
+            "Starting the selected agent launch"
+        );
         let mut session_prompt = request.prompt.clone();
         let mut session_attachments = request.attachments.clone();
         if is_acp_dispatcher {
@@ -1214,6 +1233,13 @@ impl AppState {
         if !workspace_path.uses_worktree && request.branch.is_none() {
             branch = None;
         }
+        tracing::info!(
+            event = "session_workspace_ready",
+            session_id = %session_id,
+            project_id = %request.project_id,
+            uses_worktree = workspace_path.uses_worktree,
+            "Agent workspace is ready"
+        );
         let dev_server = match dev_server_result {
             Ok(dev_server) => dev_server,
             Err(err) => {
@@ -1300,6 +1326,15 @@ impl AppState {
             && !executor.accepts_prompt_on_launch_when_interactive()
             && !prompt.trim().is_empty();
 
+        let _ = self
+            .update_launch_stage(&session_id, "Starting agent runtime")
+            .await;
+        self.emit_terminal_text(
+            &session_id,
+            format_launch_progress("Starting agent runtime..."),
+        )
+        .await;
+
         let runtime_launch = match self
             .spawn_with_runtime(
                 &project,
@@ -1344,6 +1379,17 @@ impl AppState {
         let streams_terminal_bytes = runtime_launch.streams_terminal_bytes;
         let (pid, _kind, output_rx, input_tx, terminal_rx, resize_tx, kill_tx) =
             runtime_launch.handle.into_parts();
+        tracing::info!(
+            event = "session_runtime_spawned",
+            session_id = %session_id,
+            project_id = %request.project_id,
+            agent = %project_agent,
+            pid,
+            streams_terminal_bytes,
+            has_terminal_stream = terminal_rx.is_some(),
+            has_resize_channel = resize_tx.is_some(),
+            "Agent process started and exposed its runtime channels"
+        );
         if self
             .get_session(&session_id)
             .await
@@ -1580,6 +1626,14 @@ impl AppState {
                 .expect("runtime kill channel should exist before terminal attachment"),
         )
         .await;
+        tracing::info!(
+            event = "session_terminal_attached",
+            session_id = %session_id,
+            project_id = %request.project_id,
+            agent = %project_agent,
+            pid,
+            "Agent runtime is attached to the terminal host"
+        );
         self.start_output_consumer(
             session_id.clone(),
             executor,

--- a/crates/conductor-server/src/state/spawn_queue.rs
+++ b/crates/conductor-server/src/state/spawn_queue.rs
@@ -126,6 +126,25 @@ impl AppState {
         });
 
         self.replace_session(record.clone()).await?;
+        tracing::info!(
+            event = "session_launch_queued",
+            session_id = %record.id,
+            project_id = %record.project_id,
+            agent = %record.agent,
+            source = %record
+                .metadata
+                .get(QUEUED_SOURCE_METADATA_KEY)
+                .map(String::as_str)
+                .unwrap_or("unknown"),
+            has_prompt = !record.prompt.trim().is_empty(),
+            attachment_count = record
+                .conversation
+                .first()
+                .map(|entry| entry.attachments.len())
+                .unwrap_or_default(),
+            kick_supervisor,
+            "Session launch entered the manager queue"
+        );
         if kick_supervisor {
             self.kick_spawn_supervisor().await;
         }
@@ -153,11 +172,29 @@ impl AppState {
                 continue;
             }
 
+            tracing::info!(
+                event = "session_launch_decision",
+                decision = "launch",
+                session_id = %session_id,
+                project_id = %request.project_id,
+                agent = request.agent.as_deref().unwrap_or("project-default"),
+                "Launch manager committed the queued session"
+            );
+
             match self
                 .spawn_session_now(request.clone(), Some(session_id.clone()))
                 .await
             {
-                Ok(_) => {}
+                Ok(record) => {
+                    tracing::info!(
+                        event = "session_launch_complete",
+                        session_id = %record.id,
+                        project_id = %record.project_id,
+                        agent = %record.agent,
+                        pid = record.pid,
+                        "Launch manager attached the agent runtime"
+                    );
+                }
                 Err(err) => {
                     tracing::warn!(session_id, error = %err, "Queued session launch failed");
                     self.record_error(
@@ -227,7 +264,9 @@ impl AppState {
         let queued_count = queued_ids.len();
         let (global_active, per_project_active) = self.launch_capacity_snapshot().await;
         if global_active >= MAX_GLOBAL_CONCURRENT_LAUNCHES {
-            tracing::debug!(
+            tracing::info!(
+                event = "session_launch_decision",
+                decision = "blocked_global_capacity",
                 queued_count,
                 global_active,
                 global_limit = MAX_GLOBAL_CONCURRENT_LAUNCHES,
@@ -250,7 +289,9 @@ impl AppState {
 
             // Dedup only exact launch duplicates. Different agents should not block each other.
             if active_launch_fingerprints.contains(&launch_fingerprint) {
-                tracing::debug!(
+                tracing::info!(
+                    event = "session_launch_decision",
+                    decision = "skip_exact_duplicate",
                     session_id,
                     project_id = session.project_id,
                     agent = session.agent,
@@ -265,7 +306,9 @@ impl AppState {
                 .copied()
                 .unwrap_or_default();
             if project_active >= MAX_PROJECT_CONCURRENT_LAUNCHES {
-                tracing::debug!(
+                tracing::info!(
+                    event = "session_launch_decision",
+                    decision = "blocked_project_capacity",
                     session_id,
                     project_id = session.project_id,
                     project_active,
@@ -277,6 +320,13 @@ impl AppState {
 
             let Some(raw_request) = session.metadata.get(SPAWN_REQUEST_METADATA_KEY).cloned()
             else {
+                tracing::warn!(
+                    event = "session_launch_decision",
+                    decision = "invalid_queue_record",
+                    session_id,
+                    project_id = session.project_id,
+                    "Queued session is missing its spawn request"
+                );
                 let _ = self
                     .mark_queued_session_failed(
                         &session_id,
@@ -288,15 +338,28 @@ impl AppState {
 
             match serde_json::from_str::<SpawnRequest>(&raw_request) {
                 Ok(request) => {
-                    tracing::debug!(
+                    tracing::info!(
+                        event = "session_launch_decision",
+                        decision = "selected",
                         session_id,
                         project_id = session.project_id,
                         agent = session.agent,
+                        queued_count,
+                        global_active,
+                        project_active,
                         "Spawn queue selected a queued session for launch"
                     );
                     return Some((session_id, request));
                 }
                 Err(err) => {
+                    tracing::warn!(
+                        event = "session_launch_decision",
+                        decision = "invalid_spawn_request",
+                        session_id,
+                        project_id = session.project_id,
+                        error = %err,
+                        "Queued session spawn request could not be decoded"
+                    );
                     let _ = self
                         .mark_queued_session_failed(
                             &session_id,
@@ -307,7 +370,9 @@ impl AppState {
             }
         }
 
-        tracing::debug!(
+        tracing::info!(
+            event = "session_launch_decision",
+            decision = "none_eligible",
             queued_count,
             global_active,
             "Spawn queue found queued sessions but none were eligible to launch"

--- a/packages/web/src/components/sessions/IframeTerminalPage.tsx
+++ b/packages/web/src/components/sessions/IframeTerminalPage.tsx
@@ -13,6 +13,7 @@ import {
 import { resolveNativeTerminalWebSocketUrl } from "@/components/sessions/terminal/terminalClientUrls";
 import { decodeBridgeSessionId } from "@/lib/bridgeSessionIds";
 import {
+  encodeTtydHandshakeFrame,
   encodeTtydInputFrame,
   encodeTtydResizeFrame,
   TTYD_SERVER_COMMAND,
@@ -100,11 +101,16 @@ export function IframeTerminalPage({
   const waitingForTerminalRef = useRef(false);
   const loadedOutputRef = useRef<string | null>(null);
   const hasConnectedOnceRef = useRef(false);
+  const lastSentGeometryRef = useRef<{ cols: number; rows: number } | null>(null);
   const bridgeScopedSession = useMemo(() => decodeBridgeSessionId(sessionId), [sessionId]);
   const usesRelayTerminal = Boolean(bridgeId?.trim() || bridgeScopedSession);
 
   const tokenUrl = useMemo(
     () => withBridgeQuery(`/api/sessions/${encodeURIComponent(sessionId)}/terminal/token`, bridgeId),
+    [bridgeId, sessionId],
+  );
+  const outputUrl = useMemo(
+    () => withBridgeQuery(`/api/sessions/${encodeURIComponent(sessionId)}/output`, bridgeId),
     [bridgeId, sessionId],
   );
 
@@ -119,6 +125,7 @@ export function IframeTerminalPage({
     const socket = socketRef.current;
     socketRef.current = null;
     ttydProtocolRef.current = false;
+    lastSentGeometryRef.current = null;
     allowReconnectRef.current = false;
     if (!socket) {
       return;
@@ -296,7 +303,7 @@ export function IframeTerminalPage({
 
     const tokenWsUrl = info?.wsUrl ?? info?.ttydWsUrl ?? null;
     if (!tokenWsUrl) {
-      const hasOutput = await loadStoredOutput(info?.outputUrl);
+      const hasOutput = await loadStoredOutput(info?.outputUrl ?? outputUrl);
       if (hasOutput) {
         waitingForTerminalRef.current = false;
         return;
@@ -334,11 +341,11 @@ export function IframeTerminalPage({
     ws.binaryType = "arraybuffer";
     socketRef.current = ws;
     ttydProtocolRef.current = useTtydProtocol;
+    lastSentGeometryRef.current = null;
 
     ws.onopen = () => {
       retryAttemptRef.current = 0;
       waitingForTerminalRef.current = false;
-      loadedOutputRef.current = null;
       decoderRef.current = new TextDecoder();
       if (hasConnectedOnceRef.current) {
         terminalRef.current?.reset();
@@ -346,15 +353,27 @@ export function IframeTerminalPage({
         hasConnectedOnceRef.current = true;
       }
       const geometry = fitTerminal();
+      const cols = geometry?.cols ?? 120;
+      const rows = geometry?.rows ?? 32;
       if (useTtydProtocol) {
-        ws.send(encodeResizeFrame(geometry?.cols ?? 120, geometry?.rows ?? 32));
+        // ttyd requires a JSON handshake as the first client message. Conductor's
+        // terminal facade uses it to mark the client ready and replay the retained
+        // screen; sending a resize first leaves late browser attaches blank.
+        ws.send(encodeTtydHandshakeFrame(cols, rows));
       } else {
         ws.send(JSON.stringify({
           type: "hello",
-          cols: geometry?.cols ?? 120,
-          rows: geometry?.rows ?? 32,
+          cols,
+          rows,
         }));
       }
+      lastSentGeometryRef.current = { cols, rows };
+      console.info("[Conductor terminal] websocket attached", {
+        sessionId,
+        transport: relayConnection ? "relay-ttyd" : useTtydProtocol ? "ttyd" : "native",
+        cols,
+        rows,
+      });
     };
 
     ws.onmessage = (event) => {
@@ -430,6 +449,11 @@ export function IframeTerminalPage({
       if (socketRef.current === ws) {
         socketRef.current = null;
       }
+      lastSentGeometryRef.current = null;
+      console.info("[Conductor terminal] websocket closed", {
+        sessionId,
+        transport: relayConnection ? "relay-ttyd" : useTtydProtocol ? "ttyd" : "native",
+      });
       if (!allowReconnectRef.current) {
         return;
       }
@@ -441,6 +465,7 @@ export function IframeTerminalPage({
     };
   }, [
     tokenUrl,
+    outputUrl,
     loadStoredOutput,
     scheduleReconnect,
     usesRelayTerminal,
@@ -448,12 +473,17 @@ export function IframeTerminalPage({
     fitTerminal,
     encodeResizeFrame,
     writeTerminalNotice,
+    sessionId,
   ]);
 
   const applyGeometry = useCallback(() => {
     const geometry = fitTerminal();
     const socket = socketRef.current;
     if (!geometry || !socket || socket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    const previous = lastSentGeometryRef.current;
+    if (previous?.cols === geometry.cols && previous.rows === geometry.rows) {
       return;
     }
     if (ttydProtocolRef.current) {
@@ -465,7 +495,8 @@ export function IframeTerminalPage({
         rows: geometry.rows,
       }));
     }
-  }, [encodeResizeFrame, fitTerminal, usesRelayTerminal]);
+    lastSentGeometryRef.current = geometry;
+  }, [encodeResizeFrame, fitTerminal]);
 
   useEffect(() => {
     connectInvokerRef.current = () => {

--- a/packages/web/src/components/sessions/SessionTerminal.reload.test.ts
+++ b/packages/web/src/components/sessions/SessionTerminal.reload.test.ts
@@ -37,6 +37,17 @@ test("embedded terminal schedules a geometry burst so desktop panes do not stay 
   assert.match(source, /clearGeometryBurst\?\.\(\);\n\s*clearReconnectTimer\(\);/);
 });
 
+test("embedded terminal handshakes before resize and deduplicates settled geometry", () => {
+  const source = readFileSync(new URL("./IframeTerminalPage.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /ws\.send\(encodeTtydHandshakeFrame\(cols, rows\)\);/);
+  assert.match(source, /lastSentGeometryRef\.current = \{ cols, rows \};/);
+  assert.match(
+    source,
+    /if \(previous\?\.cols === geometry\.cols && previous\.rows === geometry\.rows\) \{\n\s*return;/,
+  );
+});
+
 test("embedded terminal route avoids server-importing browser-only xterm values", () => {
   const pageSource = readFileSync(new URL("../../app/embed/terminal/[id]/page.tsx", import.meta.url), "utf8");
   const terminalSource = readFileSync(new URL("./IframeTerminalPage.tsx", import.meta.url), "utf8");

--- a/packages/web/src/components/sessions/terminal/ttydProtocol.test.ts
+++ b/packages/web/src/components/sessions/terminal/ttydProtocol.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  encodeTtydHandshakeFrame,
   encodeTtydInputFrame,
   encodeTtydResizeFrame,
   TTYD_CLIENT_COMMAND,
@@ -19,6 +20,15 @@ test("ttyd command directions preserve the shared byte contract", () => {
     resize: 0x31,
     pause: 0x32,
     resume: 0x33,
+  });
+});
+
+test("ttyd handshake is an unprefixed JSON frame", () => {
+  const handshake = encodeTtydHandshakeFrame(120, 40);
+  assert.equal(handshake[0], "{".charCodeAt(0));
+  assert.deepEqual(JSON.parse(new TextDecoder().decode(handshake)), {
+    columns: 120,
+    rows: 40,
   });
 });
 

--- a/packages/web/src/components/sessions/terminal/ttydProtocol.ts
+++ b/packages/web/src/components/sessions/terminal/ttydProtocol.ts
@@ -11,6 +11,10 @@ export const TTYD_CLIENT_COMMAND = Object.freeze({
   resume: "3".charCodeAt(0),
 });
 
+export function encodeTtydHandshakeFrame(cols: number, rows: number): Uint8Array<ArrayBuffer> {
+  return new TextEncoder().encode(JSON.stringify({ columns: cols, rows }));
+}
+
 export function encodeTtydResizeFrame(cols: number, rows: number): Uint8Array<ArrayBuffer> {
   const payload = new TextEncoder().encode(JSON.stringify({ columns: cols, rows }));
   const frame = new Uint8Array(payload.length + 1);


### PR DESCRIPTION
## User-Facing Release Notes

- Agent terminals now restore their retained screen when opened through a paired cloud bridge instead of appearing blank.
- Terminal reconnects no longer flood the relay with duplicate resize messages.

## Summary

- send the required ttyd JSON handshake before resize/input frames
- retain browser handshake frames when the browser connects before the bridge proxy
- add structured launch-manager, runtime, terminal token, WebSocket, relay, and bridge lifecycle diagnostics without logging prompts, terminal content, or credentials
- make relay queue-forward failures explicit and close corrupted streams so the browser can reconnect cleanly

## Testing

- `cargo check -p conductor-server -p conductor-relay`
- `cargo clippy -p conductor-server -p conductor-relay -- -D warnings`
- `cargo test -p conductor-relay`
- `cargo test -p conductor-server routes::terminal::tests::`
- `go test ./relay/...` from `bridge-cmd`
- root `bun run typecheck`
- web test suite: 261 passed
- live late-attach probe against v0.61.17: retained terminal output replayed after the corrected handshake

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved terminal connection reliability by preserving and replaying browser handshakes and buffered messages during delayed attachments.
  * Reduced redundant terminal resize messages during WebSocket startup.
  * Improved handling and reporting of full or closed terminal queues.

* **Observability**
  * Added detailed lifecycle information for terminal connections, session launches, backend attachments, retries, closures, and failures.
  * Added terminal traffic, timing, readiness, buffering, and launch status metrics to logs.

* **Tests**
  * Added coverage for handshake delivery, geometry tracking, and replay behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->