### PR TITLE
fix: preserve dispatcher assistant tool chronology

### DIFF
--- a/crates/conductor-server/src/state/helpers.rs
+++ b/crates/conductor-server/src/state/helpers.rs
@@ -741,35 +741,45 @@ pub(crate) fn latest_turn_runtime_assistant_text(session: &SessionRecord) -> Opt
         .map(ToOwned::to_owned)
 }
 
+fn is_streamed_runtime_assistant(entry: &ConversationEntry) -> bool {
+    entry.kind == "assistant_message"
+        && entry.source == "runtime"
+        && entry
+            .metadata
+            .get(ASSISTANT_DELTA_STREAM_METADATA_KEY)
+            .and_then(Value::as_bool)
+            == Some(true)
+}
+
 pub(crate) fn find_streamed_runtime_assistant_anchor(
     session: &SessionRecord,
 ) -> Option<(usize, Vec<usize>)> {
     let turn_start = current_turn_start_index(session);
-    let mut canonical_index = None;
-    let mut duplicate_indexes = Vec::new();
+    let mut segment_indexes = Vec::new();
 
-    for index in turn_start..session.conversation.len() {
+    for index in (turn_start..session.conversation.len()).rev() {
         let Some(entry) = session.conversation.get(index) else {
             continue;
         };
-        let is_streamed_runtime_assistant = entry.kind == "assistant_message"
-            && entry.source == "runtime"
-            && entry
-                .metadata
-                .get(ASSISTANT_DELTA_STREAM_METADATA_KEY)
-                .and_then(Value::as_bool)
-                == Some(true);
-        if !is_streamed_runtime_assistant {
-            continue;
+        if !is_streamed_runtime_assistant(entry) {
+            break;
         }
-        if canonical_index.is_none() {
-            canonical_index = Some(index);
-        } else {
-            duplicate_indexes.push(index);
-        }
+
+        segment_indexes.push(index);
     }
 
-    canonical_index.map(|index| (index, duplicate_indexes))
+    segment_indexes.reverse();
+    let mut indexes = segment_indexes.into_iter();
+    let canonical_index = indexes.next()?;
+    Some((canonical_index, indexes.collect()))
+}
+
+fn active_streamed_runtime_assistant_id(session: &SessionRecord) -> Option<String> {
+    let (canonical_index, _) = find_streamed_runtime_assistant_anchor(session)?;
+    session
+        .conversation
+        .get(canonical_index)
+        .map(|entry| entry.id.clone())
 }
 
 pub(crate) fn merge_runtime_assistant_snapshot_text(current: &mut String, incoming: &str) -> bool {
@@ -1605,21 +1615,9 @@ pub fn build_normalized_chat_feed(session: &SessionRecord) -> Vec<Value> {
     let mut feed = Vec::new();
     let is_streaming = is_streaming_status(&session.status);
     let dispatcher = is_acp_dispatcher_session(session);
-    let last_runtime_assistant_id = if is_streaming {
-        session
-            .conversation
-            .iter()
-            .rev()
-            .find(|entry| {
-                entry.kind == "assistant_message"
-                    && entry.source == "runtime"
-                    && !is_runtime_internal_noise_text(&entry.text)
-                    && (dispatcher || !is_runtime_transport_dump(&entry.text))
-            })
-            .map(|entry| entry.id.clone())
-    } else {
-        None
-    };
+    let last_runtime_assistant_id = is_streaming
+        .then(|| active_streamed_runtime_assistant_id(session))
+        .flatten();
     let has_structured_runtime_entries = session.conversation.iter().any(|entry| {
         matches!(entry.kind.as_str(), "assistant_message" | "status_message")
             && entry.source == "runtime"
@@ -1701,21 +1699,9 @@ pub fn build_normalized_chat_feed(session: &SessionRecord) -> Vec<Value> {
 pub fn build_dispatcher_chat_feed(session: &SessionRecord) -> Vec<Value> {
     let mut feed = Vec::new();
     let is_streaming = is_streaming_status(&session.status);
-    let last_runtime_assistant_id = if is_streaming {
-        session
-            .conversation
-            .iter()
-            .rev()
-            .find(|entry| {
-                entry.kind == "assistant_message"
-                    && entry.source == "runtime"
-                    && !is_runtime_internal_noise_text(&entry.text)
-                    && !is_runtime_transport_dump(&entry.text)
-            })
-            .map(|entry| entry.id.clone())
-    } else {
-        None
-    };
+    let last_runtime_assistant_id = is_streaming
+        .then(|| active_streamed_runtime_assistant_id(session))
+        .flatten();
 
     for entry in &session.conversation {
         let skip_runtime_dump = entry.source == "runtime"
@@ -2139,6 +2125,275 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(assistant_entries.len(), 1);
         assert_eq!(assistant_entries[0].text, "haha");
+    }
+
+    #[test]
+    fn streamed_runtime_assistant_segment_stays_sealed_after_tool_barrier_until_new_delta() {
+        let mut session = test_session("assistant-segment-tool-barrier");
+        session.status = SessionStatus::Working;
+        session.conversation.push(ConversationEntry {
+            id: "user-turn".to_string(),
+            kind: "user_message".to_string(),
+            source: "dispatcher_ui".to_string(),
+            text: "Inspect package.json".to_string(),
+            created_at: Utc::now().to_rfc3339(),
+            attachments: Vec::new(),
+            metadata: HashMap::new(),
+        });
+
+        assert!(append_streamed_runtime_assistant_delta(
+            &mut session,
+            "I'll inspect only the requested package manifest",
+        ));
+        let first_assistant_id = session
+            .conversation
+            .last()
+            .expect("first assistant segment")
+            .id
+            .clone();
+        assert!(append_streamed_runtime_assistant_delta(
+            &mut session,
+            " and keep the response to the exact requested shape.",
+        ));
+        assert_eq!(session.conversation.len(), 2);
+
+        assert!(upsert_runtime_status_entry(
+            &mut session,
+            "Command",
+            Some(HashMap::from([
+                ("toolCallId".to_string(), json!("command-1")),
+                ("toolKind".to_string(), json!("command")),
+                ("toolTitle".to_string(), json!("Command")),
+                ("toolStatus".to_string(), json!("running")),
+            ])),
+        ));
+        let command_tool_id = session
+            .conversation
+            .last()
+            .expect("command tool row")
+            .id
+            .clone();
+
+        for build_feed in [
+            build_dispatcher_chat_feed as fn(&SessionRecord) -> Vec<Value>,
+            build_normalized_chat_feed as fn(&SessionRecord) -> Vec<Value>,
+        ] {
+            let feed = build_feed(&session);
+            assert_eq!(
+                feed.iter()
+                    .map(|entry| entry["id"].as_str().expect("feed id"))
+                    .collect::<Vec<_>>(),
+                vec![
+                    "user-turn",
+                    first_assistant_id.as_str(),
+                    command_tool_id.as_str(),
+                ]
+            );
+            assert_eq!(feed[1]["kind"].as_str(), Some("assistant"));
+            assert_eq!(feed[1]["streaming"].as_bool(), Some(false));
+            assert_eq!(
+                feed[1]["text"].as_str(),
+                Some(
+                    "I'll inspect only the requested package manifest and keep the response to the exact requested shape."
+                )
+            );
+            assert_eq!(feed[2]["kind"].as_str(), Some("tool"));
+            assert_eq!(feed[2]["metadata"]["toolStatus"].as_str(), Some("running"));
+            assert_eq!(feed[2]["streaming"].as_bool(), Some(false));
+        }
+
+        assert!(append_streamed_runtime_assistant_delta(
+            &mut session,
+            "1. The package"
+        ));
+        let second_assistant_id = session
+            .conversation
+            .last()
+            .expect("second assistant segment")
+            .id
+            .clone();
+        assert_ne!(second_assistant_id, first_assistant_id);
+        assert!(append_streamed_runtime_assistant_delta(
+            &mut session,
+            " manifest exists."
+        ));
+        assert_eq!(session.conversation.len(), 4);
+
+        let assistant_entries = session
+            .conversation
+            .iter()
+            .filter(|entry| entry.kind == "assistant_message" && entry.source == "runtime")
+            .collect::<Vec<_>>();
+        assert_eq!(assistant_entries.len(), 2);
+        assert_eq!(
+            assistant_entries[0].text,
+            "I'll inspect only the requested package manifest and keep the response to the exact requested shape."
+        );
+        assert_eq!(assistant_entries[0].id, first_assistant_id);
+        assert_eq!(assistant_entries[1].text, "1. The package manifest exists.");
+        assert_eq!(assistant_entries[1].id, second_assistant_id);
+
+        for build_feed in [
+            build_dispatcher_chat_feed as fn(&SessionRecord) -> Vec<Value>,
+            build_normalized_chat_feed as fn(&SessionRecord) -> Vec<Value>,
+        ] {
+            let feed = build_feed(&session);
+            assert_eq!(
+                feed.iter()
+                    .map(|entry| entry["id"].as_str().expect("feed id"))
+                    .collect::<Vec<_>>(),
+                vec![
+                    "user-turn",
+                    first_assistant_id.as_str(),
+                    command_tool_id.as_str(),
+                    second_assistant_id.as_str(),
+                ]
+            );
+            assert_eq!(feed[1]["kind"].as_str(), Some("assistant"));
+            assert_eq!(feed[1]["streaming"].as_bool(), Some(false));
+            assert_eq!(feed[2]["kind"].as_str(), Some("tool"));
+            assert_eq!(feed[2]["streaming"].as_bool(), Some(false));
+            assert_eq!(feed[3]["kind"].as_str(), Some("assistant"));
+            assert_eq!(feed[3]["streaming"].as_bool(), Some(true));
+            assert_eq!(
+                feed[3]["text"].as_str(),
+                Some("1. The package manifest exists.")
+            );
+        }
+    }
+
+    #[test]
+    fn tool_updates_in_place_do_not_barrier_later_assistant_segment() {
+        let mut session = test_session("assistant-segment-tool-update");
+        session.conversation.push(ConversationEntry {
+            id: "user-turn".to_string(),
+            kind: "user_message".to_string(),
+            source: "dispatcher_ui".to_string(),
+            text: "Inspect package.json".to_string(),
+            created_at: Utc::now().to_rfc3339(),
+            attachments: Vec::new(),
+            metadata: HashMap::new(),
+        });
+
+        assert!(append_streamed_runtime_assistant_delta(
+            &mut session,
+            "Preamble."
+        ));
+        assert!(upsert_runtime_status_entry(
+            &mut session,
+            "Command",
+            Some(HashMap::from([
+                ("toolCallId".to_string(), json!("command-1")),
+                ("toolKind".to_string(), json!("command")),
+                ("toolTitle".to_string(), json!("Command")),
+                ("toolStatus".to_string(), json!("running")),
+            ])),
+        ));
+        let tool_id = session.conversation.last().expect("tool row").id.clone();
+
+        assert!(append_streamed_runtime_assistant_delta(
+            &mut session,
+            "Answer"
+        ));
+        let second_assistant_id = session
+            .conversation
+            .last()
+            .expect("second assistant row")
+            .id
+            .clone();
+
+        assert!(upsert_runtime_status_entry(
+            &mut session,
+            "",
+            Some(HashMap::from([
+                ("toolCallId".to_string(), json!("command-1")),
+                ("toolStatus".to_string(), json!("success")),
+                ("toolContent".to_string(), json!(["done"])),
+            ])),
+        ));
+        assert_eq!(
+            session
+                .conversation
+                .iter()
+                .filter(
+                    |entry| entry.metadata.get("toolCallId").and_then(Value::as_str)
+                        == Some("command-1")
+                )
+                .count(),
+            1
+        );
+        assert_eq!(
+            session
+                .conversation
+                .iter()
+                .find(|entry| entry.id == tool_id)
+                .and_then(|entry| entry.metadata.get("toolStatus"))
+                .and_then(Value::as_str),
+            Some("success")
+        );
+
+        assert!(append_streamed_runtime_assistant_delta(
+            &mut session,
+            " complete."
+        ));
+        assert_eq!(session.conversation.len(), 4);
+        let trailing_assistant = session.conversation.last().expect("trailing assistant");
+        assert_eq!(trailing_assistant.id, second_assistant_id);
+        assert_eq!(trailing_assistant.text, "Answer complete.");
+    }
+
+    #[test]
+    fn runtime_assistant_snapshot_after_tool_barrier_creates_new_tail_entry() {
+        let mut session = test_session("assistant-segment-final-only");
+        session.status = SessionStatus::Done;
+        session.conversation.push(ConversationEntry {
+            id: "user-turn".to_string(),
+            kind: "user_message".to_string(),
+            source: "dispatcher_ui".to_string(),
+            text: "Inspect package.json".to_string(),
+            created_at: Utc::now().to_rfc3339(),
+            attachments: Vec::new(),
+            metadata: HashMap::new(),
+        });
+
+        assert!(append_streamed_runtime_assistant_delta(
+            &mut session,
+            "Preamble."
+        ));
+        assert!(upsert_runtime_status_entry(
+            &mut session,
+            "Command",
+            Some(HashMap::from([
+                ("toolCallId".to_string(), json!("command-1")),
+                ("toolKind".to_string(), json!("command")),
+                ("toolTitle".to_string(), json!("Command")),
+                ("toolStatus".to_string(), json!("success")),
+            ])),
+        ));
+        assert!(append_runtime_assistant_snapshot(
+            &mut session,
+            "1. The package manifest exists.",
+        ));
+
+        let assistant_entries = session
+            .conversation
+            .iter()
+            .filter(|entry| entry.kind == "assistant_message" && entry.source == "runtime")
+            .collect::<Vec<_>>();
+        assert_eq!(assistant_entries.len(), 2);
+        assert_eq!(assistant_entries[0].text, "Preamble.");
+        assert_eq!(assistant_entries[1].text, "1. The package manifest exists.");
+
+        let feed = build_dispatcher_chat_feed(&session);
+        let feed_kinds = feed
+            .iter()
+            .map(|entry| entry["kind"].as_str().expect("feed kind"))
+            .collect::<Vec<_>>();
+        assert_eq!(feed_kinds, vec!["user", "assistant", "tool", "assistant"]);
+        assert_eq!(
+            feed[3]["text"].as_str(),
+            Some("1. The package manifest exists.")
+        );
     }
 
     #[test]

--- a/crates/conductor-server/src/state/session_manager.rs
+++ b/crates/conductor-server/src/state/session_manager.rs
@@ -3072,7 +3072,7 @@ mod tests {
     }
 
     #[test]
-    fn assistant_delta_after_interleaved_status_updates_one_canonical_row() {
+    fn assistant_delta_after_interleaved_status_starts_a_new_assistant_segment() {
         let mut session = SessionRecord::new(
             "session-1".to_string(),
             "demo".to_string(),
@@ -3103,8 +3103,9 @@ mod tests {
             .iter()
             .filter(|entry| entry.kind == "assistant_message" && entry.source == "runtime")
             .collect::<Vec<_>>();
-        assert_eq!(assistant_entries.len(), 1);
-        assert_eq!(assistant_entries[0].text, "hello world");
+        assert_eq!(assistant_entries.len(), 2);
+        assert_eq!(assistant_entries[0].text, "hello");
+        assert_eq!(assistant_entries[1].text, " world");
         assert_eq!(
             session
                 .conversation

--- a/docs/dispatcher-streaming-SPEC.md
+++ b/docs/dispatcher-streaming-SPEC.md
@@ -15,7 +15,7 @@ Implement and ship a focused streaming change from `origin/main`. Any separate d
 1. Runtime adapters expose a first-class byte-exact assistant delta event. Delta text must never be trimmed, newline-normalized, or heuristically deduplicated.
 2. Codex dispatcher turns use the Codex app-server protocol when available so `item/agentMessage/delta` notifications become live assistant deltas. Preserve model, reasoning, cwd, sandbox and approval behavior, the bounded pre-turn handshake, cancellation, stderr diagnostics, real legacy fallback if app-server startup fails before the turn begins, and the dispatcher rule that every headless turn rebuilds from the durable transcript instead of using a native resume target.
 3. Structured streaming adapters for Claude Code, Gemini, Qwen, and OpenClaw emit assistant deltas when their native protocols provide them. Completed or final frames must not duplicate already-streamed text.
-4. Dispatcher state keeps one canonical active assistant row per user turn. Tool and status rows may be interleaved without splitting subsequent assistant deltas into a new message.
+4. Dispatcher state keeps one stable assistant row per contiguous assistant segment. A newly appended runtime tool or status lifecycle row seals the prior assistant segment; later assistant deltas must create and then keep updating a new tail assistant row after that barrier. Tool lifecycle updates matched by `toolCallId` still update their original row in place and must not retroactively barrier a later assistant segment.
 5. Existing 50 ms publication batching remains the single server-side cadence control. Duplicate or no-op fragments must not churn timestamps or rebuild feeds.
 6. Protocol 2 SSE emits a compact patch for exactly one changed streaming entry by stable entry ID, even when that entry is not the tail because a tool card follows it. If identity, ordering, or multiple entries change, send a full replace snapshot.
 7. Compact patches carry UTF-16 offsets because browser string offsets use UTF-16 code units. Replayed duplicate patches are idempotent. Offset mismatch, server lag refresh, or reconnect must safely resync by replacement.
@@ -27,7 +27,7 @@ Implement and ship a focused streaming change from `origin/main`. Any separate d
 - Rust unit tests for byte-exact delta parsing and no duplicate final output across supported structured adapters.
 - Codex app-server protocol tests for initialize, thread start, turn start, delta forwarding, tool and status forwarding, completion, errors, cancellation, and paths with spaces.
 - Dispatcher regressions proving Codex ignores stale persisted native resume targets and app-server thread-start metadata exposes `codexThreadId` telemetry without claiming native resume.
-- Dispatcher-state tests proving one assistant row across interleaved tool cards and duplicate or no-op behavior.
+- Dispatcher-state tests proving exact user/assistant/tool chronology, one stable assistant row per contiguous segment, stable updates within each segment, tool completion updates in place, final-only snapshot fallback, and duplicate or no-op behavior.
 - SSE tests for non-tail single-entry patching, multi-entry replacement fallback, UTF-16 emoji offsets, lag refresh recovery, and keepalive.
 - Frontend reducer tests for delta apply, duplicate replay, offset mismatch replacement, non-tail entry update, and stable tool entries.
 - `cargo fmt --check`
@@ -38,7 +38,7 @@ Implement and ship a focused streaming change from `origin/main`. Any separate d
 - `bun run --cwd packages/web test`
 - `bun run typecheck`
 - `bun run build:frontend`
-- Real alternate-port source smoke using local Codex: observe multiple assistant text updates before turn completion, no chunk dump, one assistant row, and final text equality.
+- Real alternate-port source smoke using local Codex: observe multiple assistant text updates before turn completion, no chunk dump, one assistant row per contiguous assistant segment, preserved tool/assistant chronology, and final text equality.
 - Browser smoke against the source build with no relevant console errors.
 
 ## Delivery

--- a/packages/web/src/components/dispatcher/DispatcherSessionPane.test.ts
+++ b/packages/web/src/components/dispatcher/DispatcherSessionPane.test.ts
@@ -9,11 +9,16 @@ import {
   updateDispatcherReconnectAttemptAfterConnection,
 } from "./dispatcherFeedState.js";
 
-function makeEntry(id: string, text: string, streaming = false) {
+function makeEntry(
+  id: string,
+  text: string,
+  streaming = false,
+  kind: "assistant" | "user" = "assistant",
+) {
   return {
     id,
-    kind: "assistant" as const,
-    label: "assistant",
+    kind,
+    label: kind,
     text,
     createdAt: "2026-04-10T00:00:00.000Z",
     attachments: [],
@@ -161,6 +166,77 @@ test("applyFeedDelta applies compact token patches by entry id when a tool row f
   assert.equal(next.entries[1]?.id, "tool-1");
   assert.equal(next.entries[1]?.text, "Bash");
   assert.equal(next.entries[1], current.entries[1]);
+});
+
+test("applyFeedDelta preserves a new assistant segment appended after tool barriers", () => {
+  const current = {
+    ...EMPTY_FEED_PAYLOAD,
+    entries: [
+      makeEntry("user-1", "Inspect package.json", false, "user"),
+      makeEntry("assistant-1", "I'll inspect only the requested package manifest.", false),
+      makeToolEntry("tool-1", "Command"),
+      {
+        ...makeToolEntry("tool-2", "Thinking"),
+        metadata: {
+          toolCallId: "thinking-1",
+          toolStatus: "running",
+          toolTitle: "Thinking",
+          toolKind: "thinking",
+        },
+      },
+    ],
+  };
+
+  const appended = applyFeedDelta(current, {
+    type: "append",
+    entries: [makeEntry("assistant-2", "1. The package", true)],
+    totalEntries: 5,
+    windowLimit: 200,
+    truncated: false,
+    sessionStatus: "working",
+    approvalState: null,
+    parserState: null,
+    runtimeStatus: null,
+    source: "stream",
+    error: null,
+    integration: null,
+  });
+
+  assert.deepEqual(
+    appended.entries.map((entry) => ({ id: entry.id, kind: entry.kind })),
+    [
+      { id: "user-1", kind: "user" },
+      { id: "assistant-1", kind: "assistant" },
+      { id: "tool-1", kind: "tool" },
+      { id: "tool-2", kind: "tool" },
+      { id: "assistant-2", kind: "assistant" },
+    ],
+  );
+  assert.equal(appended.entries[2], current.entries[2]);
+  assert.equal(appended.entries[3], current.entries[3]);
+
+  const patched = applyFeedDelta(appended, {
+    type: "patch",
+    entryId: "assistant-2",
+    entry: null,
+    textDelta: " manifest exists.",
+    textOffset: 14,
+    totalEntries: 5,
+    windowLimit: 200,
+    truncated: false,
+    sessionStatus: "working",
+    approvalState: null,
+    parserState: null,
+    runtimeStatus: null,
+    source: "stream",
+    error: null,
+    integration: null,
+  });
+
+  assert.equal(patched.entries[4]?.id, "assistant-2");
+  assert.equal(patched.entries[4]?.text, "1. The package manifest exists.");
+  assert.equal(patched.entries[2], appended.entries[2]);
+  assert.equal(patched.entries[3], appended.entries[3]);
 });
 
 test("compact token patches request a snapshot refresh after an offset gap", () => {


### PR DESCRIPTION
## Summary

- preserve chronological assistant segments around dispatcher tool activity
- seal the active assistant row when a tool or status row is appended
- stream the post-tool final answer into a new stable tail row without concatenating it to the pre-tool preamble
- keep tool completion updates in place and preserve compact SSE patch behavior within each assistant segment

## Live Reproduction

Before this fix, a real Codex turn persisted as `user, assistant(preamble + final), Command, Thinking`.

After this fix, the same browser and backend flow persists and renders as `user, assistant preamble, Command, Thinking, assistant final` with distinct stable assistant IDs and compact deltas before completion.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p conductor-server`
- `cargo test -p conductor-executors`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `bun run --cwd packages/web test`
- `bun run typecheck`
- `bun run build:frontend`
- `bash scripts/validate-docs.sh`
- `git diff --check`
- live alternate-port Codex tool-call stream through the Rust backend
- browser smoke and chronological frame capture against the source build

## User-Facing Release Notes

- Dispatcher conversations now keep assistant commentary, tool activity, and final answers in the correct chronological order while streaming.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming conversation display so separate assistant responses remain distinct after tool or status updates.
  * Preserved tool activity rows in their original positions while later assistant text updates correctly.
  * Fixed snapshot and chat-feed behavior across tool execution barriers.

* **Tests**
  * Added coverage for segmented assistant messages, tool updates, and preserved conversation chronology.

* **Documentation**
  * Updated streaming requirements to clarify assistant segmentation and tool lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->