### PR TITLE
fix: restore packaged image optimization

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -90,6 +90,7 @@
         "react-icons": "^5.6.0",
         "react-markdown": "9.0.3",
         "remark-gfm": "^4.0.1",
+        "sharp": "0.35.0",
         "shiki": "^4.0.2",
         "tailwind-merge": "^3.5.0",
         "xterm": "^5.3.0",

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -61,6 +61,12 @@ const nextConfig: NextConfig = {
   ],
   // Silence "multiple lockfiles" warning — pin workspace root to the monorepo
   outputFileTracingRoot: workspaceRoot,
+  // sharp 0.35 loads libvips through the native addon at runtime, so Next's
+  // static tracer cannot discover the platform package on its own. Keep the
+  // matching native runtime in self-hosted standalone builds.
+  outputFileTracingIncludes: {
+    "/*": ["../../node_modules/@img/sharp-libvips-*/**/*"],
+  },
   async headers() {
     return [
       {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -45,6 +45,7 @@
     "react-icons": "^5.6.0",
     "react-markdown": "9.0.3",
     "remark-gfm": "^4.0.1",
+    "sharp": "0.35.0",
     "shiki": "^4.0.2",
     "tailwind-merge": "^3.5.0",
     "xterm": "^5.3.0",

--- a/scripts/cli-release-stage.mjs
+++ b/scripts/cli-release-stage.mjs
@@ -229,7 +229,7 @@ function ensureWebBundle(rootDir) {
   return { standaloneDir, staticDir, publicDir };
 }
 
-function collectStandalonePlatformDependencies(standaloneRoot) {
+export function collectStandalonePlatformDependencies(standaloneRoot) {
   const sharpManifestPath = join(standaloneRoot, "node_modules", "sharp", "package.json");
   if (!existsSync(sharpManifestPath)) {
     throw new Error("The standalone dashboard is missing its traced sharp runtime.");
@@ -238,6 +238,18 @@ function collectStandalonePlatformDependencies(standaloneRoot) {
   const sharpManifest = readJson(sharpManifestPath);
   if (typeof sharpManifest.version !== "string" || sharpManifest.version.length === 0) {
     throw new Error("The standalone dashboard has an invalid sharp package identity.");
+  }
+
+  const tracedLibvipsPackages = Object.keys(sharpManifest.optionalDependencies ?? {})
+    .filter((packageName) => packageName.startsWith("@img/sharp-libvips-"))
+    .filter((packageName) => existsSync(join(
+      standaloneRoot,
+      "node_modules",
+      ...packageName.split("/"),
+      "package.json",
+    )));
+  if (tracedLibvipsPackages.length === 0) {
+    throw new Error("The standalone dashboard is missing sharp's traced libvips runtime.");
   }
 
   // The Linux-built standalone already carries all traced JavaScript. Publishing

--- a/scripts/cli-release-stage.test.mjs
+++ b/scripts/cli-release-stage.test.mjs
@@ -5,7 +5,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
-import { packCliReleasePackage } from "./cli-release-stage.mjs";
+import {
+  collectStandalonePlatformDependencies,
+  packCliReleasePackage,
+} from "./cli-release-stage.mjs";
 import {
   assertBundledDependencyVersionsInTarball,
   assertCliReleaseTarballEquivalence,
@@ -14,6 +17,27 @@ import {
 function writeJson(path, value) {
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, "utf8");
 }
+
+test("release staging rejects sharp without its traced libvips runtime", () => {
+  const standaloneDir = mkdtempSync(join(tmpdir(), "conductor-standalone-sharp-fixture-"));
+
+  try {
+    const sharpDir = join(standaloneDir, "node_modules", "sharp");
+    mkdirSync(sharpDir, { recursive: true });
+    writeJson(join(sharpDir, "package.json"), {
+      name: "sharp",
+      version: "0.35.0",
+      optionalDependencies: { "@img/sharp-libvips-linux-x64": "1.3.0" },
+    });
+
+    assert.throws(
+      () => collectStandalonePlatformDependencies(standaloneDir),
+      /missing sharp's traced libvips runtime/,
+    );
+  } finally {
+    rmSync(standaloneDir, { recursive: true, force: true });
+  }
+});
 
 test("release staging gives bundled private packages the parent release identity", () => {
   const rootDir = mkdtempSync(join(tmpdir(), "conductor-cli-stage-fixture-"));
@@ -29,6 +53,10 @@ test("release staging gives bundled private packages the parent release identity
     mkdirSync(join(webDir, ".next", "standalone"), { recursive: true });
     mkdirSync(join(webDir, ".next", "standalone", "node_modules", "next"), { recursive: true });
     mkdirSync(join(webDir, ".next", "standalone", "node_modules", "sharp"), { recursive: true });
+    mkdirSync(
+      join(webDir, ".next", "standalone", "node_modules", "@img", "sharp-libvips-linux-x64"),
+      { recursive: true },
+    );
     mkdirSync(join(webDir, ".next", "static"), { recursive: true });
 
     writeJson(join(cliDir, "package.json"), {
@@ -62,6 +90,19 @@ test("release staging gives bundled private packages the parent release identity
     writeJson(join(webDir, ".next", "standalone", "node_modules", "sharp", "package.json"), {
       name: "sharp",
       version: "0.34.5",
+      optionalDependencies: { "@img/sharp-libvips-linux-x64": "1.2.4" },
+    });
+    writeJson(join(
+      webDir,
+      ".next",
+      "standalone",
+      "node_modules",
+      "@img",
+      "sharp-libvips-linux-x64",
+      "package.json",
+    ), {
+      name: "@img/sharp-libvips-linux-x64",
+      version: "1.2.4",
     });
 
     const { tarballPath } = packCliReleasePackage({


### PR DESCRIPTION
## Summary

- declare the secured sharp runtime as a direct web dependency
- include the platform libvips package in Next standalone output tracing
- make release staging reject incomplete sharp runtimes before publication
- add a regression test for the libvips staging invariant

## Root Cause

The sharp 0.35 security upgrade moved libvips behind a native runtime package that Next static tracing did not discover. The packaged dashboard contained sharp and its native addon but omitted libvips, so image optimization failed at runtime and Next served the original PNG. The release WebP smoke check correctly blocked publication.

## Validation

- `cargo fmt --all`
- `bun audit --audit-level=high`
- `bun run build:frontend`
- `bun run typecheck`
- `bun run test:packages`
- `node scripts/pack-cli-release.mjs --pack-destination <temp-dir>`
- `node scripts/verify-cli-package.mjs --tarball <packed-tarball>` (`release preflight passed`)

## User-Facing Release Notes

- Packaged Conductor dashboards now retain native image optimization after the secured sharp runtime upgrade.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved self-hosted builds to retain required native image-processing files.
  * Added release validation to detect missing native image-processing runtime packages before packaging.

* **Reliability**
  * Added coverage for standalone builds with native image-processing dependencies, including clear failure handling when required files are absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->