### PR TITLE
fix(web): keep mobile inputs above keyboard

### DIFF
--- a/packages/web/src/components/board/WorkspaceKanban.tsx
+++ b/packages/web/src/components/board/WorkspaceKanban.tsx
@@ -36,6 +36,10 @@ import {
   X,
 } from "lucide-react";
 import { AgentTileIcon } from "@/components/AgentTileIcon";
+import {
+  KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME,
+  KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME,
+} from "@/components/layout/keyboardSafeViewport";
 import { usePreferences } from "@/hooks/usePreferences";
 import { getDisplaySessionId } from "@/lib/bridgeSessionIds";
 import { withBridgeQuery } from "@/lib/bridgeQuery";
@@ -4151,11 +4155,11 @@ export function WorkspaceKanban({
 
       {activeEditingTask && (
         <div
-          className="fixed inset-0 z-[75] flex items-start justify-center overflow-y-auto bg-black/60 px-3 py-3 sm:items-center sm:py-0"
+          className={`fixed ${KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME} z-[75] flex items-start justify-center overflow-y-auto bg-black/60 px-3 py-3 sm:items-center sm:py-0`}
           onClick={closeEditor}
         >
           <div
-            className="flex max-h-[100dvh] w-full flex-col overflow-hidden border-[var(--vk-border)] bg-[var(--vk-bg-panel)] sm:max-h-[calc(100dvh-1.5rem)] sm:max-w-[560px] sm:rounded-[6px] sm:border"
+            className={`flex ${KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME} w-full flex-col overflow-hidden border-[var(--vk-border)] bg-[var(--vk-bg-panel)] sm:max-w-[560px] sm:rounded-[6px] sm:border`}
             onClick={(event) => event.stopPropagation()}
             role="dialog"
             aria-modal="true"
@@ -4432,11 +4436,11 @@ export function WorkspaceKanban({
 
       {composerOpen && (
         <div
-          className="fixed inset-0 z-[75] flex items-start justify-center overflow-y-auto bg-black/60 px-3 py-3 sm:items-center sm:py-0"
+          className={`fixed ${KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME} z-[75] flex items-start justify-center overflow-y-auto bg-black/60 px-3 py-3 sm:items-center sm:py-0`}
           onClick={() => !submitting && setComposerOpen(false)}
         >
           <div
-            className="flex max-h-[100dvh] w-full flex-col overflow-hidden border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_28px_80px_rgba(0,0,0,0.45)] sm:max-h-[calc(100dvh-1.5rem)] sm:max-w-[980px] sm:rounded-[10px] sm:border"
+            className={`flex ${KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME} w-full flex-col overflow-hidden border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_28px_80px_rgba(0,0,0,0.45)] sm:max-w-[980px] sm:rounded-[10px] sm:border`}
             onClick={(event) => event.stopPropagation()}
             role="dialog"
             aria-modal="true"

--- a/packages/web/src/components/layout/AppShell.tsx
+++ b/packages/web/src/components/layout/AppShell.tsx
@@ -4,6 +4,14 @@ import { useEffect, useState, type CSSProperties, type ReactNode } from "react";
 import { PanelLeftOpen, PanelRightClose } from "lucide-react";
 import { cn } from "@/lib/cn";
 import { AppUpdateNotice } from "@/components/layout/AppUpdateNotice";
+import {
+  KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VALUE,
+  KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VAR,
+  KEYBOARD_SAFE_VISUAL_VIEWPORT_HEIGHT_CSS_VAR,
+  KEYBOARD_SAFE_VISUAL_VIEWPORT_OFFSET_TOP_CSS_VAR,
+  resolveKeyboardSafeViewportMetrics,
+  resolveStableLayoutViewportHeight,
+} from "@/components/layout/keyboardSafeViewport";
 
 interface AppShellProps {
   sidebar: ReactNode;
@@ -74,11 +82,38 @@ export function AppShell({
 
   useEffect(() => {
     const root = document.documentElement;
+    const initialVisualViewport = window.visualViewport;
+    let stableLayoutViewportHeight = resolveStableLayoutViewportHeight(
+      0,
+      window.innerHeight,
+      root.clientHeight,
+      initialVisualViewport?.height ?? Number.NaN,
+      initialVisualViewport?.offsetTop ?? Number.NaN,
+    );
 
     const syncViewportMetrics = () => {
       const visualViewport = window.visualViewport;
-      const viewportHeight = visualViewport?.height ?? window.innerHeight;
-      root.style.setProperty("--oc-app-shell-height", `${Math.round(viewportHeight)}px`);
+      stableLayoutViewportHeight = resolveStableLayoutViewportHeight(
+        stableLayoutViewportHeight,
+        window.innerHeight,
+        root.clientHeight,
+        visualViewport?.height ?? Number.NaN,
+        visualViewport?.offsetTop ?? Number.NaN,
+      );
+      const viewportMetrics = resolveKeyboardSafeViewportMetrics(
+        stableLayoutViewportHeight,
+        visualViewport?.height ?? Number.NaN,
+        visualViewport?.offsetTop ?? Number.NaN,
+      );
+      root.style.setProperty(KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VAR, `${viewportMetrics.bottom}px`);
+      root.style.setProperty(
+        KEYBOARD_SAFE_VISUAL_VIEWPORT_HEIGHT_CSS_VAR,
+        `${viewportMetrics.visibleHeight}px`,
+      );
+      root.style.setProperty(
+        KEYBOARD_SAFE_VISUAL_VIEWPORT_OFFSET_TOP_CSS_VAR,
+        `${viewportMetrics.offsetTop}px`,
+      );
     };
 
     syncViewportMetrics();
@@ -91,12 +126,15 @@ export function AppShell({
       visualViewport?.removeEventListener("resize", syncViewportMetrics);
       visualViewport?.removeEventListener("scroll", syncViewportMetrics);
       window.removeEventListener("resize", syncViewportMetrics);
+      root.style.removeProperty(KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VAR);
+      root.style.removeProperty(KEYBOARD_SAFE_VISUAL_VIEWPORT_HEIGHT_CSS_VAR);
+      root.style.removeProperty(KEYBOARD_SAFE_VISUAL_VIEWPORT_OFFSET_TOP_CSS_VAR);
     };
   }, []);
 
   const shellStyle = {
     "--workspace-sidebar-width": `${sidebarWidth}px`,
-    "--oc-shell-height": "var(--oc-app-shell-height, 100dvh)",
+    "--oc-shell-height": KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VALUE,
   } as CSSProperties;
 
   return (

--- a/packages/web/src/components/layout/keyboardSafeViewport.test.ts
+++ b/packages/web/src/components/layout/keyboardSafeViewport.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  KEYBOARD_SAFE_VIEWPORT_DIALOG_MAX_HEIGHT_CLASS_NAME,
+  KEYBOARD_SAFE_VIEWPORT_FRAME_CLASS_NAME,
+  KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VALUE,
+  KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VAR,
+  KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME,
+  KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME,
+  KEYBOARD_SAFE_VIEWPORT_SHEET_CLASS_NAME,
+  KEYBOARD_SAFE_VISUAL_VIEWPORT_HEIGHT_CSS_VAR,
+  KEYBOARD_SAFE_VISUAL_VIEWPORT_OFFSET_TOP_CSS_VAR,
+  resolveKeyboardSafeViewportHeight,
+  resolveKeyboardSafeViewportMetrics,
+  resolveStableLayoutViewportHeight,
+} from "./keyboardSafeViewport";
+
+test("stable layout height survives keyboard-driven innerHeight shrinkage", () => {
+  assert.equal(resolveStableLayoutViewportHeight(844, 320, 320, 320, 150), 844);
+  assert.equal(resolveStableLayoutViewportHeight(0, 320, 320, 320, 150), 470);
+  assert.equal(resolveStableLayoutViewportHeight(390, 844, 844, 844, 0), 844);
+  assert.equal(
+    resolveStableLayoutViewportHeight(844, 600, 600, Number.NaN, Number.NaN),
+    600,
+  );
+});
+
+test("keyboard-safe viewport metrics fill through the visual viewport bottom edge", () => {
+  assert.deepEqual(resolveKeyboardSafeViewportMetrics(844, 320, 150), {
+    visibleHeight: 320,
+    offsetTop: 150,
+    bottom: 470,
+  });
+  assert.equal(resolveKeyboardSafeViewportHeight(844, 320, 150), 470);
+});
+
+test("keyboard-safe viewport metrics preserve standard sizing when offsetTop is zero", () => {
+  assert.deepEqual(resolveKeyboardSafeViewportMetrics(844, 512, 0), {
+    visibleHeight: 512,
+    offsetTop: 0,
+    bottom: 512,
+  });
+});
+
+test("keyboard-safe viewport metrics clamp visual bottom transitions to the layout viewport", () => {
+  assert.deepEqual(resolveKeyboardSafeViewportMetrics(844, 820, 64), {
+    visibleHeight: 780,
+    offsetTop: 64,
+    bottom: 844,
+  });
+  assert.deepEqual(resolveKeyboardSafeViewportMetrics(320, 320, 150), {
+    visibleHeight: 170,
+    offsetTop: 150,
+    bottom: 320,
+  });
+});
+
+test("keyboard-safe viewport metrics fall back safely when viewport values are invalid", () => {
+  assert.deepEqual(resolveKeyboardSafeViewportMetrics(844, Number.NaN, Number.NaN), {
+    visibleHeight: 844,
+    offsetTop: 0,
+    bottom: 844,
+  });
+  assert.equal(resolveKeyboardSafeViewportHeight(Number.NaN, 320, 150), 470);
+  assert.equal(resolveKeyboardSafeViewportHeight(Number.NaN, Number.NaN, Number.NaN), 0);
+});
+
+test("keyboard-safe viewport css helpers expose literal Tailwind-detectable contracts", () => {
+  assert.equal(KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VAR, "--oc-safe-viewport-height");
+  assert.equal(KEYBOARD_SAFE_VISUAL_VIEWPORT_HEIGHT_CSS_VAR, "--oc-visual-viewport-height");
+  assert.equal(KEYBOARD_SAFE_VISUAL_VIEWPORT_OFFSET_TOP_CSS_VAR, "--oc-visual-viewport-offset-top");
+  assert.equal(KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VALUE, "var(--oc-safe-viewport-height,100dvh)");
+  assert.equal(
+    KEYBOARD_SAFE_VIEWPORT_FRAME_CLASS_NAME,
+    "h-[var(--oc-visual-viewport-height,100dvh)]",
+  );
+  assert.equal(
+    KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME,
+    "inset-x-0 top-[var(--oc-visual-viewport-offset-top,0px)] h-[var(--oc-visual-viewport-height,100dvh)]",
+  );
+  assert.equal(
+    KEYBOARD_SAFE_VIEWPORT_DIALOG_MAX_HEIGHT_CLASS_NAME,
+    "sm:max-h-[calc(var(--oc-visual-viewport-height,100dvh)-3rem)]",
+  );
+  assert.match(KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME, /--oc-visual-viewport-height/);
+  assert.equal(
+    KEYBOARD_SAFE_VIEWPORT_SHEET_CLASS_NAME,
+    "top-[calc(var(--oc-visual-viewport-offset-top,0px)+10dvh)] h-[calc(var(--oc-visual-viewport-height,100dvh)-10dvh)]",
+  );
+});
+
+test("AppShell writes and cleans up every shared keyboard-safe viewport css variable", () => {
+  const source = readFileSync(new URL("./AppShell.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /resolveStableLayoutViewportHeight/);
+  assert.match(source, /resolveKeyboardSafeViewportMetrics/);
+  for (const cssVarName of [
+    "KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VAR",
+    "KEYBOARD_SAFE_VISUAL_VIEWPORT_HEIGHT_CSS_VAR",
+    "KEYBOARD_SAFE_VISUAL_VIEWPORT_OFFSET_TOP_CSS_VAR",
+  ]) {
+    assert.match(source, new RegExp(`setProperty\\(\\s*${cssVarName}`));
+    assert.match(source, new RegExp(`removeProperty\\(${cssVarName}\\)`));
+  }
+});
+
+test("dashboard dialogs use shared keyboard-safe frames for mobile forms", () => {
+  const source = readFileSync(new URL("../../features/dashboard/components/DashboardDialogs.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /KEYBOARD_SAFE_VIEWPORT_FRAME_CLASS_NAME/);
+  assert.match(source, /KEYBOARD_SAFE_VIEWPORT_DIALOG_MAX_HEIGHT_CLASS_NAME/);
+  assert.match(source, /KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME/);
+  assert.match(source, /KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME/);
+  assert.doesNotMatch(source, /sm:max-h-\[calc\(100dvh-/);
+});
+
+test("workspace kanban dialogs use the shared inset frame", () => {
+  const source = readFileSync(new URL("../board/WorkspaceKanban.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME/);
+  assert.match(source, /KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME/);
+  assert.doesNotMatch(source, /sm:max-h-\[calc\(100dvh-/);
+});
+
+test("notes mobile sheets stay between the visual top and bottom edges", () => {
+  const source = readFileSync(new URL("../notes/ProjectNotesWorkspace.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /KEYBOARD_SAFE_VIEWPORT_SHEET_CLASS_NAME/);
+  assert.doesNotMatch(KEYBOARD_SAFE_VIEWPORT_SHEET_CLASS_NAME, /bottom-/);
+  assert.doesNotMatch(source, /KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VALUE}\*0\.9/);
+});

--- a/packages/web/src/components/layout/keyboardSafeViewport.ts
+++ b/packages/web/src/components/layout/keyboardSafeViewport.ts
@@ -1,0 +1,93 @@
+export const KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VAR = "--oc-safe-viewport-height";
+export const KEYBOARD_SAFE_VISUAL_VIEWPORT_HEIGHT_CSS_VAR = "--oc-visual-viewport-height";
+export const KEYBOARD_SAFE_VISUAL_VIEWPORT_OFFSET_TOP_CSS_VAR = "--oc-visual-viewport-offset-top";
+
+export const KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VALUE = "var(--oc-safe-viewport-height,100dvh)";
+export const KEYBOARD_SAFE_VISUAL_VIEWPORT_HEIGHT_CSS_VALUE = "var(--oc-visual-viewport-height,100dvh)";
+export const KEYBOARD_SAFE_VISUAL_VIEWPORT_OFFSET_TOP_CSS_VALUE = "var(--oc-visual-viewport-offset-top,0px)";
+
+// Keep these as complete string literals so Tailwind can detect every arbitrary-value class.
+export const KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME =
+  "inset-x-0 top-[var(--oc-visual-viewport-offset-top,0px)] h-[var(--oc-visual-viewport-height,100dvh)]";
+export const KEYBOARD_SAFE_VIEWPORT_FRAME_CLASS_NAME =
+  "h-[var(--oc-visual-viewport-height,100dvh)]";
+export const KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME =
+  "max-h-[calc(var(--oc-visual-viewport-height,100dvh)-1.5rem)]";
+export const KEYBOARD_SAFE_VIEWPORT_DIALOG_MAX_HEIGHT_CLASS_NAME =
+  "sm:max-h-[calc(var(--oc-visual-viewport-height,100dvh)-3rem)]";
+export const KEYBOARD_SAFE_VIEWPORT_SHEET_CLASS_NAME =
+  "top-[calc(var(--oc-visual-viewport-offset-top,0px)+10dvh)] h-[calc(var(--oc-visual-viewport-height,100dvh)-10dvh)]";
+
+export interface KeyboardSafeViewportMetrics {
+  visibleHeight: number;
+  offsetTop: number;
+  bottom: number;
+}
+
+export function resolveStableLayoutViewportHeight(
+  previousHeight: number,
+  innerHeight: number,
+  clientHeight: number,
+  visualViewportHeight: number,
+  visualViewportOffsetTop: number,
+): number {
+  const currentLayoutHeight = Math.max(
+    0,
+    ...[innerHeight, clientHeight].map((value) =>
+      Number.isFinite(value) ? Math.max(0, value) : 0,
+    ),
+  );
+  const hasVisualViewportHeight = Number.isFinite(visualViewportHeight) && visualViewportHeight > 0;
+  if (!hasVisualViewportHeight) return Math.round(currentLayoutHeight);
+
+  const safeOffsetTop = Number.isFinite(visualViewportOffsetTop)
+    ? Math.max(0, visualViewportOffsetTop)
+    : 0;
+  const candidates = [previousHeight, currentLayoutHeight, visualViewportHeight + safeOffsetTop];
+
+  return Math.round(
+    Math.max(
+      0,
+      ...candidates.map((value) => (Number.isFinite(value) ? Math.max(0, value) : 0)),
+    ),
+  );
+}
+
+export function resolveKeyboardSafeViewportMetrics(
+  layoutViewportHeight: number,
+  visualViewportHeight: number,
+  visualViewportOffsetTop: number,
+): KeyboardSafeViewportMetrics {
+  const hasLayoutViewportHeight = Number.isFinite(layoutViewportHeight) && layoutViewportHeight > 0;
+  const safeLayoutHeight = hasLayoutViewportHeight ? Math.max(0, layoutViewportHeight) : 0;
+  const hasVisualViewportHeight = Number.isFinite(visualViewportHeight) && visualViewportHeight > 0;
+  const rawVisibleHeight = hasVisualViewportHeight
+    ? Math.max(0, visualViewportHeight)
+    : safeLayoutHeight;
+  const rawOffsetTop = hasVisualViewportHeight && Number.isFinite(visualViewportOffsetTop)
+    ? Math.max(0, visualViewportOffsetTop)
+    : 0;
+  const bottom = hasLayoutViewportHeight
+    ? Math.min(safeLayoutHeight, rawOffsetTop + rawVisibleHeight)
+    : rawOffsetTop + rawVisibleHeight;
+  const offsetTop = Math.min(rawOffsetTop, bottom);
+  const visibleHeight = Math.max(0, bottom - offsetTop);
+
+  return {
+    visibleHeight: Math.round(visibleHeight),
+    offsetTop: Math.round(offsetTop),
+    bottom: Math.round(bottom),
+  };
+}
+
+export function resolveKeyboardSafeViewportHeight(
+  layoutViewportHeight: number,
+  visualViewportHeight: number,
+  visualViewportOffsetTop: number,
+): number {
+  return resolveKeyboardSafeViewportMetrics(
+    layoutViewportHeight,
+    visualViewportHeight,
+    visualViewportOffsetTop,
+  ).bottom;
+}

--- a/packages/web/src/components/notes/ProjectNotesWorkspace.tsx
+++ b/packages/web/src/components/notes/ProjectNotesWorkspace.tsx
@@ -13,6 +13,7 @@ import {
 import type { DashboardSession } from "@/lib/types";
 import { withBridgeQuery } from "@/lib/bridgeQuery";
 import { isProjectDispatcherSession } from "@/lib/sessionKinds";
+import { KEYBOARD_SAFE_VIEWPORT_SHEET_CLASS_NAME } from "@/components/layout/keyboardSafeViewport";
 
 import type {
   ViewMode,
@@ -57,7 +58,7 @@ const NOTES_MAIN_PANEL_COMPACT_CLASS_NAME = "flex min-h-0 flex-1 flex-col overfl
 const NOTES_EDITOR_PANEL_CLASS_NAME = "min-h-[320px] overflow-hidden xl:min-h-0";
 const NOTES_PREVIEW_PANEL_CLASS_NAME = "min-h-[280px] overflow-auto bg-[var(--vk-bg-panel)]/25 px-4 py-4 xl:min-h-0";
 const NOTES_SHEET_OVERLAY_CLASS_NAME = "fixed inset-0 z-[130] bg-black/60 backdrop-blur-[2px]";
-const NOTES_SHEET_CONTENT_CLASS_NAME = "fixed inset-x-0 bottom-0 top-[10%] z-[131] flex flex-col overflow-hidden rounded-t-[20px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_-24px_80px_rgba(0,0,0,0.42)]";
+const NOTES_SHEET_CONTENT_CLASS_NAME = `fixed inset-x-0 ${KEYBOARD_SAFE_VIEWPORT_SHEET_CLASS_NAME} z-[131] flex flex-col overflow-hidden rounded-t-[20px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_-24px_80px_rgba(0,0,0,0.42)]`;
 
 // ---------------------------------------------------------------------------
 // Component

--- a/packages/web/src/features/dashboard/components/DashboardDialogs.tsx
+++ b/packages/web/src/features/dashboard/components/DashboardDialogs.tsx
@@ -52,6 +52,12 @@ import { playNotificationSound } from "@/lib/notificationSounds";
 import { filterGitHubRepos, type GitHubRepo } from "../githubRepos";
 import { agentModelAccessBadgeLabel, agentSetupStatusLabel } from "@/lib/agentSetupStatus";
 import { normalizeModelAccessPreferences } from "@/lib/modelAccess";
+import {
+  KEYBOARD_SAFE_VIEWPORT_DIALOG_MAX_HEIGHT_CLASS_NAME,
+  KEYBOARD_SAFE_VIEWPORT_FRAME_CLASS_NAME,
+  KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME,
+  KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME,
+} from "@/components/layout/keyboardSafeViewport";
 import { SettingsProfilePanel } from "./SettingsProfilePanel";
 import {
   type RuntimeAgentModelCatalog,
@@ -1114,7 +1120,7 @@ export function NewWorkspaceDialog({
   return (
     <>
       <div
-        className="fixed inset-0 z-[80] flex items-end justify-center overflow-y-auto bg-black/65 px-0 py-0 sm:items-center sm:px-3 sm:py-3"
+        className={`fixed ${KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME} z-[80] flex items-start justify-center overflow-y-auto bg-black/65 px-0 py-0 sm:items-center sm:px-3 sm:py-3`}
         onClick={() => {
           if (creating || folderPickerOpen) return;
           onClose();
@@ -1124,7 +1130,7 @@ export function NewWorkspaceDialog({
         <form
           onSubmit={handleSubmit}
           onClick={(event) => event.stopPropagation()}
-          className="flex h-dvh w-full max-w-none flex-col overflow-hidden rounded-none border-x-0 border-b-0 border-t border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_24px_80px_rgba(0,0,0,0.55)] sm:h-auto sm:max-h-[calc(100dvh-3rem)] sm:max-w-[860px] sm:rounded-[10px] sm:border"
+          className={`flex ${KEYBOARD_SAFE_VIEWPORT_FRAME_CLASS_NAME} ${KEYBOARD_SAFE_VIEWPORT_DIALOG_MAX_HEIGHT_CLASS_NAME} w-full max-w-none flex-col overflow-hidden rounded-none border-x-0 border-b-0 border-t border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_24px_80px_rgba(0,0,0,0.55)] sm:h-auto sm:max-w-[860px] sm:rounded-[10px] sm:border`}
         >
           <header className="border-b border-[var(--vk-border)] bg-[color:color-mix(in_srgb,var(--vk-bg-panel)_92%,transparent)] px-4 py-3 backdrop-blur">
             <div className="mb-3 flex justify-center sm:hidden">
@@ -1962,7 +1968,7 @@ function FolderPickerDialog({
 
   return (
     <div
-      className="fixed inset-0 z-[95] flex items-start justify-center overflow-y-auto bg-black/70 px-3 py-3 sm:items-center sm:py-0"
+      className={`fixed ${KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME} z-[95] flex items-start justify-center overflow-y-auto bg-black/70 px-3 py-3 sm:items-center sm:py-0`}
       onClick={() => {
         onClose();
         onSelect(null);
@@ -1970,7 +1976,7 @@ function FolderPickerDialog({
       role="presentation"
     >
       <div
-        className="flex max-h-[calc(100dvh-1.5rem)] w-full max-w-[760px] flex-col overflow-hidden rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_24px_80px_rgba(0,0,0,0.55)]"
+        className={`flex ${KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME} w-full max-w-[760px] flex-col overflow-hidden rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_24px_80px_rgba(0,0,0,0.55)]`}
         onClick={(event) => event.stopPropagation()}
       >
         <header className="border-b border-[var(--vk-border)] px-4 py-3">
@@ -2716,7 +2722,7 @@ function hydrateRepositoryDraft(value: RepositorySettingsPayload): RepositorySet
   return (
     <>
       <div
-        className="fixed inset-0 z-[90] flex items-start justify-center overflow-y-auto bg-black/70 px-3 py-3 sm:items-center sm:py-6"
+        className={`fixed ${KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME} z-[90] flex items-start justify-center overflow-y-auto bg-black/70 px-3 py-3 sm:items-center sm:py-6`}
         onClick={() => {
           if (isBusy || mode === "onboarding" || repositoryFolderPickerOpen || notesFolderPickerOpen || filesystemRootPickerOpen) return;
           onClose();
@@ -2724,7 +2730,7 @@ function hydrateRepositoryDraft(value: RepositorySettingsPayload): RepositorySet
         role="presentation"
       >
         <div
-          className="flex h-[100dvh] w-full flex-col overflow-hidden border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_24px_80px_rgba(0,0,0,0.55)] sm:h-[min(90vh,820px)] sm:max-h-[calc(100dvh-3rem)] sm:max-w-[1180px] sm:rounded-[6px] sm:border sm:flex-row"
+          className={`flex ${KEYBOARD_SAFE_VIEWPORT_FRAME_CLASS_NAME} ${KEYBOARD_SAFE_VIEWPORT_DIALOG_MAX_HEIGHT_CLASS_NAME} w-full flex-col overflow-hidden border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_24px_80px_rgba(0,0,0,0.55)] sm:h-[min(90vh,820px)] sm:max-w-[1180px] sm:rounded-[6px] sm:border sm:flex-row`}
           onClick={(event) => event.stopPropagation()}
         >
           <aside className="flex w-full shrink-0 flex-col border-b border-[var(--vk-border)] bg-[rgba(28,28,28,0.8)] sm:w-[224px] sm:border-b-0 sm:border-r">


### PR DESCRIPTION
## Summary

Fixes iOS Safari keyboard clipping across Conductor's mobile text-entry surfaces. The app now tracks the full Visual Viewport geometry, exposes shared keyboard-safe CSS variables, and keeps fullscreen dialogs and sheets inside the visible area.

## User-Facing Release Notes

- Launch forms, dialogs, board editors, and notes now stay usable when the iOS keyboard opens.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Testing

- `bun run --cwd packages/web test`
- `bun run --cwd packages/web typecheck`
- `bun run --cwd packages/web build`
- `bun run typecheck`
- `bun run --cwd packages/core test`
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Codex GPT-5.4 high review, no remaining findings
- iOS 18.6 iPhone 16 Pro Simulator production-build QA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved modal, dialog, and mobile sheet layouts to remain visible and usable when the on-screen keyboard is open.
  * Added adaptive viewport sizing and positioning across task editing, task creation, notes, workspace, folder picker, and settings interfaces.

* **Bug Fixes**
  * Prevented dialogs and sheets from being obscured, improperly sized, or positioned during mobile keyboard interactions.

* **Tests**
  * Added coverage for keyboard-safe viewport calculations and responsive dialog styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->