### PR TITLE
fix(preview): recover local browser sessions

### DIFF
--- a/packages/web/src/lib/devPreviewBrowser.test.ts
+++ b/packages/web/src/lib/devPreviewBrowser.test.ts
@@ -6,6 +6,7 @@ import type { Page } from "puppeteer-core";
 import {
   MAX_BUFFERED_PREVIEW_BYTES,
   MAX_CONCURRENT_PREVIEW_REQUESTS,
+  PreviewBrowserManager,
   assertSafeDirectNavigationTarget,
   beginPreviewInterception,
   buildPinnedRequestOptions,
@@ -14,9 +15,63 @@ import {
   isPrivateNetworkHostname,
   requestSafeDirectNavigation,
   retainDirectLoopbackOrigin,
+  resolvePreviewNavigationCapabilities,
   resolveSafeDirectNavigationTarget,
   resolvePreviewNavigationMode,
 } from "./devPreviewBrowser";
+
+test("preview history excludes Chromium's initial about:blank entry", () => {
+  assert.deepEqual(resolvePreviewNavigationCapabilities(1, [
+    { url: "about:blank" },
+    { url: "http://127.0.0.1:3000/" },
+  ]), {
+    canGoBack: false,
+    canGoForward: false,
+  });
+
+  assert.deepEqual(resolvePreviewNavigationCapabilities(1, [
+    { url: "http://127.0.0.1:3000/" },
+    { url: "http://127.0.0.1:3000/second" },
+    { url: "http://127.0.0.1:3000/third" },
+  ]), {
+    canGoBack: true,
+    canGoForward: true,
+  });
+});
+
+test("preview browser manager relaunches after Chromium disconnects", async () => {
+  const browsers: Array<EventEmitter & { connected: boolean }> = [];
+  const manager = new PreviewBrowserManager(async () => {
+    const browser = Object.assign(new EventEmitter(), { connected: true });
+    browsers.push(browser);
+    return browser as never;
+  });
+  const getBrowser = (manager as unknown as { getBrowser(): Promise<{ connected: boolean }> }).getBrowser.bind(manager);
+
+  const first = await getBrowser();
+  assert.equal(browsers.length, 1);
+  browsers[0]!.connected = false;
+  browsers[0]!.emit("disconnected");
+
+  const second = await getBrowser();
+  assert.equal(browsers.length, 2);
+  assert.notEqual(second, first);
+});
+
+test("preview browser manager retries after a launch failure", async () => {
+  let launches = 0;
+  const browser = Object.assign(new EventEmitter(), { connected: true });
+  const manager = new PreviewBrowserManager(async () => {
+    launches += 1;
+    if (launches === 1) throw new Error("launch failed");
+    return browser as never;
+  });
+  const getBrowser = (manager as unknown as { getBrowser(): Promise<{ connected: boolean }> }).getBrowser.bind(manager);
+
+  await assert.rejects(getBrowser(), /launch failed/);
+  assert.equal(await getBrowser(), browser);
+  assert.equal(launches, 2);
+});
 
 test("browser network guard blocks WebSocket and non-HTTP network schemes below the page", async () => {
   const events = new EventEmitter();
@@ -160,7 +215,13 @@ test("direct preview requests enforce an absolute deadline against slow-drip res
     for (const interval of intervals) clearInterval(interval);
     server.closeAllConnections();
     await new Promise<void>((resolve, reject) => {
-      server.close((error) => error ? reject(error) : resolve());
+      server.close((error) => {
+        if (!error || (error as NodeJS.ErrnoException).code === "ERR_SERVER_NOT_RUNNING") {
+          resolve();
+          return;
+        }
+        reject(error);
+      });
     });
   }
 });

--- a/packages/web/src/lib/devPreviewBrowser.ts
+++ b/packages/web/src/lib/devPreviewBrowser.ts
@@ -669,25 +669,102 @@ function normalizeText(value: string | null | undefined): string {
   return (value ?? "").replace(/\s+/g, " ").trim();
 }
 
-class PreviewBrowserManager {
+export interface PreviewNavigationHistoryEntry {
+  url?: string | null;
+}
+
+export function resolvePreviewNavigationCapabilities(
+  currentIndex: number,
+  entries: PreviewNavigationHistoryEntry[],
+): { canGoBack: boolean; canGoForward: boolean } {
+  const isUsableEntry = (entry: PreviewNavigationHistoryEntry | undefined): boolean => {
+    const url = entry?.url?.trim();
+    return Boolean(url && url !== "about:blank");
+  };
+
+  return {
+    canGoBack: currentIndex > 0 && isUsableEntry(entries[currentIndex - 1]),
+    canGoForward: currentIndex >= 0
+      && currentIndex < entries.length - 1
+      && isUsableEntry(entries[currentIndex + 1]),
+  };
+}
+
+export type PreviewBrowserLauncher = () => Promise<Browser>;
+
+function launchSystemPreviewBrowser(): Promise<Browser> {
+  return puppeteer.launch({
+    headless: true,
+    executablePath: resolveChromePath(),
+    defaultViewport: VIEWPORT,
+    args: [
+      "--disable-dev-shm-usage",
+      "--disable-background-networking",
+      "--no-first-run",
+      "--no-default-browser-check",
+    ],
+  });
+}
+
+export class PreviewBrowserManager {
   private browserPromise: Promise<Browser> | null = null;
   private states = new Map<string, PreviewState>();
 
-  private async getBrowser(): Promise<Browser> {
-    if (!this.browserPromise) {
-      this.browserPromise = puppeteer.launch({
-        headless: true,
-        executablePath: resolveChromePath(),
-        defaultViewport: VIEWPORT,
-        args: [
-          "--disable-dev-shm-usage",
-          "--disable-background-networking",
-          "--no-first-run",
-          "--no-default-browser-check",
-        ],
-      });
+  constructor(private readonly launchBrowser: PreviewBrowserLauncher = launchSystemPreviewBrowser) {}
+
+  private resetDisconnectedBrowserStates(): void {
+    for (const state of this.states.values()) {
+      state.context = null;
+      state.page = null;
+      state.networkGuardSession = null;
+      state.requestInterceptionEnabled = false;
+      state.activeFrameId = null;
+      state.selectedElement = null;
+      state.navigationMode = "direct";
+      state.directLoopbackOrigin = null;
+      state.interceptionBudget = { activeRequests: 0, bufferedBytes: 0 };
+      state.lastError = "Preview browser disconnected. Connect again to relaunch it.";
     }
-    return this.browserPromise;
+  }
+
+  private beginBrowserLaunch(): Promise<Browser> {
+    const launchPromise = this.launchBrowser();
+    this.browserPromise = launchPromise;
+
+    void launchPromise.then((browser) => {
+      browser.once("disconnected", () => {
+        if (this.browserPromise !== launchPromise) return;
+        this.browserPromise = null;
+        this.resetDisconnectedBrowserStates();
+      });
+
+      if (!browser.connected) {
+        if (this.browserPromise === launchPromise) {
+          this.browserPromise = null;
+        }
+        this.resetDisconnectedBrowserStates();
+      }
+    }).catch(() => {
+      if (this.browserPromise === launchPromise) {
+        this.browserPromise = null;
+      }
+    });
+
+    return launchPromise;
+  }
+
+  private async getBrowser(): Promise<Browser> {
+    while (true) {
+      const browserPromise = this.browserPromise ?? this.beginBrowserLaunch();
+      const browser = await browserPromise;
+      if (browser.connected) {
+        return browser;
+      }
+      if (this.browserPromise === browserPromise) {
+        this.browserPromise = null;
+        this.resetDisconnectedBrowserStates();
+      }
+    }
   }
 
   private getState(sessionId: string): PreviewState {
@@ -1017,6 +1094,7 @@ class PreviewBrowserManager {
       }
     });
     page.on("close", () => {
+      if (this.states.get(state.sessionId)?.page !== page) return;
       void this.destroySession(state.sessionId, { closePage: false });
     });
   }
@@ -1528,14 +1606,18 @@ class PreviewBrowserManager {
       const root = document.body ?? document.documentElement;
       const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
       const results = [];
-      let visited = 0;
+      let truncated = false;
 
       while (walker.nextNode()) {
-        visited += 1;
         const element = walker.currentNode;
         if (!(element instanceof Element)) continue;
         const interactive = isInteractive(element);
         if (onlyInteractive && !interactive) continue;
+
+        if (results.length >= limit) {
+          truncated = true;
+          break;
+        }
 
         const text = normalize(element.textContent).slice(0, 220);
         const rect = element.getBoundingClientRect();
@@ -1556,14 +1638,11 @@ class PreviewBrowserManager {
             height: rect.height,
           },
         });
-        if (results.length >= limit) {
-          break;
-        }
       }
 
       return {
         nodes: results,
-        truncated: results.length >= limit || visited > results.length,
+        truncated,
       };
     }, { interactiveOnly, limit: DOM_NODE_LIMIT });
 
