### PR TITLE
fix: recover projects after bridge outages

### DIFF
--- a/bridge-cmd/relay/client.go
+++ b/bridge-cmd/relay/client.go
@@ -710,7 +710,10 @@ func runSession(ctx context.Context, opts sessionOptions) (bool, error) {
 			return true, nil
 		case err := <-errCh:
 			stopTtyd()
-			return false, err
+			// The relay handshake and initial status message already succeeded.
+			// Report that this attempt connected so Run resets exponential
+			// backoff before retrying a dropped long-lived session.
+			return true, err
 		case <-heartbeat.C:
 			if err := send(bridgeEnvelope{
 				Type:      "bridge_status",
@@ -720,14 +723,14 @@ func runSession(ctx context.Context, opts sessionOptions) (bool, error) {
 				Version:   opts.version,
 			}); err != nil {
 				stopTtyd()
-				return false, fmt.Errorf("send bridge_status: %w", err)
+				return true, fmt.Errorf("send bridge_status: %w", err)
 			}
 			relayMu.Lock()
 			err := relayConn.WriteControl(websocket.PingMessage, []byte("ping"), time.Now().Add(2*time.Second))
 			relayMu.Unlock()
 			if err != nil {
 				stopTtyd()
-				return false, fmt.Errorf("relay ping: %w", err)
+				return true, fmt.Errorf("relay ping: %w", err)
 			}
 		}
 	}

--- a/bridge-cmd/relay/client_test.go
+++ b/bridge-cmd/relay/client_test.go
@@ -70,7 +70,9 @@ func TestRunSessionReportsEstablishedConnectionAfterRelayDrops(t *testing.T) {
 	}))
 	defer server.Close()
 
