### PR TITLE
fix(preview): bound browser teardown

### DIFF
--- a/preview-worker/src/browser/BrowserManager.test.ts
+++ b/preview-worker/src/browser/BrowserManager.test.ts
@@ -53,12 +53,17 @@ function fakeBrowser(options: {
   title?: () => Promise<string>;
   screenshotError?: Error;
   newPageError?: Error;
+  pageClose?: () => Promise<void>;
+  browserClose?: () => Promise<void>;
 } = {}) {
   const pageEvents = new EventEmitter();
   const cdpEvents = new EventEmitter();
   const cdpCommands: Array<{ method: string; params?: unknown }> = [];
   let pageClosed = false;
   let browserClosed = false;
+  let browserConnected = true;
+  let browserDisconnected = false;
+  let browserProcessKilled = false;
   const frame = {
     name: () => "",
     url: () => options.url ?? "about:blank",
@@ -99,18 +104,39 @@ function fakeBrowser(options: {
       return Buffer.from("png");
     },
     close: async () => {
+      if (options.pageClose) {
+        await options.pageClose();
+      }
       pageClosed = true;
       pageEvents.emit("close");
     },
   } as unknown as Page;
   const browser = {
-    connected: true,
+    get connected() {
+      return browserConnected;
+    },
     newPage: async () => {
       if (options.newPageError) throw options.newPageError;
       return page;
     },
     close: async () => {
+      if (options.browserClose) {
+        await options.browserClose();
+      }
       browserClosed = true;
+      browserConnected = false;
+    },
+    process: () => ({
+      kill: () => {
+        browserProcessKilled = true;
+        browserClosed = true;
+        browserConnected = false;
+        return true;
+      },
+    }),
+    disconnect: () => {
+      browserDisconnected = true;
+      browserConnected = false;
     },
   } as unknown as Browser;
 
@@ -119,6 +145,8 @@ function fakeBrowser(options: {
     page,
     pageClosed: () => pageClosed,
     browserClosed: () => browserClosed,
+    browserDisconnected: () => browserDisconnected,
+    browserProcessKilled: () => browserProcessKilled,
     cdpCommands,
     emitCdp: (name: string, payload: unknown) => cdpEvents.emit(name, payload),
   };
@@ -398,6 +426,47 @@ test("a command that loses its browser target releases the preview session", asy
   assert.equal(fake.pageClosed(), true);
   assert.equal(fake.browserClosed(), true);
   assert.equal(store.get(session.id), undefined);
+
+  await manager.close();
+});
+
+test("browser teardown is bounded when Chromium does not close gracefully", async () => {
+  const never = new Promise<void>(() => {});
+  const fake = fakeBrowser({ pageClose: async () => await never });
+  const store = new SessionStore(60_000);
+  const manager = new BrowserManager(
+    config({ chromeCommandTimeoutMs: 20 }),
+    store,
+    async () => fake.browser,
+  );
+  const session = await manager.createSession("key-a", { clientSessionId: "client-1" });
+
+  const startedAt = Date.now();
+  await manager.destroySession(session.id);
+
+  assert.ok(Date.now() - startedAt < 500);
+  assert.equal(store.get(session.id), undefined);
+  assert.equal(fake.browserProcessKilled(), true);
+  assert.equal(fake.browserDisconnected(), true);
+
+  await manager.close();
+});
+
+test("browser teardown forces a still-connected process after close rejects", async () => {
+  const fake = fakeBrowser({
+    browserClose: async () => {
+      throw new Error("browser close failed");
+    },
+  });
+  const store = new SessionStore(60_000);
+  const manager = new BrowserManager(config(), store, async () => fake.browser);
+  const session = await manager.createSession("key-a", { clientSessionId: "client-1" });
+
+  await manager.destroySession(session.id);
+
+  assert.equal(store.get(session.id), undefined);
+  assert.equal(fake.browserProcessKilled(), true);
+  assert.equal(fake.browserDisconnected(), true);
 
   await manager.close();
 });

--- a/preview-worker/src/browser/BrowserManager.ts
+++ b/preview-worker/src/browser/BrowserManager.ts
@@ -47,6 +47,7 @@ const CLEANUP_INTERVAL_MS = 30_000;
 const MAX_DIRECT_RESPONSE_BYTES = 25 * 1024 * 1024;
 const MAX_INTERCEPTED_REQUEST_BODY_BYTES = 8 * 1024 * 1024;
 const MAX_BRIDGE_RESPONSE_PAYLOAD_BYTES = 36 * 1024 * 1024;
+const MAX_BROWSER_TEARDOWN_TIMEOUT_MS = 5_000;
 export const MAX_CONCURRENT_PREVIEW_REQUESTS = 32;
 export const MAX_BUFFERED_PREVIEW_BYTES = 64 * 1024 * 1024;
 export const BLOCKED_BROWSER_NETWORK_URL_PATTERNS = [
@@ -1311,18 +1312,43 @@ export class BrowserManager {
 
     const destruction = (async () => {
       session.status = "closing";
-      await stopTunnel(session.tunnelProcess);
-
-      try {
+      const gracefulTeardown = (async () => {
+        await stopTunnel(session.tunnelProcess).catch(() => {});
         await session.networkGuardSession?.detach().catch(() => {});
         session.networkGuardSession = null;
         if (!session.page.isClosed()) {
           await session.page.close().catch(() => {});
         }
-      } finally {
         await session.browser.close().catch(() => {});
-        this.sessionStore.delete(session.id);
+      })();
+      const teardownTimeoutMs = Math.max(
+        1,
+        Math.min(this.config.chromeCommandTimeoutMs, MAX_BROWSER_TEARDOWN_TIMEOUT_MS),
+      );
+      let timeoutId: NodeJS.Timeout | null = null;
+      const timedOut = await Promise.race([
+        gracefulTeardown.then(() => false),
+        new Promise<boolean>((resolve) => {
+          timeoutId = setTimeout(() => resolve(true), teardownTimeoutMs);
+          timeoutId.unref();
+        }),
+      ]);
+      if (timeoutId) {
+        clearTimeout(timeoutId);
       }
+      if (timedOut || session.browser.connected) {
+        try {
+          session.browser.process()?.kill("SIGKILL");
+        } catch {
+          // The browser may already have exited while teardown was timing out.
+        }
+        try {
+          session.browser.disconnect();
+        } catch {
+          // The browser may already be disconnected after a forced process exit.
+        }
+      }
+      this.sessionStore.delete(session.id);
     })();
     this.sessionDestructions.set(session.id, destruction);
 

--- a/preview-worker/src/browser/BrowserManager.ts
+++ b/preview-worker/src/browser/BrowserManager.ts
@@ -1330,7 +1330,6 @@ export class BrowserManager {
         gracefulTeardown.then(() => false),
         new Promise<boolean>((resolve) => {
           timeoutId = setTimeout(() => resolve(true), teardownTimeoutMs);
-          timeoutId.unref();
         }),
       ]);
       if (timeoutId) {


### PR DESCRIPTION
## Summary

- cap preview browser teardown at five seconds when Chromium page or browser close calls stop responding
- force-kill and disconnect a still-connected Chromium process after timeout or close failure
- release the worker session slot after bounded cleanup so failed paired-preview requests cannot exhaust capacity

## User-Facing Release Notes

- Failed preview connections now clean up their browser session reliably instead of leaving a worker slot occupied.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Test Plan

- `bun run --cwd preview-worker test` (49 passed)
- `bun run --cwd preview-worker build`
- `bun run typecheck`
- `bun run test:packages`
- `bun run build:frontend`
- `cargo fmt --all -- --check`
- production-shaped hardened container probe with an intentionally invalid paired-relay token: navigation returned the expected 500, DELETE returned 204 in 280 ms, and worker sessions returned to zero

## Backward Compatibility

No API or configuration changes. Graceful browser shutdown remains the first path; forced termination is only used when Chromium remains connected after close or exceeds the teardown deadline.