@@ -1596,12 +1675,9 @@ class PreviewBrowserManager {
       cdpSession = await page.createCDPSession();
       const history = await cdpSession.send("Page.getNavigationHistory") as {
         currentIndex: number;
-        entries: Array<unknown>;
+        entries: PreviewNavigationHistoryEntry[];
       };
-      return {
-        canGoBack: history.currentIndex > 0,
-        canGoForward: history.currentIndex < history.entries.length - 1,
-      };
+      return resolvePreviewNavigationCapabilities(history.currentIndex, history.entries);
     } catch {
       return {
         canGoBack: false,


### PR DESCRIPTION
## Summary

- recover local Preview sessions after the managed Chromium process disconnects or fails to launch
- prevent stale page-close events from tearing down a newly recovered Preview page
- report accurate initial navigation history and DOM inspector truncation state

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo build --workspace --release`
- `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2024-0384 --ignore RUSTSEC-2026-0008 --ignore RUSTSEC-2026-0097`
- `go test ./...` and `go vet ./...` in `bridge-cmd`
- `bun run typecheck`
- `bun run test:packages`
- `bun run build:frontend`
- `bun audit --audit-level=high`
- `node scripts/verify-cli-package.mjs`
- real local and installed-artifact browser recovery smoke tests

## User-Facing Release Notes

- Local Preview now recovers automatically when its managed browser process disconnects or its first launch fails.
- Preview navigation buttons no longer treat Chromium's initial blank page as real browsing history.
- The Preview DOM inspector now reports truncation only when matching results actually exceed its result limit.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview browser recovery after unexpected disconnections and initial launch failures.
  * Corrected back and forward navigation availability for Chromium preview sessions.
  * Prevented unrelated page closures from ending the active preview session.
  * Improved DOM inspection truncation reporting.
* **Tests**
  * Added coverage for navigation history, browser relaunches, launch retries, and server cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->