### PR TITLE
fix(preview): restore sandboxed screenshots

### DIFF
--- a/packages/web/src/lib/previewWorkerClient.test.ts
+++ b/packages/web/src/lib/previewWorkerClient.test.ts
@@ -97,6 +97,47 @@ test("runCommand creates a remote session and posts the command to the worker", 
   assert.ok(calls.some((c) => c.includes("POST") && c.includes("/sessions/remote-1/command")));
 });
 
+test("destroySession omits the JSON content type when deleting a worker session", async () => {
+  env.CONDUCTOR_PREVIEW_WORKER_URL = "http://127.0.0.1:3099";
+  env.CONDUCTOR_PREVIEW_WORKER_KEY = "unit-test-key";
+
+  let deleteRequest: RequestInit | undefined;
+  global.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" || input instanceof URL ? String(input) : input.url;
+
+    if (url.endsWith("/sessions") && init?.method === "POST") {
+      return new Response(JSON.stringify({ sessionId: "remote-delete-1" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (url.endsWith("/sessions/remote-delete-1/command")) {
+      return new Response(JSON.stringify({ kind: "status", connected: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (url.endsWith("/sessions/remote-delete-1") && init?.method === "DELETE") {
+      deleteRequest = init;
+      return new Response(null, { status: 204 });
+    }
+
+    return new Response("unexpected", { status: 500 });
+  }) as typeof fetch;
+
+  const client = getPreviewWorkerClient();
+  await client.runCommand("session-delete", { command: "reload" });
+  await client.destroySession("session-delete");
+
+  assert.ok(deleteRequest);
+  const headers = new Headers(deleteRequest.headers);
+  assert.equal(headers.get("Authorization"), "Bearer unit-test-key");
+  assert.equal(headers.get("Content-Type"), null);
+  assert.equal(deleteRequest.body, undefined);
+});
+
 
 test("configureBridgePreview forwards bridge relay metadata when creating a remote session", async () => {
   env.CONDUCTOR_PREVIEW_WORKER_URL = "http://127.0.0.1:3099";

--- a/packages/web/src/lib/previewWorkerClient.ts
+++ b/packages/web/src/lib/previewWorkerClient.ts
@@ -123,7 +123,7 @@ class PreviewWorkerClient implements PreviewBrowserManagerClient {
     try {
       await fetch(`${this.workerUrl}/sessions/${encodeURIComponent(remoteSessionId)}`, {
         method: "DELETE",
-        headers: this.buildHeaders(),
+        headers: this.buildAuthHeaders(),
         cache: "no-store",
       });
     } catch {
@@ -142,7 +142,7 @@ class PreviewWorkerClient implements PreviewBrowserManagerClient {
     try {
       await fetch(`${this.workerUrl}/sessions/${encodeURIComponent(remoteSessionId)}`, {
         method: "DELETE",
-        headers: this.buildHeaders(),
+        headers: this.buildAuthHeaders(),
         cache: "no-store",
       });
     } catch {
@@ -308,8 +308,14 @@ class PreviewWorkerClient implements PreviewBrowserManagerClient {
 
   private buildHeaders(): HeadersInit {
     return {
-      Authorization: `Bearer ${this.workerApiKey}`,
+      ...this.buildAuthHeaders(),
       "Content-Type": "application/json",
+    };
+  }
+
+  private buildAuthHeaders(): HeadersInit {
+    return {
+      Authorization: `Bearer ${this.workerApiKey}`,
     };
   }
 

--- a/preview-worker/Dockerfile
+++ b/preview-worker/Dockerfile
@@ -1,6 +1,9 @@
 FROM oven/bun:1.3.11-alpine@sha256:7ed9f74c326d1c260abe247ac423ccbf5ac92af62bb442d515d1f92f21e8ea9b AS bun-bin
 
-FROM node:22-alpine@sha256:ab07539e0988b63558ff621f5fbe1077054c39d9809112974fb79993949d41cd
+# Alpine 3.24's Chromium 150 aborts its sandboxed GPU process on pwritev2
+# while capturing screenshots. Keep the supported 3.23 line pinned until the
+# upstream Chromium sandbox policy includes that syscall.
+FROM node:22-alpine3.23@sha256:8516dce0483394d5708d4b2ee6cacb79fb1d617ea4e2787c2120bcca92ce372e
 
 ARG TARGETARCH
 ARG CONDUCTOR_BUILD_SHA=unknown
@@ -14,7 +17,7 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 RUN apk add --no-cache \
     ca-certificates \
-    chromium \
+    chromium=149.0.7827.53-r0 \
     harfbuzz \
     libgcc \
     libstdc++ \

--- a/preview-worker/src/browser/BrowserManager.test.ts
+++ b/preview-worker/src/browser/BrowserManager.test.ts
@@ -51,6 +51,7 @@ function config(overrides: Partial<PreviewWorkerConfig> = {}): PreviewWorkerConf
 function fakeBrowser(options: {
   url?: string;
   title?: () => Promise<string>;
+  screenshotError?: Error;
   newPageError?: Error;
 } = {}) {
   const pageEvents = new EventEmitter();
@@ -89,12 +90,21 @@ function fakeBrowser(options: {
       detach: async () => {},
     }),
     isClosed: () => pageClosed,
+    screenshot: async () => {
+      if (options.screenshotError) {
+        pageClosed = true;
+        pageEvents.emit("close");
+        throw options.screenshotError;
+      }
+      return Buffer.from("png");
+    },
     close: async () => {
       pageClosed = true;
       pageEvents.emit("close");
     },
   } as unknown as Page;
   const browser = {
+    connected: true,
     newPage: async () => {
       if (options.newPageError) throw options.newPageError;
       return page;
@@ -369,5 +379,25 @@ test("a timed-out command poisons and closes its session before queued work can 
   assert.equal(store.get(session.id), undefined);
 
   titleGate.resolve("late result");
+  await manager.close();
+});
+
+test("a command that loses its browser target releases the preview session", async () => {
+  const fake = fakeBrowser({
+    url: "https://preview.example/",
+    screenshotError: new Error("Protocol error (Page.captureScreenshot): Target closed"),
+  });
+  const store = new SessionStore(60_000);
+  const manager = new BrowserManager(config(), store, async () => fake.browser);
+  const session = await manager.createSession("key-a", { clientSessionId: "client-1" });
+
+  await assert.rejects(
+    manager.executeCommand(session.id, { command: "screenshot" }),
+    /Target closed/,
+  );
+  assert.equal(fake.pageClosed(), true);
+  assert.equal(fake.browserClosed(), true);
+  assert.equal(store.get(session.id), undefined);
+
   await manager.close();
 });

--- a/preview-worker/src/browser/BrowserManager.ts
+++ b/preview-worker/src/browser/BrowserManager.ts
@@ -683,8 +683,12 @@ export class BrowserManager {
       try {
         return await this.withTimeout(operation, this.config.chromeCommandTimeoutMs);
       } catch (error) {
-        if (error instanceof PreviewWorkerError && error.statusCode === 408) {
+        const timedOut = error instanceof PreviewWorkerError && error.statusCode === 408;
+        const browserTargetClosed = session.page.isClosed() || session.browser.connected === false;
+        if (timedOut) {
           session.lastError = error.message;
+        }
+        if (timedOut || browserTargetClosed) {
           await this.destroySessionInternal(session);
         }
         throw error;
@@ -886,6 +890,11 @@ export class BrowserManager {
 
     if (session.status === "closing") {
       throw this.error(404, `Preview session ${sessionId} is closing.`);
+    }
+
+    if (session.page.isClosed() || session.browser.connected === false) {
+      await this.destroySessionInternal(session);
+      throw this.error(404, `Preview session ${sessionId} browser target is unavailable.`);
     }
 
     if (this.sessionStore.isExpired(session)) {

--- a/scripts/conductor-preview-deploy-host.sh
+++ b/scripts/conductor-preview-deploy-host.sh
@@ -189,46 +189,66 @@ if [ "$healthy" -ne 1 ]; then
   exit 1
 fi
 
-session_json=$(run_docker exec "$container_name" node -e '
+run_docker exec -e PREVIEW_SMOKE_URL="$public_health_url" "$container_name" node -e '
 const fail = (error) => {
   console.error(error instanceof Error ? error.message : String(error));
   process.exit(1);
 };
-fetch("http://127.0.0.1:3099/sessions", {
-  method: "POST",
-  headers: {
-    Authorization: `Bearer ${process.env.WORKER_API_KEY}`,
-    "Content-Type": "application/json",
-  },
-  body: "{}",
-  signal: AbortSignal.timeout(30_000),
-})
-  .then(async (response) => {
-    const body = await response.text();
-    if (!response.ok) throw new Error(`session launch failed (${response.status}): ${body}`);
-    process.stdout.write(body);
-  })
-  .catch(fail);
-')
-session_id=$(jq -r '.sessionId // empty' <<< "$session_json")
-if [ -z "$session_id" ]; then
-  echo "New preview worker could not launch a sandboxed browser session." >&2
-  exit 1
-fi
-run_docker exec -e PREVIEW_SMOKE_SESSION_ID="$session_id" "$container_name" node -e '
-const fail = (error) => {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
+const workerUrl = "http://127.0.0.1:3099";
+const authHeaders = { Authorization: `Bearer ${process.env.WORKER_API_KEY}` };
+const jsonHeaders = { ...authHeaders, "Content-Type": "application/json" };
+let sessionId = null;
+let smokeCompleted = false;
+
+const requestJson = async (path, body) => {
+  const response = await fetch(`${workerUrl}${path}`, {
+    method: "POST",
+    headers: jsonHeaders,
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(30_000),
+  });
+  const payload = await response.json();
+  if (!response.ok || payload.kind === "error") {
+    throw new Error(`preview smoke request failed (${response.status}): ${JSON.stringify(payload)}`);
+  }
+  return payload;
 };
-fetch(`http://127.0.0.1:3099/sessions/${encodeURIComponent(process.env.PREVIEW_SMOKE_SESSION_ID)}`, {
-  method: "DELETE",
-  headers: { Authorization: `Bearer ${process.env.WORKER_API_KEY}` },
-  signal: AbortSignal.timeout(10_000),
-})
-  .then(async (response) => {
-    if (!response.ok) throw new Error(`session cleanup failed (${response.status}): ${await response.text()}`);
-  })
-  .catch(fail);
+
+(async () => {
+  try {
+    const created = await requestJson("/sessions", {});
+    sessionId = created.sessionId;
+    if (!sessionId) throw new Error("preview smoke session did not return an id");
+
+    const connected = await requestJson(`/sessions/${encodeURIComponent(sessionId)}/command`, {
+      command: "connect",
+      url: process.env.PREVIEW_SMOKE_URL,
+    });
+    if (!connected.connected || connected.currentUrl !== process.env.PREVIEW_SMOKE_URL) {
+      throw new Error(`preview smoke navigation failed: ${JSON.stringify(connected)}`);
+    }
+
+    const screenshot = await requestJson(`/sessions/${encodeURIComponent(sessionId)}/command`, {
+      command: "screenshot",
+    });
+    const image = Buffer.from(screenshot.imageBase64 || "", "base64");
+    if (image.length < 100 || image.subarray(0, 8).toString("hex") !== "89504e470d0a1a0a") {
+      throw new Error("preview smoke screenshot did not return a valid PNG");
+    }
+    smokeCompleted = true;
+  } finally {
+    if (sessionId) {
+      const response = await fetch(`${workerUrl}/sessions/${encodeURIComponent(sessionId)}`, {
+        method: "DELETE",
+        headers: authHeaders,
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!response.ok && !(response.status === 404 && !smokeCompleted)) {
+        throw new Error(`preview smoke cleanup failed (${response.status}): ${await response.text()}`);
+      }
+    }
+  }
+})().catch(fail);
 ' >/dev/null
 
 upstream_health=$(run_docker exec clawcloud-caddy-1 \


### PR DESCRIPTION
## Summary

- restore sandboxed preview screenshots by pinning the worker to the validated Alpine 3.23 / Chromium 149 runtime
- release dead browser sessions immediately and send bodyless worker DELETE requests without a JSON content type
- make production rollout prove navigation and a valid PNG screenshot before replacing the rollback container

## User-Facing Release Notes

- Preview sessions can once again load paired local applications, inspect and interact with the page, navigate, and capture screenshots reliably.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Test Plan

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `go build ./... && go vet ./... && go test ./...` in `bridge-cmd`
- `bun run build:frontend`
- `bun run typecheck`
- `bun run test:packages`
- `bash -n scripts/conductor-preview-deploy-host.sh`
- `shellcheck scripts/conductor-preview-deploy-host.sh`
- production-shaped Docker validation with read-only rootfs, dropped capabilities, Chromium sandbox enabled, production relay, paired bridge, local preview navigation, DOM inspection, input/click, second-page navigation, and PNG screenshot

## Backward Compatibility

No API or configuration changes. Existing preview worker credentials, relay pairing, and dashboard clients continue to work.

## Screenshots / Logs

Production-shaped E2E result: connected, first page title and DOM verified, 15,327-byte PNG captured, input/click succeeded, second-page marker verified, and the worker session was cleaned up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved preview session handling when browser targets close or connections are lost.
  - Sessions are now cleaned up automatically after browser failures and command timeouts.
  - Improved session deletion requests for more reliable cleanup.

- **Reliability**
  - Enhanced preview deployment smoke tests to verify browser connections and valid PNG screenshots.
  - Preview services now use a pinned browser environment to improve screenshot consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->