-	connected, err := runSession(context.Background(), sessionOptions{
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	connected, err := runSession(ctx, sessionOptions{
 		relayURL:          server.URL,
 		refreshToken:      "refresh-token",
 		scope:             "device-123",
@@ -80,8 +82,13 @@ func TestRunSessionReportsEstablishedConnectionAfterRelayDrops(t *testing.T) {
 		stderr:            io.Discard,
 		heartbeatInterval: time.Hour,
 	})
-	if serverErr := <-serverErr; serverErr != nil {
-		t.Fatalf("relay test server failed: %v", serverErr)
+	select {
+	case serverErr := <-serverErr:
+		if serverErr != nil {
+			t.Fatalf("relay test server failed: %v", serverErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("relay test server did not complete the handshake")
 	}
 	if !connected {
 		t.Fatal("runSession reported an unestablished attempt after completing the relay handshake")

--- a/bridge-cmd/relay/client_test.go
+++ b/bridge-cmd/relay/client_test.go
@@ -1,14 +1,17 @@
 package relay
 
 import (
+	"context"
 	"encoding/base64"
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gorilla/websocket"
 )
@@ -43,6 +46,48 @@ func TestTerminalBridgeEndpointOmitsTokenQuery(t *testing.T) {
 	}
 	if endpoint != "wss://relay.example.com/terminal/terminal-123/bridge" {
 		t.Fatalf("endpoint = %q", endpoint)
+	}
+}
+
+func TestRunSessionReportsEstablishedConnectionAfterRelayDrops(t *testing.T) {
+	t.Setenv(legacyTTYDMirrorEnv, "")
+
+	serverErr := make(chan error, 1)
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		defer conn.Close()
+
+		if _, _, err := conn.ReadMessage(); err != nil {
+			serverErr <- err
+			return
+		}
+		serverErr <- nil
+	}))
+	defer server.Close()
+
+	connected, err := runSession(context.Background(), sessionOptions{
+		relayURL:          server.URL,
+		refreshToken:      "refresh-token",
+		scope:             "device-123",
+		hostname:          "test-host",
+		osName:            "test-os",
+		version:           "test-version",
+		stderr:            io.Discard,
+		heartbeatInterval: time.Hour,
+	})
+	if serverErr := <-serverErr; serverErr != nil {
+		t.Fatalf("relay test server failed: %v", serverErr)
+	}
+	if !connected {
+		t.Fatal("runSession reported an unestablished attempt after completing the relay handshake")
+	}
+	if err == nil {
+		t.Fatal("runSession returned nil error after the relay dropped the connection")
 	}
 }
 

--- a/crates/conductor-cli/src/bridge.rs
+++ b/crates/conductor-cli/src/bridge.rs
@@ -56,9 +56,9 @@ struct PreviewProxyResponse {
     body_base64: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum ConnectionOutcome {
-    Reconnect,
+    Reconnect { error: Option<String> },
     Exit,
 }
 
@@ -779,7 +779,7 @@ async fn run_bridge_connection_once(
             }
             message = inbound.next() => {
                 let Some(message) = message else {
-                    break ConnectionOutcome::Reconnect;
+                    break ConnectionOutcome::Reconnect { error: None };
                 };
                 match message {
                     Ok(Message::Text(text)) => {
@@ -915,9 +915,14 @@ async fn run_bridge_connection_once(
                     Ok(Message::Binary(_)) => {}
                     Ok(Message::Frame(_)) => {}
                     Ok(Message::Close(_)) => {
-                        break ConnectionOutcome::Reconnect;
+                        break ConnectionOutcome::Reconnect { error: None };
                     }
-                    Err(err) => return Err(err.into()),
+                    Err(err) => {
+                        tracing::warn!(error = %err, "bridge relay connection dropped");
+                        break ConnectionOutcome::Reconnect {
+                            error: Some(err.to_string()),
+                        };
+                    }
                 }
             }
         }
@@ -980,11 +985,14 @@ pub async fn connect(relay: String, token: Option<String>) -> Result<()> {
                 clear_state()?;
                 return Ok(());
             }
-            Ok(ConnectionOutcome::Reconnect) => {
+            Ok(ConnectionOutcome::Reconnect { error }) => {
+                // A reconnect outcome means the websocket handshake completed.
+                // Do not carry dial-failure backoff across a healthy session.
+                backoff = Duration::from_secs(1);
                 save_state(&BridgeRuntimeState {
                     relay_url: relay_url.to_string(),
                     connected: false,
-                    last_error: None,
+                    last_error: error,
                     active_session_id: load_state()?.and_then(|state| state.active_session_id),
                     updated_at_unix: unix_timestamp(),
                 })?;

--- a/packages/web/src/components/layout/WorkspaceSidebarPanel.tsx
+++ b/packages/web/src/components/layout/WorkspaceSidebarPanel.tsx
@@ -20,6 +20,7 @@ interface WorkspaceSidebarPanelProps {
   projects: ProjectItem[];
   projectsLoading?: boolean;
   projectsError?: string | null;
+  projectsRecovering?: boolean;
   selectedProjectId: string | null;
   onSelectProject: (projectId: string | null) => void;
   onUnlinkProject?: (projectId: string) => Promise<void>;
@@ -36,6 +37,7 @@ export const WorkspaceSidebarPanel = memo(function WorkspaceSidebarPanel({
   projects,
   projectsLoading = false,
   projectsError = null,
+  projectsRecovering = false,
   selectedProjectId,
   onSelectProject,
   onUnlinkProject,
@@ -151,6 +153,8 @@ export const WorkspaceSidebarPanel = memo(function WorkspaceSidebarPanel({
                 )}
                 aria-label={projectsError && projects.length === 0
                   ? "Projects temporarily unavailable"
+                  : projectsLoading && projects.length === 0
+                    ? "Loading projects"
                   : `${projects.length} projects`}
               >
                 {projectCountLabel}
@@ -163,7 +167,9 @@ export const WorkspaceSidebarPanel = memo(function WorkspaceSidebarPanel({
                 role="status"
                 aria-live="polite"
               >
-                Projects unavailable. Retrying bridge connection…
+                {projectsRecovering
+                  ? "Projects unavailable. Retrying connection…"
+                  : "Projects unavailable. Check the connection and refresh."}
               </p>
             ) : null}
 

--- a/packages/web/src/components/layout/WorkspaceSidebarPanel.tsx
+++ b/packages/web/src/components/layout/WorkspaceSidebarPanel.tsx
@@ -18,6 +18,8 @@ interface ProjectItem {
 
 interface WorkspaceSidebarPanelProps {
   projects: ProjectItem[];
+  projectsLoading?: boolean;
+  projectsError?: string | null;
   selectedProjectId: string | null;
   onSelectProject: (projectId: string | null) => void;
   onUnlinkProject?: (projectId: string) => Promise<void>;
@@ -32,6 +34,8 @@ interface WorkspaceSidebarPanelProps {
 
 export const WorkspaceSidebarPanel = memo(function WorkspaceSidebarPanel({
   projects,
+  projectsLoading = false,
+  projectsError = null,
   selectedProjectId,
   onSelectProject,
   onUnlinkProject,
@@ -64,6 +68,13 @@ export const WorkspaceSidebarPanel = memo(function WorkspaceSidebarPanel({
     () => projects.find((project) => project.id === confirmUnlinkProjectId) ?? null,
     [confirmUnlinkProjectId, projects],
   );
+  const projectCountLabel = projects.length > 0
+    ? String(projects.length)
+    : projectsError
+      ? "!"
+      : projectsLoading
+        ? "…"
+        : "0";
 
   const getProjectDefaultsLabel = (project: ProjectItem): string | null => {
     const parts: string[] = [];
@@ -131,8 +142,30 @@ export const WorkspaceSidebarPanel = memo(function WorkspaceSidebarPanel({
             >
               <span className="h-2.5 w-2.5 rounded-full bg-[var(--vk-text-muted)]" />
               <span className="truncate">All projects</span>
-              <span className="ml-auto text-[11px] text-[var(--vk-text-muted)]">{projects.length}</span>
+              <span
+                className={cn(
+                  "ml-auto text-[11px]",
+                  projectsError && projects.length === 0
+                    ? "text-[var(--vk-red)]"
+                    : "text-[var(--vk-text-muted)]",
+                )}
+                aria-label={projectsError && projects.length === 0
+                  ? "Projects temporarily unavailable"
+                  : `${projects.length} projects`}
+              >
+                {projectCountLabel}
+              </span>
             </button>
+
+            {projectsError && projects.length === 0 ? (
+              <p
+                className="mb-2 px-3 text-[11px] leading-4 text-[var(--vk-text-muted)]"
+                role="status"
+                aria-live="polite"
+              >
+                Projects unavailable. Retrying bridge connection…
+              </p>
+            ) : null}
 
             {projects.map((project) => {
               const selected = selectedProjectId === project.id;

--- a/packages/web/src/features/dashboard/DashboardClient.tsx
+++ b/packages/web/src/features/dashboard/DashboardClient.tsx
@@ -992,7 +992,13 @@ export default function DashboardClient({
     () => !requiresPairedDeviceScope || Boolean(effectiveBridgeId),
     [effectiveBridgeId, requiresPairedDeviceScope],
   );
-  const { projects, loading: configLoading, error: configError, refresh: refreshConfig } = useConfig(effectiveBridgeId, {
+  const {
+    projects,
+    loading: configLoading,
+    error: configError,
+    recovering: configRecovering,
+    refresh: refreshConfig,
+  } = useConfig(effectiveBridgeId, {
     enabled: scopeRequestsEnabled,
   });
   const { agents, loading: agentsLoading } = useAgents(effectiveBridgeId, { enabled: scopeRequestsEnabled });
@@ -2040,6 +2046,7 @@ export default function DashboardClient({
         projects={projects}
         projectsLoading={configLoading}
         projectsError={configError}
+        projectsRecovering={configRecovering}
         selectedProjectId={selectedProjectId}
         onSelectProject={handleSelectProject}
         onUnlinkProject={handleUnlinkProject}
@@ -2054,6 +2061,7 @@ export default function DashboardClient({
     dashboardSessions,
     configError,
     configLoading,
+    configRecovering,
     handleArchiveSession,
     handleSelectProject,
     handleSelectSession,
@@ -2504,6 +2512,7 @@ export default function DashboardClient({
           projects={projects}
           projectsLoading={configLoading}
           projectsError={configError}
+          projectsRecovering={configRecovering}
           sessions={dashboardSessions}
           onCreateWorkspace={openWorkspaceDialog}
           onSelectSession={handleSelectSession}
@@ -2514,6 +2523,7 @@ export default function DashboardClient({
     dashboardSessions,
     configError,
     configLoading,
+    configRecovering,
     mountedSessionIds,
     projectWorkspaceContent,
     selectedSession,

--- a/packages/web/src/features/dashboard/DashboardClient.tsx
+++ b/packages/web/src/features/dashboard/DashboardClient.tsx
@@ -2038,6 +2038,8 @@ export default function DashboardClient({
     return (
       <WorkspaceSidebarPanel
         projects={projects}
+        projectsLoading={configLoading}
+        projectsError={configError}
         selectedProjectId={selectedProjectId}
         onSelectProject={handleSelectProject}
         onUnlinkProject={handleUnlinkProject}
@@ -2050,6 +2052,8 @@ export default function DashboardClient({
     );
   }, [
     dashboardSessions,
+    configError,
+    configLoading,
     handleArchiveSession,
     handleSelectProject,
     handleSelectSession,
@@ -2498,6 +2502,8 @@ export default function DashboardClient({
       <div className="flex h-full min-h-0 w-full flex-1 overflow-hidden">
         <WorkspaceOverview
           projects={projects}
+          projectsLoading={configLoading}
+          projectsError={configError}
           sessions={dashboardSessions}
           onCreateWorkspace={openWorkspaceDialog}
           onSelectSession={handleSelectSession}
@@ -2506,6 +2512,8 @@ export default function DashboardClient({
     );
   }, [
     dashboardSessions,
+    configError,
+    configLoading,
     mountedSessionIds,
     projectWorkspaceContent,
     selectedSession,

--- a/packages/web/src/features/dashboard/components/WorkspaceOverview.tsx
+++ b/packages/web/src/features/dashboard/components/WorkspaceOverview.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from "react";
 import {
+  AlertTriangle,
   FolderGit2,
   FolderKanban,
   GitBranch,
@@ -24,6 +25,7 @@ interface WorkspaceOverviewProps {
   projects: ConfigProject[];
   projectsLoading?: boolean;
   projectsError?: string | null;
+  projectsRecovering?: boolean;
   sessions: DashboardSession[];
   onCreateWorkspace: () => void;
   onSelectSession: (sessionId: string) => void;
@@ -55,6 +57,7 @@ export function WorkspaceOverview({
   projects,
   projectsLoading = false,
   projectsError = null,
+  projectsRecovering = false,
   sessions,
   onCreateWorkspace,
   onSelectSession,
@@ -88,11 +91,13 @@ export function WorkspaceOverview({
 
     return { active, attention, merge };
   }, [visibleSessions]);
-  const showProjectRecovery = projects.length === 0 && Boolean(projectsError);
+  const showProjectRecovery = projects.length === 0 && Boolean(projectsError) && projectsRecovering;
+  const showProjectError = projects.length === 0 && Boolean(projectsError) && !projectsRecovering;
   const showProjectLoading = projects.length === 0 && projectsLoading && !projectsError;
   const showWelcomeState = projects.length === 0
     && visibleSessions.length === 0
     && !showProjectRecovery
+    && !showProjectError
     && !showProjectLoading;
 
   const statCards = [
@@ -102,22 +107,30 @@ export function WorkspaceOverview({
     { label: "Merge ready", value: String(sessionStats.merge), icon: GitBranch, caption: "Cleared to land" },
   ];
 
-  if (showProjectRecovery || showProjectLoading) {
+  if (showProjectRecovery || showProjectError || showProjectLoading) {
     return (
       <div className={`flex h-full min-h-0 w-full flex-col bg-[linear-gradient(180deg,rgba(255,255,255,0.03),rgba(255,255,255,0))] ${APP_SURFACE_SCROLL_CLASS_NAME}`}>
         <div className="flex h-full min-h-0 w-full flex-1 items-center justify-center px-3 py-3 sm:px-4 sm:py-4">
           <Card className="w-full max-w-[680px] border-[var(--vk-border)] bg-[color:color-mix(in_srgb,var(--vk-bg-panel)_88%,transparent)]">
             <CardContent className="flex flex-col items-center px-6 py-10 text-center sm:px-10 sm:py-12">
               <span className="inline-flex h-12 w-12 items-center justify-center rounded-[12px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] text-[var(--vk-text-normal)]">
-                <RefreshCw className="h-5 w-5 animate-spin" aria-hidden="true" />
+                {showProjectError
+                  ? <AlertTriangle className="h-5 w-5" aria-hidden="true" />
+                  : <RefreshCw className="h-5 w-5 animate-spin" aria-hidden="true" />}
               </span>
               <h1 className="mt-5 text-[24px] font-semibold tracking-[-0.035em] text-[var(--vk-text-strong)] sm:text-[30px]">
-                {showProjectRecovery ? "Reconnecting to your paired device" : "Loading your projects"}
+                {showProjectRecovery
+                  ? "Reconnecting to Conductor"
+                  : showProjectError
+                    ? "Projects are unavailable"
+                    : "Loading your projects"}
               </h1>
               <p className="mt-3 max-w-[520px] text-[14px] leading-6 text-[var(--vk-text-muted)]">
                 {showProjectRecovery
-                  ? "Your projects remain on your device. Conductor is retrying the bridge connection automatically."
-                  : "Conductor is retrieving the projects linked on your paired device."}
+                  ? "Your projects have not been removed. Conductor is retrying the project connection automatically."
+                  : showProjectError
+                    ? "Conductor could not load projects from this connection. Check the bridge or local backend, then refresh the page."
+                    : "Conductor is retrieving your linked projects."}
               </p>
             </CardContent>
           </Card>

--- a/packages/web/src/features/dashboard/components/WorkspaceOverview.tsx
+++ b/packages/web/src/features/dashboard/components/WorkspaceOverview.tsx
@@ -6,6 +6,7 @@ import {
   FolderKanban,
   GitBranch,
   Layers3,
+  RefreshCw,
   Sparkles,
 } from "lucide-react";
 import { Button } from "@/components/ui/Button";
@@ -21,6 +22,8 @@ import { SessionCard } from "@/components/SessionCard";
 
 interface WorkspaceOverviewProps {
   projects: ConfigProject[];
+  projectsLoading?: boolean;
+  projectsError?: string | null;
   sessions: DashboardSession[];
   onCreateWorkspace: () => void;
   onSelectSession: (sessionId: string) => void;
@@ -50,6 +53,8 @@ function selectRecentSessions(sessions: DashboardSession[], limit: number): Dash
 
 export function WorkspaceOverview({
   projects,
+  projectsLoading = false,
+  projectsError = null,
   sessions,
   onCreateWorkspace,
   onSelectSession,
@@ -83,7 +88,12 @@ export function WorkspaceOverview({
 
     return { active, attention, merge };
   }, [visibleSessions]);
-  const showWelcomeState = projects.length === 0 && visibleSessions.length === 0;
+  const showProjectRecovery = projects.length === 0 && Boolean(projectsError);
+  const showProjectLoading = projects.length === 0 && projectsLoading && !projectsError;
+  const showWelcomeState = projects.length === 0
+    && visibleSessions.length === 0
+    && !showProjectRecovery
+    && !showProjectLoading;
 
   const statCards = [
     { label: "Projects", value: String(projects.length), icon: FolderGit2, caption: "Linked workspaces" },
@@ -91,6 +101,30 @@ export function WorkspaceOverview({
     { label: "Need attention", value: String(sessionStats.attention), icon: Sparkles, caption: "Awaiting review or input" },
     { label: "Merge ready", value: String(sessionStats.merge), icon: GitBranch, caption: "Cleared to land" },
   ];
+
+  if (showProjectRecovery || showProjectLoading) {
+    return (
+      <div className={`flex h-full min-h-0 w-full flex-col bg-[linear-gradient(180deg,rgba(255,255,255,0.03),rgba(255,255,255,0))] ${APP_SURFACE_SCROLL_CLASS_NAME}`}>
+        <div className="flex h-full min-h-0 w-full flex-1 items-center justify-center px-3 py-3 sm:px-4 sm:py-4">
+          <Card className="w-full max-w-[680px] border-[var(--vk-border)] bg-[color:color-mix(in_srgb,var(--vk-bg-panel)_88%,transparent)]">
+            <CardContent className="flex flex-col items-center px-6 py-10 text-center sm:px-10 sm:py-12">
+              <span className="inline-flex h-12 w-12 items-center justify-center rounded-[12px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] text-[var(--vk-text-normal)]">
+                <RefreshCw className="h-5 w-5 animate-spin" aria-hidden="true" />
+              </span>
+              <h1 className="mt-5 text-[24px] font-semibold tracking-[-0.035em] text-[var(--vk-text-strong)] sm:text-[30px]">
+                {showProjectRecovery ? "Reconnecting to your paired device" : "Loading your projects"}
+              </h1>
+              <p className="mt-3 max-w-[520px] text-[14px] leading-6 text-[var(--vk-text-muted)]">
+                {showProjectRecovery
+                  ? "Your projects remain on your device. Conductor is retrying the bridge connection automatically."
+                  : "Conductor is retrieving the projects linked on your paired device."}
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
 
   if (showWelcomeState) {
     return (

--- a/packages/web/src/features/sessions/SessionPageClient.tsx
+++ b/packages/web/src/features/sessions/SessionPageClient.tsx
@@ -57,6 +57,7 @@ export default function SessionPageClient({
     projects,
     loading: projectsLoading,
     error: projectsError,
+    recovering: projectsRecovering,
   } = useConfig(effectiveBridgeId, { enabled: !requiresPairedDeviceScope || Boolean(effectiveBridgeId) });
   const { preferences, loading: preferencesLoading } = usePreferences(effectiveBridgeId, {
     enabled: !requiresPairedDeviceScope || Boolean(effectiveBridgeId),
@@ -188,6 +189,7 @@ export default function SessionPageClient({
           projects={projects}
           projectsLoading={projectsLoading}
           projectsError={projectsError}
+          projectsRecovering={projectsRecovering}
           selectedProjectId={selectedProjectId}
           onSelectProject={(projectId) => {
             if (projectId === null) {

--- a/packages/web/src/features/sessions/SessionPageClient.tsx
+++ b/packages/web/src/features/sessions/SessionPageClient.tsx
@@ -53,7 +53,11 @@ export default function SessionPageClient({
     enabled: scopeReady,
   });
   const effectiveBridgeId = currentSession?.bridgeId ?? requestedBridgeId;
-  const { projects } = useConfig(effectiveBridgeId, { enabled: !requiresPairedDeviceScope || Boolean(effectiveBridgeId) });
+  const {
+    projects,
+    loading: projectsLoading,
+    error: projectsError,
+  } = useConfig(effectiveBridgeId, { enabled: !requiresPairedDeviceScope || Boolean(effectiveBridgeId) });
   const { preferences, loading: preferencesLoading } = usePreferences(effectiveBridgeId, {
     enabled: !requiresPairedDeviceScope || Boolean(effectiveBridgeId),
   });
@@ -182,6 +186,8 @@ export default function SessionPageClient({
       sidebar={sidebarVisible ? (
         <WorkspaceSidebarPanel
           projects={projects}
+          projectsLoading={projectsLoading}
+          projectsError={projectsError}
           selectedProjectId={selectedProjectId}
           onSelectProject={(projectId) => {
             if (projectId === null) {

--- a/packages/web/src/hooks/useConfig.ts
+++ b/packages/web/src/hooks/useConfig.ts
@@ -24,6 +24,7 @@ interface UseConfigReturn {
   projects: ConfigProject[];
   loading: boolean;
   error: string | null;
+  recovering: boolean;
   refresh: () => Promise<void>;
 }
 
@@ -108,6 +109,7 @@ export function useConfig(bridgeId?: string | null, options?: UseConfigOptions):
   const [projects, setProjects] = useState<ConfigProject[]>([]);
   const [loading, setLoading] = useState(enabled);
   const [error, setError] = useState<string | null>(null);
+  const [recovering, setRecovering] = useState(false);
   const activeScopeRef = useRef<string | null>(null);
   const requestEpochRef = useRef(0);
   const retryAttemptRef = useRef(0);
@@ -123,6 +125,7 @@ export function useConfig(bridgeId?: string | null, options?: UseConfigOptions):
 
   const scheduleRetry = useCallback(() => {
     if (!enabled || retryTimerRef.current !== null) return;
+    setRecovering(true);
     const failedAttempt = retryAttemptRef.current;
     retryAttemptRef.current += 1;
     retryTimerRef.current = window.setTimeout(() => {
@@ -135,6 +138,7 @@ export function useConfig(bridgeId?: string | null, options?: UseConfigOptions):
     if (!enabled) {
       setProjects([]);
       setError(null);
+      setRecovering(false);
       setLoading(false);
       return;
     }
@@ -160,12 +164,15 @@ export function useConfig(bridgeId?: string | null, options?: UseConfigOptions):
       if (requestEpoch !== requestEpochRef.current) return;
       setProjects(normalizeProjects(payload));
       setError(null);
+      setRecovering(false);
       retryAttemptRef.current = 0;
     } catch (err) {
       if (requestEpoch !== requestEpochRef.current) return;
       setError(err instanceof Error ? err.message : "Failed to fetch config");
       if (!(err instanceof ConfigRequestError) || err.retryable) {
         scheduleRetry();
+      } else {
+        setRecovering(false);
       }
     } finally {
       if (requestEpoch === requestEpochRef.current) {
@@ -185,6 +192,7 @@ export function useConfig(bridgeId?: string | null, options?: UseConfigOptions):
     if (scopeChanged || !enabled) {
       setProjects([]);
       setError(null);
+      setRecovering(false);
     }
 
     if (!enabled) {
@@ -210,5 +218,11 @@ export function useConfig(bridgeId?: string | null, options?: UseConfigOptions):
     };
   }, [clearRetryTimer, enabled, fetchConfig, scopeKey]);
 
-  return { projects, loading: enabled ? loading : false, error: enabled ? error : null, refresh: fetchConfig };
+  return {
+    projects,
+    loading: enabled ? loading : false,
+    error: enabled ? error : null,
+    recovering: enabled ? recovering : false,
+    refresh: fetchConfig,
+  };
 }

--- a/packages/web/src/hooks/useConfig.ts
+++ b/packages/web/src/hooks/useConfig.ts
@@ -1,7 +1,9 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { withBridgeQuery } from "@/lib/bridgeQuery";
+import { normalizeBridgeId } from "@/lib/bridgeSessionIds";
+import { isTransientRequestStatus, requestRetryDelayMs } from "@/lib/requestRetry";
 
 export interface ConfigProject {
   id: string;
@@ -27,6 +29,16 @@ interface UseConfigReturn {
 
 interface UseConfigOptions {
   enabled?: boolean;
+}
+
+class ConfigRequestError extends Error {
+  readonly retryable: boolean;
+
+  constructor(message: string, retryable: boolean) {
+    super(message);
+    this.name = "ConfigRequestError";
+    this.retryable = retryable;
+  }
 }
 
 function normalizeProject(
@@ -92,9 +104,32 @@ function normalizeProjects(payload: unknown): ConfigProject[] {
 
 export function useConfig(bridgeId?: string | null, options?: UseConfigOptions): UseConfigReturn {
   const enabled = options?.enabled ?? true;
+  const scopeKey = normalizeBridgeId(bridgeId) ?? "local";
   const [projects, setProjects] = useState<ConfigProject[]>([]);
   const [loading, setLoading] = useState(enabled);
   const [error, setError] = useState<string | null>(null);
+  const activeScopeRef = useRef<string | null>(null);
+  const requestEpochRef = useRef(0);
+  const retryAttemptRef = useRef(0);
+  const retryTimerRef = useRef<number | null>(null);
+  const fetchConfigRef = useRef<() => Promise<void>>(async () => {});
+
+  const clearRetryTimer = useCallback(() => {
+    if (retryTimerRef.current !== null) {
+      window.clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleRetry = useCallback(() => {
+    if (!enabled || retryTimerRef.current !== null) return;
+    const failedAttempt = retryAttemptRef.current;
+    retryAttemptRef.current += 1;
+    retryTimerRef.current = window.setTimeout(() => {
+      retryTimerRef.current = null;
+      void fetchConfigRef.current();
+    }, requestRetryDelayMs(failedAttempt));
+  }, [enabled]);
 
   const fetchConfig = useCallback(async () => {
     if (!enabled) {
@@ -104,9 +139,11 @@ export function useConfig(bridgeId?: string | null, options?: UseConfigOptions):
       return;
     }
 
+    clearRetryTimer();
+    const requestEpoch = ++requestEpochRef.current;
     setLoading(true);
     try {
-      const res = await fetch(withBridgeQuery("/api/config", bridgeId));
+      const res = await fetch(withBridgeQuery("/api/config", bridgeId), { cache: "no-store" });
       const payload = (await res.json().catch(() => null)) as
         | { error?: string; reason?: string }
         | unknown;
@@ -115,21 +152,63 @@ export function useConfig(bridgeId?: string | null, options?: UseConfigOptions):
           ? ((payload as { error?: string; reason?: string }).error
             ?? (payload as { error?: string; reason?: string }).reason)
           : null;
-        throw new Error(message ?? `Failed to fetch config: ${res.status}`);
+        throw new ConfigRequestError(
+          message ?? `Failed to fetch config: ${res.status}`,
+          isTransientRequestStatus(res.status),
+        );
       }
+      if (requestEpoch !== requestEpochRef.current) return;
       setProjects(normalizeProjects(payload));
       setError(null);
+      retryAttemptRef.current = 0;
     } catch (err) {
-      setProjects([]);
+      if (requestEpoch !== requestEpochRef.current) return;
       setError(err instanceof Error ? err.message : "Failed to fetch config");
+      if (!(err instanceof ConfigRequestError) || err.retryable) {
+        scheduleRetry();
+      }
     } finally {
-      setLoading(false);
+      if (requestEpoch === requestEpochRef.current) {
+        setLoading(false);
+      }
     }
-  }, [bridgeId, enabled]);
+  }, [bridgeId, clearRetryTimer, enabled, scheduleRetry]);
+
+  fetchConfigRef.current = fetchConfig;
 
   useEffect(() => {
+    const scopeChanged = activeScopeRef.current !== scopeKey;
+    activeScopeRef.current = scopeKey;
+    requestEpochRef.current += 1;
+    clearRetryTimer();
+    retryAttemptRef.current = 0;
+    if (scopeChanged || !enabled) {
+      setProjects([]);
+      setError(null);
+    }
+
+    if (!enabled) {
+      setLoading(false);
+      return undefined;
+    }
+
     void fetchConfig();
-  }, [fetchConfig]);
+
+    const refreshVisibleConfig = () => {
+      if (document.visibilityState === "visible") {
+        void fetchConfigRef.current();
+      }
+    };
+    window.addEventListener("focus", refreshVisibleConfig);
+    document.addEventListener("visibilitychange", refreshVisibleConfig);
+
+    return () => {
+      requestEpochRef.current += 1;
+      clearRetryTimer();
+      window.removeEventListener("focus", refreshVisibleConfig);
+      document.removeEventListener("visibilitychange", refreshVisibleConfig);
+    };
+  }, [clearRetryTimer, enabled, fetchConfig, scopeKey]);
 
   return { projects, loading: enabled ? loading : false, error: enabled ? error : null, refresh: fetchConfig };
 }

--- a/packages/web/src/lib/requestRetry.test.ts
+++ b/packages/web/src/lib/requestRetry.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isTransientRequestStatus, requestRetryDelayMs } from "./requestRetry";
+
+test("transient request status classification retries bridge and server outages", () => {
+  for (const status of [408, 425, 429, 500, 502, 503, 504]) {
+    assert.equal(isTransientRequestStatus(status), true, `status ${status}`);
+  }
+
+  for (const status of [400, 401, 403, 404, 409, 422, 505]) {
+    assert.equal(isTransientRequestStatus(status), false, `status ${status}`);
+  }
+});
+
+test("request retry delay backs off, jitters, and remains capped", () => {
+  assert.equal(requestRetryDelayMs(0, 0), 1_000);
+  assert.equal(requestRetryDelayMs(1, 0), 2_000);
+  assert.equal(requestRetryDelayMs(2, 1), 5_000);
+  assert.equal(requestRetryDelayMs(3, 1), 10_000);
+  assert.equal(requestRetryDelayMs(4, 1), 15_000);
+  assert.equal(requestRetryDelayMs(20, 1), 15_000);
+  assert.equal(requestRetryDelayMs(Number.NaN, Number.NaN), 1_000);
+});

--- a/packages/web/src/lib/requestRetry.ts
+++ b/packages/web/src/lib/requestRetry.ts
@@ -1,0 +1,30 @@
+const REQUEST_RETRY_BASE_DELAY_MS = 1_000;
+const REQUEST_RETRY_MAX_DELAY_MS = 15_000;
+const REQUEST_RETRY_JITTER_RATIO = 0.25;
+
+export function isTransientRequestStatus(status: number): boolean {
+  return status === 408
+    || status === 425
+    || status === 429
+    || (status >= 500 && status <= 504);
+}
+
+export function requestRetryDelayMs(
+  failedAttempt: number,
+  randomValue: number = Math.random(),
+): number {
+  const normalizedAttempt = Number.isFinite(failedAttempt)
+    ? Math.max(0, Math.floor(failedAttempt))
+    : 0;
+  const baseDelay = Math.min(
+    REQUEST_RETRY_MAX_DELAY_MS,
+    REQUEST_RETRY_BASE_DELAY_MS * (2 ** normalizedAttempt),
+  );
+  const normalizedRandom = Number.isFinite(randomValue)
+    ? Math.min(1, Math.max(0, randomValue))
+    : 0;
+  const jitteredDelay = Math.round(
+    baseDelay * (1 + (REQUEST_RETRY_JITTER_RATIO * normalizedRandom)),
+  );
+  return Math.min(REQUEST_RETRY_MAX_DELAY_MS, jitteredDelay);
+}


### PR DESCRIPTION
## Summary

- retry project configuration reads after transient relay and backend failures without discarding the last known project list
- distinguish a recovering bridge from a genuinely empty workspace in the dashboard and sidebar
- reset reconnect backoff after an established Go or Rust bridge session drops
- add a WebSocket regression test for the Go bridge and deterministic retry-policy tests for the dashboard

## Root Cause

The dashboard loaded `/api/config` only once. A temporary relay outage replaced the project list with an empty array and the UI never requested it again, so linked projects appeared permanently missing until a reload. Independently, both bridge implementations carried dial-failure backoff across established sessions; repeated network interruptions could leave reconnects delayed by the 30-second ceiling.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `go test ./...`
- `go vet ./...`
- production Go bridge binary build and help smoke check
- `bun run typecheck`
- `bun run test:packages`
- `bun run build:frontend`

## User-Facing Release Notes

- Linked projects now recover automatically after temporary bridge or relay interruptions instead of remaining stuck at zero.
- The dashboard now shows a reconnecting state when projects are temporarily unavailable, rather than presenting an empty workspace.
- Bridge reconnects recover promptly after an established connection drops.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relay recovery after an established connection drops, preserving connection state and retry information.
  * Added automatic retries for temporary project-configuration request failures.
  * Refreshes project configuration when the app regains focus or becomes visible.

* **User Experience**
  * Added loading, error, and reconnecting states to project lists and workspace views.
  * Displays clear retry messaging when projects are temporarily unavailable.
  * Prevents outdated configuration responses from overwriting current project data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->