### PR TITLE
fix: stream SSE through paired-device bridge

### DIFF
--- a/crates/conductor-cli/src/bridge.rs
+++ b/crates/conductor-cli/src/bridge.rs
@@ -1,19 +1,24 @@
 use anyhow::{Context, Result};
 use base64::Engine;
-use conductor_types::{BridgeToBrowserMessage, BrowserToBridgeMessage, FileEntry, FileEntryKind};
+use conductor_types::{
+    BridgeToBrowserMessage, BrowserToBridgeMessage, FileEntry, FileEntryKind,
+    API_STREAM_V1_CAPABILITY,
+};
 use futures_util::{SinkExt, StreamExt};
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
-    Arc,
+    Arc, Mutex as StdMutex,
 };
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::{mpsc, Mutex};
+use tokio::task::{AbortHandle, Id as TaskId, JoinSet};
 use tokio::time::sleep;
 use tokio_tungstenite::{
     connect_async,
@@ -33,6 +38,10 @@ const CONTROL_SCOPE: &str = "conductor-bridge-control";
 const MAX_PREVIEW_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
 const MAX_PREVIEW_REQUEST_BODY_BYTES: usize = 5 * 1024 * 1024;
 const PREVIEW_REQUEST_TIMEOUT_SECS: u64 = 30;
+const BRIDGE_CONTROL_QUEUE_CAPACITY: usize = 128;
+const BRIDGE_STREAM_QUEUE_CAPACITY: usize = 128;
+const MAX_BRIDGE_CONTROL_MESSAGE_BYTES: usize = 1024 * 1024;
+const MAX_PROXY_STREAM_CHUNK_BYTES: usize = 48 * 1024;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 struct BridgeRuntimeState {
@@ -54,6 +63,54 @@ struct PreviewProxyResponse {
     status: u16,
     headers: std::collections::BTreeMap<String, String>,
     body_base64: Option<String>,
+}
+
+#[derive(Debug)]
+struct StreamTaskAbortEntry {
+    task_id: TaskId,
+    abort_handle: AbortHandle,
+}
+
+#[derive(Debug, Default)]
+struct StreamTaskAbortRegistry {
+    by_request_id: HashMap<String, StreamTaskAbortEntry>,
+    by_task_id: HashMap<TaskId, String>,
+}
+
+impl StreamTaskAbortRegistry {
+    fn register(&mut self, request_id: String, abort_handle: AbortHandle) {
+        let task_id = abort_handle.id();
+        if let Some(previous) = self.by_request_id.insert(
+            request_id.clone(),
+            StreamTaskAbortEntry {
+                task_id,
+                abort_handle,
+            },
+        ) {
+            self.by_task_id.remove(&previous.task_id);
+            previous.abort_handle.abort();
+        }
+        self.by_task_id.insert(task_id, request_id);
+    }
+
+    fn remove_by_request_id(&mut self, request_id: &str) -> Option<StreamTaskAbortEntry> {
+        let entry = self.by_request_id.remove(request_id)?;
+        self.by_task_id.remove(&entry.task_id);
+        Some(entry)
+    }
+
+    fn remove_by_task_id(&mut self, task_id: TaskId) -> Option<StreamTaskAbortEntry> {
+        let request_id = self.by_task_id.remove(&task_id)?;
+        self.by_request_id.remove(&request_id)
+    }
+
+    fn drain_abort_handles(&mut self) -> Vec<AbortHandle> {
+        self.by_task_id.clear();
+        self.by_request_id
+            .drain()
+            .map(|(_, entry)| entry.abort_handle)
+            .collect()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -168,6 +225,42 @@ fn status_payload(connected: bool) -> BridgeToBrowserMessage {
         os: std::env::consts::OS.to_string(),
         connected,
         version: Some(conductor_core::BUILD_VERSION.to_string()),
+        capabilities: vec![API_STREAM_V1_CAPABILITY.to_string()],
+    }
+}
+
+fn register_stream_task_abort(
+    registry: &Arc<StdMutex<StreamTaskAbortRegistry>>,
+    request_id: String,
+    abort_handle: AbortHandle,
+) {
+    if let Ok(mut aborts) = registry.lock() {
+        aborts.register(request_id, abort_handle);
+    }
+}
+
+fn remove_completed_stream_task_abort(
+    registry: &Arc<StdMutex<StreamTaskAbortRegistry>>,
+    task_id: TaskId,
+) {
+    if let Ok(mut aborts) = registry.lock() {
+        aborts.remove_by_task_id(task_id);
+    }
+}
+
+fn cancel_stream_task_abort(registry: &Arc<StdMutex<StreamTaskAbortRegistry>>, request_id: &str) {
+    if let Ok(mut aborts) = registry.lock() {
+        if let Some(entry) = aborts.remove_by_request_id(request_id) {
+            entry.abort_handle.abort();
+        }
+    }
+}
+
+fn abort_all_stream_tasks(registry: &Arc<StdMutex<StreamTaskAbortRegistry>>) {
+    if let Ok(mut aborts) = registry.lock() {
+        for abort_handle in aborts.drain_abort_handles() {
+            abort_handle.abort();
+        }
     }
 }
 
@@ -264,6 +357,108 @@ fn resolve_backend_terminal_websocket_url(backend: &Url, candidate: &str) -> Res
     Ok(url)
 }
 
+fn resolve_proxy_url(backend: &Url, path: &str) -> Result<Url> {
+    if path.starts_with("http://") || path.starts_with("https://") {
+        Url::parse(path).context("invalid proxied URL")
+    } else {
+        backend.join(path).context("failed to resolve backend URL")
+    }
+}
+
+fn sanitize_proxy_request_headers(
+    headers: &BTreeMap<String, String>,
+) -> Result<BTreeMap<String, String>> {
+    let mut sanitized = BTreeMap::new();
+    for (name, value) in headers {
+        let lower = name.trim().to_ascii_lowercase();
+        if lower.is_empty()
+            || matches!(
+                lower.as_str(),
+                "authorization"
+                    | "cookie"
+                    | "host"
+                    | "connection"
+                    | "content-length"
+                    | "transfer-encoding"
+                    | "x-forwarded-host"
+                    | "x-forwarded-proto"
+            )
+        {
+            continue;
+        }
+        if lower.contains('\r') || lower.contains('\n') {
+            anyhow::bail!("invalid proxy request header name");
+        }
+        let clean_value = sanitize_header_value(value);
+        sanitized.insert(lower, clean_value);
+    }
+    Ok(sanitized)
+}
+
+fn sanitize_proxy_response_headers(
+    headers: &reqwest::header::HeaderMap,
+) -> BTreeMap<String, String> {
+    let mut sanitized = BTreeMap::new();
+    for (name, value) in headers.iter() {
+        let name = name.as_str().to_ascii_lowercase();
+        match name.as_str() {
+            "connection"
+            | "proxy-connection"
+            | "keep-alive"
+            | "transfer-encoding"
+            | "content-length"
+            | "content-encoding"
+            | "upgrade"
+            | "proxy-authenticate"
+            | "proxy-authentication-info"
+            | "proxy-authorization"
+            | "te"
+            | "trailers"
+            | "set-cookie"
+            | "set-cookie2" => {
+                continue;
+            }
+            _ => {}
+        }
+
+        let value = match value.to_str() {
+            Ok(value) => sanitize_header_value(value),
+            Err(_) => continue,
+        };
+        if value.contains('\r') || value.contains('\n') {
+            continue;
+        }
+        sanitized.insert(name, value);
+    }
+    sanitized
+}
+
+fn build_proxy_request(
+    client: &reqwest::Client,
+    backend: &Url,
+    method: &str,
+    path: &str,
+    headers: &BTreeMap<String, String>,
+    body: Option<Value>,
+) -> Result<reqwest::RequestBuilder> {
+    let method = method
+        .parse::<reqwest::Method>()
+        .context("invalid HTTP method")?;
+    let url = resolve_proxy_url(backend, path)?;
+    let mut request = client.request(method, url);
+    for (name, value) in sanitize_proxy_request_headers(headers)? {
+        let header_name = reqwest::header::HeaderName::from_bytes(name.as_bytes())
+            .context("invalid proxy request header name")?;
+        let header_value = reqwest::header::HeaderValue::from_str(&value)
+            .context("invalid proxy request header value")?;
+        request = request.header(header_name, header_value);
+    }
+    if let Some(body) = body {
+        request = request.json(&body);
+    }
+    Ok(request)
+}
+
 async fn proxy_request(
     client: &reqwest::Client,
     backend: &Url,
@@ -271,23 +466,9 @@ async fn proxy_request(
     path: &str,
     body: Option<Value>,
 ) -> Result<BackendProxyResponse> {
-    let method = method
-        .parse::<reqwest::Method>()
-        .context("invalid HTTP method")?;
-    let url = if path.starts_with("http://") || path.starts_with("https://") {
-        Url::parse(path).context("invalid proxied URL")?
-    } else {
-        backend
-            .join(path)
-            .context("failed to resolve backend URL")?
-    };
-
-    let mut request = client.request(method, url);
-    if let Some(body) = body {
-        request = request.json(&body);
-    }
-
-    let response = request.send().await?;
+    let response = build_proxy_request(client, backend, method, path, &BTreeMap::new(), body)?
+        .send()
+        .await?;
     let status = response.status().as_u16();
     let content_type = response
         .headers()
@@ -316,6 +497,185 @@ async fn proxy_request(
     };
 
     Ok(BackendProxyResponse { status, body })
+}
+
+fn bridge_message_to_text(payload: &BridgeToBrowserMessage) -> Result<String> {
+    let encoded = serde_json::to_string(payload)?;
+    if encoded.len() > MAX_BRIDGE_CONTROL_MESSAGE_BYTES {
+        anyhow::bail!("bridge control payload exceeded the websocket message size limit");
+    }
+    Ok(encoded)
+}
+
+fn try_send_bridge_payload(
+    tx: &mpsc::Sender<Message>,
+    payload: &BridgeToBrowserMessage,
+) -> Result<()> {
+    let text = bridge_message_to_text(payload)?;
+    tx.try_send(Message::Text(text.into()))
+        .map_err(|err| anyhow::anyhow!("bridge outbound queue is unavailable: {err}"))
+}
+
+async fn send_bridge_payload(
+    tx: &mpsc::Sender<Message>,
+    payload: &BridgeToBrowserMessage,
+) -> Result<()> {
+    let text = bridge_message_to_text(payload)?;
+    tx.send(Message::Text(text.into()))
+        .await
+        .map_err(|_| anyhow::anyhow!("bridge outbound queue is closed"))
+}
+
+async fn send_stream_failure_response(
+    tx: &mpsc::Sender<Message>,
+    id: &str,
+    status: u16,
+    message: &str,
+) -> Result<()> {
+    send_bridge_payload(
+        tx,
+        &BridgeToBrowserMessage::ApiStreamStart {
+            id: id.to_string(),
+            status,
+            headers: BTreeMap::from([("content-type".to_string(), "application/json".to_string())]),
+        },
+    )
+    .await?;
+    send_bridge_payload(
+        tx,
+        &BridgeToBrowserMessage::ApiStreamChunk {
+            id: id.to_string(),
+            chunk_base64: base64::engine::general_purpose::STANDARD
+                .encode(json!({ "error": message }).to_string().as_bytes()),
+        },
+    )
+    .await?;
+    send_bridge_payload(
+        tx,
+        &BridgeToBrowserMessage::ApiStreamEnd {
+            id: id.to_string(),
+            error: None,
+        },
+    )
+    .await
+}
+
+struct ProxyStreamRequest {
+    id: String,
+    method: String,
+    path: String,
+    headers: BTreeMap<String, String>,
+    body: Option<Value>,
+}
+
+struct ProxyStreamContext {
+    client: reqwest::Client,
+    backend: Url,
+    stream_tx: mpsc::Sender<Message>,
+}
+
+async fn proxy_stream_request(
+    context: ProxyStreamContext,
+    request: ProxyStreamRequest,
+) -> Result<()> {
+    let ProxyStreamContext {
+        client,
+        backend,
+        stream_tx,
+    } = context;
+    let ProxyStreamRequest {
+        id,
+        method,
+        path,
+        headers,
+        body,
+    } = request;
+
+    let response = match build_proxy_request(&client, &backend, &method, &path, &headers, body)?
+        .send()
+        .await
+    {
+        Ok(response) => response,
+        Err(err) => {
+            send_stream_failure_response(
+                &stream_tx,
+                &id,
+                StatusCode::BAD_GATEWAY.as_u16(),
+                &err.to_string(),
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+
+    let status = response.status().as_u16();
+    let response_headers = sanitize_proxy_response_headers(response.headers());
+    let chunk_stream = Box::pin(futures_util::stream::unfold(
+        response,
+        |mut response| async move {
+            match response.chunk().await {
+                Ok(Some(chunk)) => Some((Ok(chunk.to_vec()), response)),
+                Ok(None) => None,
+                Err(err) => Some((Err(err.to_string()), response)),
+            }
+        },
+    ));
+
+    forward_proxy_stream_response(id, status, response_headers, stream_tx, chunk_stream).await
+}
+
+async fn forward_proxy_stream_response(
+    id: String,
+    status: u16,
+    headers: BTreeMap<String, String>,
+    tx: mpsc::Sender<Message>,
+    mut chunks: std::pin::Pin<
+        Box<dyn futures_util::Stream<Item = std::result::Result<Vec<u8>, String>> + Send>,
+    >,
+) -> Result<()> {
+    send_bridge_payload(
+        &tx,
+        &BridgeToBrowserMessage::ApiStreamStart {
+            id: id.clone(),
+            status,
+            headers,
+        },
+    )
+    .await?;
+
+    while let Some(chunk) = chunks.next().await {
+        match chunk {
+            Ok(chunk) => {
+                for part in chunk.chunks(MAX_PROXY_STREAM_CHUNK_BYTES) {
+                    send_bridge_payload(
+                        &tx,
+                        &BridgeToBrowserMessage::ApiStreamChunk {
+                            id: id.clone(),
+                            chunk_base64: base64::engine::general_purpose::STANDARD.encode(part),
+                        },
+                    )
+                    .await?;
+                }
+            }
+            Err(err) => {
+                send_bridge_payload(
+                    &tx,
+                    &BridgeToBrowserMessage::ApiStreamEnd {
+                        id,
+                        error: Some(err),
+                    },
+                )
+                .await?;
+                return Ok(());
+            }
+        }
+    }
+
+    send_bridge_payload(
+        &tx,
+        &BridgeToBrowserMessage::ApiStreamEnd { id, error: None },
+    )
+    .await
 }
 
 async fn proxy_preview_request(
@@ -650,7 +1010,7 @@ async fn poll_session_output(
     active_session: Arc<Mutex<Option<String>>>,
     client: reqwest::Client,
     backend: Url,
-    bridge_tx: mpsc::UnboundedSender<Message>,
+    bridge_tx: mpsc::Sender<Message>,
 ) {
     let mut current_session = String::new();
     let mut last_output = String::new();
@@ -695,14 +1055,41 @@ async fn poll_session_output(
 
         if !delta.is_empty() {
             let message = BridgeToBrowserMessage::TerminalOutput { data: delta };
-            if let Ok(text) = serde_json::to_string(&message) {
-                if bridge_tx.send(Message::Text(text.into())).is_err() {
+            if let Ok(text) = bridge_message_to_text(&message) {
+                if bridge_tx.try_send(Message::Text(text.into())).is_err() {
                     break;
                 }
             }
         }
 
         last_output = output.to_string();
+    }
+}
+
+async fn recv_prioritized_bridge_message(
+    control_rx: &mut mpsc::Receiver<Message>,
+    stream_rx: &mut mpsc::Receiver<Message>,
+) -> Option<Message> {
+    loop {
+        match control_rx.try_recv() {
+            Ok(message) => return Some(message),
+            Err(mpsc::error::TryRecvError::Disconnected) if stream_rx.is_closed() => return None,
+            Err(mpsc::error::TryRecvError::Disconnected | mpsc::error::TryRecvError::Empty) => {}
+        }
+
+        tokio::select! {
+            biased;
+            control = control_rx.recv() => match control {
+                Some(message) => return Some(message),
+                None if stream_rx.is_closed() => return None,
+                None => {}
+            },
+            stream = stream_rx.recv(), if !stream_rx.is_closed() => match stream {
+                Some(message) => return Some(message),
+                None if control_rx.is_closed() => return None,
+                None => {}
+            },
+        }
     }
 }
 
@@ -715,19 +1102,24 @@ async fn run_bridge_connection_once(
     let ws_url = bridge_websocket_url(relay, token)?;
     let (ws, _) = connect_async(ws_url.as_str()).await?;
     let (mut outbound, mut inbound) = ws.split();
-    let (tx, mut rx) = mpsc::unbounded_channel::<Message>();
+    let (control_tx, mut control_rx) = mpsc::channel::<Message>(BRIDGE_CONTROL_QUEUE_CAPACITY);
+    let (stream_tx, mut stream_rx) = mpsc::channel::<Message>(BRIDGE_STREAM_QUEUE_CAPACITY);
     let stop = Arc::new(AtomicBool::new(false));
     let active_session = Arc::new(Mutex::new(None::<String>));
+    let mut stream_tasks = JoinSet::new();
+    let stream_task_aborts = Arc::new(StdMutex::new(StreamTaskAbortRegistry::default()));
 
     let writer = tokio::spawn(async move {
-        while let Some(message) = rx.recv().await {
+        while let Some(message) =
+            recv_prioritized_bridge_message(&mut control_rx, &mut stream_rx).await
+        {
             if outbound.send(message).await.is_err() {
                 break;
             }
         }
     });
 
-    let heartbeat_tx = tx.clone();
+    let heartbeat_tx = control_tx.clone();
     let heartbeat_stop = stop.clone();
     let heartbeat_task = tokio::spawn(async move {
         let mut heartbeat = tokio::time::interval(Duration::from_secs(30));
@@ -738,8 +1130,11 @@ async fn run_bridge_connection_once(
             if heartbeat_stop.load(Ordering::Relaxed) {
                 break;
             }
-            if let Ok(payload) = serde_json::to_string(&status_payload(true)) {
-                if heartbeat_tx.send(Message::Text(payload.into())).is_err() {
+            if let Ok(payload) = bridge_message_to_text(&status_payload(true)) {
+                if heartbeat_tx
+                    .try_send(Message::Text(payload.into()))
+                    .is_err()
+                {
                     break;
                 }
             }
@@ -752,11 +1147,11 @@ async fn run_bridge_connection_once(
         active_session.clone(),
         client.clone(),
         backend.clone(),
-        tx.clone(),
+        control_tx.clone(),
     ));
 
-    if let Ok(payload) = serde_json::to_string(&status_payload(true)) {
-        let _ = tx.send(Message::Text(payload.into()));
+    if let Ok(payload) = bridge_message_to_text(&status_payload(true)) {
+        let _ = control_tx.try_send(Message::Text(payload.into()));
     }
     save_state(&BridgeRuntimeState {
         relay_url: relay.to_string(),
@@ -772,6 +1167,19 @@ async fn run_bridge_connection_once(
 
     let outcome = loop {
         tokio::select! {
+            Some(joined) = stream_tasks.join_next_with_id(), if !stream_tasks.is_empty() => {
+                let completed_task_id = match &joined {
+                    Ok((task_id, _)) => *task_id,
+                    Err(err) => err.id(),
+                };
+                remove_completed_stream_task_abort(&stream_task_aborts, completed_task_id);
+                if let Err(err) = joined {
+                    if err.is_cancelled() {
+                        continue;
+                    }
+                    tracing::warn!(error = %err, "bridge API stream task failed");
+                }
+            }
             _ = disconnect_check.tick() => {
                 if load_token()?.is_none() {
                     break ConnectionOutcome::Exit;
@@ -788,13 +1196,14 @@ async fn run_bridge_connection_once(
                             Ok(event) => {
                                 match event {
                                     BrowserToBridgeMessage::Ping => {
-                                        let payload = serde_json::to_string(&BridgeToBrowserMessage::Pong)?;
-                                        let _ = tx.send(Message::Text(payload.into()));
+                                        let _ = try_send_bridge_payload(&control_tx, &BridgeToBrowserMessage::Pong);
                                     }
                                     BrowserToBridgeMessage::FileBrowse { path } => {
                                         let entries = browse_path(&path);
-                                        let payload = serde_json::to_string(&BridgeToBrowserMessage::FileTree { path, entries })?;
-                                        let _ = tx.send(Message::Text(payload.into()));
+                                        let _ = try_send_bridge_payload(
+                                            &control_tx,
+                                            &BridgeToBrowserMessage::FileTree { path, entries },
+                                        );
                                     }
                                     BrowserToBridgeMessage::ApiRequest { id, method, path, body } => {
                                         if let Some(session_id) = extract_session_id(&path) {
@@ -810,22 +1219,64 @@ async fn run_bridge_connection_once(
 
                                         match proxy_request(&client, &backend, &method, &path, body).await {
                                             Ok(response) => {
-                                                let payload = BridgeToBrowserMessage::ApiResponse {
+                                                let _ = try_send_bridge_payload(&control_tx, &BridgeToBrowserMessage::ApiResponse {
                                                     id,
                                                     status: response.status,
                                                     body: response.body,
-                                                };
-                                                let _ = tx.send(Message::Text(serde_json::to_string(&payload)?.into()));
+                                                });
                                             }
                                             Err(err) => {
-                                                let payload = BridgeToBrowserMessage::ApiResponse {
+                                                let _ = try_send_bridge_payload(&control_tx, &BridgeToBrowserMessage::ApiResponse {
                                                     id,
                                                     status: StatusCode::BAD_GATEWAY.as_u16(),
                                                     body: json!({ "error": err.to_string() }),
-                                                };
-                                                let _ = tx.send(Message::Text(serde_json::to_string(&payload)?.into()));
+                                                });
                                             }
                                         }
+                                    }
+                                    BrowserToBridgeMessage::ApiStreamRequest {
+                                        id,
+                                        method,
+                                        path,
+                                        headers,
+                                        body,
+                                    } => {
+                                        let context = ProxyStreamContext {
+                                            stream_tx: stream_tx.clone(),
+                                            client: client.clone(),
+                                            backend: backend.clone(),
+                                        };
+                                        let request = ProxyStreamRequest {
+                                            id,
+                                            method,
+                                            path,
+                                            headers,
+                                            body,
+                                        };
+                                        let failure_tx = context.stream_tx.clone();
+                                        let stream_id = request.id.clone();
+                                        let abort_handle = stream_tasks.spawn(async move {
+                                            let fallback_id = request.id.clone();
+                                            if let Err(err) =
+                                                proxy_stream_request(context, request).await
+                                            {
+                                                let _ = send_stream_failure_response(
+                                                    &failure_tx,
+                                                    &fallback_id,
+                                                    StatusCode::BAD_GATEWAY.as_u16(),
+                                                    &err.to_string(),
+                                                )
+                                                .await;
+                                            }
+                                        });
+                                        register_stream_task_abort(
+                                            &stream_task_aborts,
+                                            stream_id,
+                                            abort_handle,
+                                        );
+                                    }
+                                    BrowserToBridgeMessage::ApiStreamCancel { id } => {
+                                        cancel_stream_task_abort(&stream_task_aborts, &id);
                                     }
                                     BrowserToBridgeMessage::PreviewRequest {
                                         id,
@@ -867,7 +1318,7 @@ async fn run_bridge_connection_once(
                                                 }
                                             }
                                         };
-                                        let _ = tx.send(Message::Text(serde_json::to_string(&payload)?.into()));
+                                        let _ = try_send_bridge_payload(&control_tx, &payload);
                                     }
                                     BrowserToBridgeMessage::TerminalInput { data } => {
                                         if let Some(session_id) = current_active_session(&active_session).await {
@@ -909,7 +1360,7 @@ async fn run_bridge_connection_once(
                         }
                     }
                     Ok(Message::Ping(data)) => {
-                        let _ = tx.send(Message::Pong(data));
+                        let _ = control_tx.try_send(Message::Pong(data));
                     }
                     Ok(Message::Pong(_)) => {}
                     Ok(Message::Binary(_)) => {}
@@ -928,7 +1379,17 @@ async fn run_bridge_connection_once(
         }
     };
 
-    drop(tx);
+    abort_all_stream_tasks(&stream_task_aborts);
+    stream_tasks.abort_all();
+    while let Some(joined) = stream_tasks.join_next().await {
+        if let Err(err) = joined {
+            if !err.is_cancelled() {
+                tracing::warn!(error = %err, "bridge API stream task failed during shutdown");
+            }
+        }
+    }
+    drop(control_tx);
+    drop(stream_tx);
     stop.store(true, Ordering::Relaxed);
     let _ = heartbeat_task.await;
     let _ = poller_task.await;
@@ -1143,5 +1604,256 @@ mod tests {
         assert!(check_preview_host_allowed("192.168.1.1", Some(80)).is_some());
         assert!(check_preview_host_allowed("example.com", Some(443)).is_some());
         assert!(check_preview_host_allowed("metadata.google.internal", Some(80)).is_some());
+    }
+
+    #[tokio::test]
+    async fn bridge_writer_prioritizes_control_queue_over_stream_backlog() {
+        let (control_tx, mut control_rx) = mpsc::channel::<Message>(1);
+        let (stream_tx, mut stream_rx) = mpsc::channel::<Message>(1);
+
+        stream_tx
+            .try_send(Message::Text("stream".into()))
+            .expect("stream backlog should fit in its own queue");
+        control_tx
+            .try_send(Message::Text("control".into()))
+            .expect("control queue should stay available even when stream queue is full");
+
+        let first = recv_prioritized_bridge_message(&mut control_rx, &mut stream_rx)
+            .await
+            .expect("prioritized reader should return a message");
+        assert_eq!(first, Message::Text("control".into()));
+
+        let second = recv_prioritized_bridge_message(&mut control_rx, &mut stream_rx)
+            .await
+            .expect("prioritized reader should return the queued stream message");
+        assert_eq!(second, Message::Text("stream".into()));
+    }
+
+    #[tokio::test]
+    async fn proxy_stream_request_emits_start_chunk_end_without_blocking_other_control_messages() {
+        let (upstream_tx, upstream_rx) = mpsc::channel::<std::result::Result<Vec<u8>, String>>(4);
+        let (control_tx, mut control_rx) = mpsc::channel::<Message>(BRIDGE_CONTROL_QUEUE_CAPACITY);
+        let (stream_tx, mut stream_rx) = mpsc::channel::<Message>(BRIDGE_STREAM_QUEUE_CAPACITY);
+        let chunk_stream = Box::pin(futures_util::stream::unfold(
+            upstream_rx,
+            |mut rx| async move { rx.recv().await.map(|item| (item, rx)) },
+        ));
+        let stream_task = tokio::spawn(forward_proxy_stream_response(
+            "stream-1".to_string(),
+            200,
+            BTreeMap::from([
+                ("content-type".to_string(), "text/event-stream".to_string()),
+                (
+                    "cache-control".to_string(),
+                    "no-cache, no-transform".to_string(),
+                ),
+                ("x-accel-buffering".to_string(), "no".to_string()),
+            ]),
+            stream_tx.clone(),
+            chunk_stream,
+        ));
+
+        let start = match recv_prioritized_bridge_message(&mut control_rx, &mut stream_rx)
+            .await
+            .expect("stream should emit start")
+        {
+            Message::Text(text) => {
+                serde_json::from_str::<BridgeToBrowserMessage>(&text).expect("decode start")
+            }
+            other => panic!("expected text message, got {other:?}"),
+        };
+        assert_eq!(
+            start,
+            BridgeToBrowserMessage::ApiStreamStart {
+                id: "stream-1".to_string(),
+                status: 200,
+                headers: BTreeMap::from([
+                    (
+                        "cache-control".to_string(),
+                        "no-cache, no-transform".to_string()
+                    ),
+                    ("content-type".to_string(), "text/event-stream".to_string()),
+                    ("x-accel-buffering".to_string(), "no".to_string()),
+                ]),
+            }
+        );
+
+        upstream_tx
+            .send(Ok(b"chunk-1".to_vec()))
+            .await
+            .expect("send first chunk");
+        try_send_bridge_payload(&control_tx, &BridgeToBrowserMessage::Pong).expect("queue pong");
+        let pong = recv_prioritized_bridge_message(&mut control_rx, &mut stream_rx)
+            .await
+            .expect("pong should be forwarded before the stream finishes");
+        assert!(matches!(pong, Message::Text(_)));
+        if let Message::Text(text) = pong {
+            assert_eq!(
+                serde_json::from_str::<BridgeToBrowserMessage>(&text).expect("decode pong"),
+                BridgeToBrowserMessage::Pong
+            );
+        }
+
+        let first_chunk = match recv_prioritized_bridge_message(&mut control_rx, &mut stream_rx)
+            .await
+            .expect("first chunk should arrive")
+        {
+            Message::Text(text) => {
+                serde_json::from_str::<BridgeToBrowserMessage>(&text).expect("decode first chunk")
+            }
+            other => panic!("expected text message, got {other:?}"),
+        };
+        assert_eq!(
+            first_chunk,
+            BridgeToBrowserMessage::ApiStreamChunk {
+                id: "stream-1".to_string(),
+                chunk_base64: base64::engine::general_purpose::STANDARD.encode(b"chunk-1"),
+            }
+        );
+
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(25),
+                recv_prioritized_bridge_message(&mut control_rx, &mut stream_rx),
+            )
+            .await
+            .is_err(),
+            "the stream should stay open until the second chunk is released"
+        );
+
+        upstream_tx
+            .send(Ok(b"chunk-2".to_vec()))
+            .await
+            .expect("send second chunk");
+        drop(upstream_tx);
+        let second_chunk = match recv_prioritized_bridge_message(&mut control_rx, &mut stream_rx)
+            .await
+            .expect("second chunk should arrive")
+        {
+            Message::Text(text) => {
+                serde_json::from_str::<BridgeToBrowserMessage>(&text).expect("decode second chunk")
+            }
+            other => panic!("expected text message, got {other:?}"),
+        };
+        assert_eq!(
+            second_chunk,
+            BridgeToBrowserMessage::ApiStreamChunk {
+                id: "stream-1".to_string(),
+                chunk_base64: base64::engine::general_purpose::STANDARD.encode(b"chunk-2"),
+            }
+        );
+        let end = match recv_prioritized_bridge_message(&mut control_rx, &mut stream_rx)
+            .await
+            .expect("stream should end cleanly")
+        {
+            Message::Text(text) => {
+                serde_json::from_str::<BridgeToBrowserMessage>(&text).expect("decode end")
+            }
+            other => panic!("expected text message, got {other:?}"),
+        };
+        assert_eq!(
+            end,
+            BridgeToBrowserMessage::ApiStreamEnd {
+                id: "stream-1".to_string(),
+                error: None,
+            }
+        );
+
+        stream_task
+            .await
+            .expect("stream task join")
+            .expect("stream task");
+    }
+
+    #[tokio::test]
+    async fn stream_task_registry_cleans_up_fast_completed_streams_after_registration() {
+        let registry = Arc::new(StdMutex::new(StreamTaskAbortRegistry::default()));
+        let mut stream_tasks = JoinSet::new();
+        let abort_handle = stream_tasks.spawn(async {});
+
+        tokio::task::yield_now().await;
+        register_stream_task_abort(&registry, "stream-fast".to_string(), abort_handle);
+
+        let joined = stream_tasks
+            .join_next_with_id()
+            .await
+            .expect("fast stream should complete");
+        let completed_task_id = match joined {
+            Ok((task_id, ())) => task_id,
+            Err(err) => panic!("fast stream should not fail: {err}"),
+        };
+        remove_completed_stream_task_abort(&registry, completed_task_id);
+
+        let aborts = registry.lock().expect("registry lock");
+        assert!(aborts.by_request_id.is_empty());
+        assert!(aborts.by_task_id.is_empty());
+    }
+
+    #[tokio::test]
+    async fn api_stream_cancel_aborts_only_the_matching_stream_task() {
+        let registry = Arc::new(StdMutex::new(StreamTaskAbortRegistry::default()));
+        let mut stream_tasks = JoinSet::new();
+        let (survivor_tx, survivor_rx) = tokio::sync::oneshot::channel::<()>();
+
+        let cancelled_handle = stream_tasks.spawn(async {
+            std::future::pending::<()>().await;
+            false
+        });
+        let cancelled_task_id = cancelled_handle.id();
+        register_stream_task_abort(&registry, "stream-cancelled".to_string(), cancelled_handle);
+
+        let survivor_handle = stream_tasks.spawn(async move {
+            survivor_rx
+                .await
+                .expect("survivor should receive completion");
+            true
+        });
+        let survivor_task_id = survivor_handle.id();
+        register_stream_task_abort(&registry, "stream-survivor".to_string(), survivor_handle);
+
+        cancel_stream_task_abort(&registry, "stream-cancelled");
+
+        {
+            let aborts = registry.lock().expect("registry lock");
+            assert!(!aborts.by_request_id.contains_key("stream-cancelled"));
+            assert!(aborts.by_request_id.contains_key("stream-survivor"));
+        }
+
+        survivor_tx.send(()).expect("send completion");
+
+        let mut cancelled_joined = false;
+        let mut survivor_joined = false;
+        while let Some(joined) = stream_tasks.join_next_with_id().await {
+            let completed_task_id = match &joined {
+                Ok((task_id, _)) => *task_id,
+                Err(err) => err.id(),
+            };
+            remove_completed_stream_task_abort(&registry, completed_task_id);
+            match joined {
+                Ok((task_id, result)) => {
+                    if task_id == survivor_task_id {
+                        assert!(result, "survivor stream should complete normally");
+                        survivor_joined = true;
+                    } else {
+                        panic!("unexpected successful stream task: {task_id}");
+                    }
+                }
+                Err(err) => {
+                    assert!(err.is_cancelled(), "unexpected join error: {err}");
+                    assert_eq!(err.id(), cancelled_task_id);
+                    cancelled_joined = true;
+                }
+            }
+            if cancelled_joined && survivor_joined {
+                break;
+            }
+        }
+
+        assert!(cancelled_joined, "matching stream should be cancelled");
+        assert!(survivor_joined, "non-matching stream should keep running");
+
+        let aborts = registry.lock().expect("registry lock");
+        assert!(aborts.by_request_id.is_empty());
+        assert!(aborts.by_task_id.is_empty());
     }
 }

--- a/crates/conductor-relay/src/relay.rs
+++ b/crates/conductor-relay/src/relay.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use axum::body::{Body, Bytes};
 use axum::extract::ws::{CloseFrame, Message, WebSocket, WebSocketUpgrade};
 use axum::extract::ConnectInfo;
 use axum::extract::{Path, Query, State};
@@ -10,7 +11,9 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, post};
 use axum::{Json, Router};
 use base64::Engine;
-use conductor_types::{BridgeStatus, BridgeToBrowserMessage, BrowserToBridgeMessage};
+use conductor_types::{
+    BridgeStatus, BridgeToBrowserMessage, BrowserToBridgeMessage, API_STREAM_V1_CAPABILITY,
+};
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -19,8 +22,10 @@ use std::env;
 use std::io::ErrorKind;
 use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
+use std::task::{Context as TaskContext, Poll};
 use std::time::{Duration, Instant};
 use tokio::fs::{self, OpenOptions};
 use tokio::io::AsyncWriteExt;
@@ -30,12 +35,13 @@ use tower_http::cors::CorsLayer;
 use tracing::{info, warn};
 use uuid::Uuid;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct RelayState {
     inner: Arc<Mutex<RelayInner>>,
     persistence: Arc<Mutex<PersistenceCoordinator>>,
     trusted_proxies: Arc<Vec<TrustedProxyNetwork>>,
     queue_budget: Arc<QueueByteBudget>,
+    api_stream_queue_budget: Arc<ApiStreamQueueByteBudget>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -58,8 +64,10 @@ struct RelayInner {
     devices: HashMap<String, DeviceRecord>,
     terminal_sessions: HashMap<String, TerminalSessionRecord>,
     pending_api_requests: HashMap<String, PendingApiRequest>,
+    pending_api_stream_requests: HashMap<String, PendingApiStreamRequest>,
     pending_preview_requests: HashMap<String, PendingPreviewRequest>,
     pending_api_bytes: usize,
+    pending_api_stream_bytes: usize,
     pending_preview_bytes: usize,
     pending_device_claim_bytes: usize,
     refresh_tokens: HashMap<String, String>,
@@ -74,6 +82,7 @@ struct BridgeChannel {
     bridge: Option<ConnectionRecord>,
     browsers: HashMap<u64, ConnectionRecord>,
     last_status: Option<BridgeStatus>,
+    active_bridge_status_seen: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -480,6 +489,14 @@ struct PendingApiRequest {
 }
 
 #[derive(Debug)]
+struct PendingApiStreamRequest {
+    device_id: String,
+    request_bytes: usize,
+    tx: ApiStreamEventSender,
+    started: bool,
+}
+
+#[derive(Debug)]
 struct PendingPreviewRequest {
     device_id: String,
     request_bytes: usize,
@@ -490,6 +507,260 @@ struct PendingPreviewRequest {
 struct ProxiedApiResponse {
     status: u16,
     body: Value,
+}
+
+#[derive(Debug)]
+struct ProxiedApiStreamResponse {
+    status: u16,
+    headers: BTreeMap<String, String>,
+    body: ProxiedApiStreamBody,
+}
+
+#[derive(Debug)]
+enum ProxiedApiStreamEvent {
+    Start {
+        status: u16,
+        headers: BTreeMap<String, String>,
+    },
+    Chunk(Vec<u8>),
+    End {
+        error: Option<String>,
+    },
+}
+
+#[derive(Debug)]
+struct ProxiedApiStreamBody {
+    cleanup: Option<PendingApiStreamCleanup>,
+    receiver: ApiStreamEventReceiver,
+    finished: bool,
+}
+
+#[derive(Debug)]
+struct ApiStreamQueueByteBudget {
+    queued_bytes: AtomicUsize,
+    capacity: usize,
+}
+
+impl ApiStreamQueueByteBudget {
+    fn new(capacity: usize) -> Self {
+        Self {
+            queued_bytes: AtomicUsize::new(0),
+            capacity,
+        }
+    }
+
+    fn production() -> Self {
+        Self::new(GLOBAL_API_STREAM_EVENT_QUEUE_BYTE_CAPACITY)
+    }
+
+    fn try_reserve(self: &Arc<Self>, bytes: usize) -> Option<ApiStreamQueueByteReservation> {
+        self.queued_bytes
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |queued| {
+                queued
+                    .checked_add(bytes)
+                    .filter(|next| *next <= self.capacity)
+            })
+            .ok()?;
+        Some(ApiStreamQueueByteReservation {
+            stream_bytes: None,
+            aggregate: Arc::clone(self),
+            bytes,
+        })
+    }
+
+    fn release(&self, bytes: usize) {
+        self.queued_bytes.fetch_sub(bytes, Ordering::AcqRel);
+    }
+
+    #[cfg(test)]
+    fn usage(&self) -> usize {
+        self.queued_bytes.load(Ordering::Acquire)
+    }
+}
+
+#[derive(Debug)]
+struct ApiStreamQueueByteReservation {
+    stream_bytes: Option<Arc<AtomicUsize>>,
+    aggregate: Arc<ApiStreamQueueByteBudget>,
+    bytes: usize,
+}
+
+impl Drop for ApiStreamQueueByteReservation {
+    fn drop(&mut self) {
+        if let Some(stream_bytes) = self.stream_bytes.as_ref() {
+            stream_bytes.fetch_sub(self.bytes, Ordering::AcqRel);
+        }
+        self.aggregate.release(self.bytes);
+    }
+}
+
+#[derive(Debug)]
+struct QueuedApiStreamEvent {
+    event: ProxiedApiStreamEvent,
+    _reservation: ApiStreamQueueByteReservation,
+}
+
+#[derive(Debug, Clone)]
+struct ApiStreamEventSender {
+    tx: mpsc::Sender<QueuedApiStreamEvent>,
+    queued_bytes: Arc<AtomicUsize>,
+    byte_capacity: usize,
+    aggregate_budget: Arc<ApiStreamQueueByteBudget>,
+}
+
+#[derive(Debug)]
+struct ApiStreamEventReceiver {
+    rx: mpsc::Receiver<QueuedApiStreamEvent>,
+}
+
+#[derive(Debug)]
+struct PendingApiStreamCleanup {
+    state: RelayState,
+    device_id: String,
+    request_id: String,
+}
+
+impl futures_util::Stream for ProxiedApiStreamBody {
+    type Item = std::result::Result<Bytes, std::io::Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<Option<Self::Item>> {
+        match Pin::new(&mut self.receiver.rx).poll_recv(cx) {
+            Poll::Ready(Some(QueuedApiStreamEvent {
+                event: ProxiedApiStreamEvent::Chunk(chunk),
+                ..
+            })) => Poll::Ready(Some(Ok(Bytes::from(chunk)))),
+            Poll::Ready(Some(QueuedApiStreamEvent {
+                event: ProxiedApiStreamEvent::End { error },
+                ..
+            })) => {
+                self.finished = true;
+                if let Some(error) = error {
+                    let request_id = self
+                        .cleanup
+                        .as_ref()
+                        .map(|cleanup| cleanup.request_id.as_str())
+                        .unwrap_or("buffered-compat");
+                    warn!(request_id = %request_id, error = %error, "proxied API stream ended early");
+                }
+                Poll::Ready(None)
+            }
+            Poll::Ready(Some(QueuedApiStreamEvent {
+                event: ProxiedApiStreamEvent::Start { .. },
+                ..
+            })) => {
+                self.finished = true;
+                Poll::Ready(Some(Err(std::io::Error::new(
+                    ErrorKind::InvalidData,
+                    "proxied API stream received a duplicate start event",
+                ))))
+            }
+            Poll::Ready(None) => {
+                self.finished = true;
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl ApiStreamEventSender {
+    fn try_send(
+        &self,
+        event: ProxiedApiStreamEvent,
+    ) -> std::result::Result<(), mpsc::error::TrySendError<ProxiedApiStreamEvent>> {
+        let bytes = proxied_api_stream_event_size(&event);
+        let reserved =
+            self.queued_bytes
+                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |queued| {
+                    queued
+                        .checked_add(bytes)
+                        .filter(|next| *next <= self.byte_capacity)
+                });
+        if reserved.is_err() {
+            return Err(mpsc::error::TrySendError::Full(event));
+        }
+
+        let Some(mut reservation) = self.aggregate_budget.try_reserve(bytes) else {
+            self.queued_bytes.fetch_sub(bytes, Ordering::AcqRel);
+            return Err(mpsc::error::TrySendError::Full(event));
+        };
+        reservation.stream_bytes = Some(Arc::clone(&self.queued_bytes));
+
+        match self.tx.try_send(QueuedApiStreamEvent {
+            event,
+            _reservation: reservation,
+        }) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(queued)) => {
+                Err(mpsc::error::TrySendError::Full(queued.event))
+            }
+            Err(mpsc::error::TrySendError::Closed(queued)) => {
+                Err(mpsc::error::TrySendError::Closed(queued.event))
+            }
+        }
+    }
+}
+
+impl ApiStreamEventReceiver {
+    async fn recv(&mut self) -> Option<ProxiedApiStreamEvent> {
+        let queued = self.rx.recv().await?;
+        Some(queued.event)
+    }
+}
+
+fn api_stream_event_channel(
+    capacity: usize,
+    byte_capacity: usize,
+    aggregate_budget: Arc<ApiStreamQueueByteBudget>,
+) -> (ApiStreamEventSender, ApiStreamEventReceiver) {
+    let (tx, rx) = mpsc::channel(capacity);
+    let queued_bytes = Arc::new(AtomicUsize::new(0));
+    (
+        ApiStreamEventSender {
+            tx,
+            queued_bytes: Arc::clone(&queued_bytes),
+            byte_capacity,
+            aggregate_budget,
+        },
+        ApiStreamEventReceiver { rx },
+    )
+}
+
+fn proxied_api_stream_event_size(event: &ProxiedApiStreamEvent) -> usize {
+    match event {
+        ProxiedApiStreamEvent::Start { headers, .. } => headers
+            .iter()
+            .map(|(name, value)| name.len().saturating_add(value.len()))
+            .sum::<usize>()
+            .saturating_add(32),
+        ProxiedApiStreamEvent::Chunk(chunk) => chunk.len(),
+        ProxiedApiStreamEvent::End { error } => error.as_ref().map_or(0, String::len),
+    }
+}
+
+impl Drop for ProxiedApiStreamBody {
+    fn drop(&mut self) {
+        if self.finished {
+            return;
+        }
+        let Some(cleanup) = self.cleanup.take() else {
+            return;
+        };
+        tokio::spawn(async move {
+            let should_cancel = {
+                let mut inner = cleanup.state.inner.lock().await;
+                inner
+                    .take_pending_api_stream_for_device(&cleanup.request_id, &cleanup.device_id)
+                    .is_some()
+            };
+            if should_cancel {
+                cleanup
+                    .state
+                    .send_api_stream_cancel(&cleanup.device_id, &cleanup.request_id)
+                    .await;
+            }
+        });
+    }
 }
 
 #[derive(Debug)]
@@ -683,6 +954,10 @@ struct DeviceAuthResolveResponse {
 struct DeviceProxyRequest {
     method: String,
     path: String,
+    #[serde(default)]
+    headers: BTreeMap<String, String>,
+    #[serde(default)]
+    stream: bool,
     body: Option<Value>,
 }
 
@@ -804,9 +1079,14 @@ const DEVICE_ACCESS_TOKEN_TTL_SECS: u64 = 3600;
 const DEVICE_PROXY_TIMEOUT: Duration = Duration::from_secs(45);
 const DEVICE_PICKER_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 const MAX_PENDING_API_REQUESTS: usize = 256;
+const MAX_PENDING_API_STREAM_REQUESTS: usize = 64;
 const MAX_PENDING_PREVIEW_REQUESTS: usize = 128;
 const MAX_PENDING_API_REQUEST_BYTES: usize = 8 * 1024 * 1024;
+const MAX_PENDING_API_STREAM_REQUEST_BYTES: usize = 4 * 1024 * 1024;
 const MAX_PENDING_PREVIEW_REQUEST_BYTES: usize = 8 * 1024 * 1024;
+const API_STREAM_EVENT_QUEUE_CAPACITY: usize = 4;
+const API_STREAM_EVENT_QUEUE_BYTE_CAPACITY: usize = MAX_WS_MESSAGE_BYTES;
+const GLOBAL_API_STREAM_EVENT_QUEUE_BYTE_CAPACITY: usize = 4 * 1024 * 1024;
 const MAX_TERMINAL_SESSIONS: usize = 256;
 const MAX_TERMINAL_SESSIONS_PER_DEVICE: usize = 16;
 const MAX_TERMINAL_SESSIONS_PER_USER: usize = 64;
@@ -827,6 +1107,7 @@ impl Default for RelayState {
             persistence: Arc::new(Mutex::new(PersistenceCoordinator::default())),
             trusted_proxies: Arc::new(Vec::new()),
             queue_budget: Arc::new(QueueByteBudget::production()),
+            api_stream_queue_budget: Arc::new(ApiStreamQueueByteBudget::production()),
         }
     }
 }
@@ -960,6 +1241,7 @@ impl RelayState {
             })),
             trusted_proxies: Arc::new(Vec::new()),
             queue_budget: Arc::new(QueueByteBudget::production()),
+            api_stream_queue_budget: Arc::new(ApiStreamQueueByteBudget::production()),
         })
     }
 
@@ -1554,12 +1836,29 @@ async fn proxy_device_api(
             .into_response();
     };
 
-    match state
-        .forward_device_api_request(&user_id, &device_id, &body.method, &body.path, body.body)
-        .await
-    {
-        Ok(response) => response_from_proxied_api(response.status, response.body),
-        Err((status, message)) => (status, Json(json!({ "error": message }))).into_response(),
+    if body.stream {
+        match state
+            .forward_device_api_stream_request(
+                &user_id,
+                &device_id,
+                &body.method,
+                &body.path,
+                body.headers,
+                body.body,
+            )
+            .await
+        {
+            Ok(response) => response_from_proxied_api_stream(response),
+            Err((status, message)) => (status, Json(json!({ "error": message }))).into_response(),
+        }
+    } else {
+        match state
+            .forward_device_api_request(&user_id, &device_id, &body.method, &body.path, body.body)
+            .await
+        {
+            Ok(response) => response_from_proxied_api(response.status, response.body),
+            Err((status, message)) => (status, Json(json!({ "error": message }))).into_response(),
+        }
     }
 }
 
@@ -1776,8 +2075,14 @@ async fn delete_bridge(
             .into_response();
     };
 
-    let (bridge_closes, browser_closes, pending_requests, pending_previews, removed) =
-        state.disconnect_bridge_for_user(&user_id, &bridge_id).await;
+    let (
+        bridge_closes,
+        browser_closes,
+        pending_requests,
+        pending_streams,
+        pending_previews,
+        removed,
+    ) = state.disconnect_bridge_for_user(&user_id, &bridge_id).await;
     close_senders(bridge_closes).await;
     close_senders(browser_closes).await;
     fail_pending_api_requests(
@@ -1785,6 +2090,7 @@ async fn delete_bridge(
         StatusCode::SERVICE_UNAVAILABLE,
         "Device disconnected.",
     );
+    fail_pending_api_stream_requests(pending_streams, Some("Device disconnected.".to_string()));
     fail_pending_preview_requests(pending_previews, StatusCode::SERVICE_UNAVAILABLE);
 
     if removed {
@@ -1867,6 +2173,7 @@ async fn bridge_ws(
                     os: format_device_os(&device.os, &device.arch),
                     connected: true,
                     version: None,
+                    capabilities: Vec::new(),
                 }),
             )
         } else if let Some(user_id) = query
@@ -3000,7 +3307,9 @@ impl RelayState {
                         os: env::consts::OS.to_string(),
                         connected: true,
                         version: None,
+                        capabilities: Vec::new(),
                     }));
+                    channel.active_bridge_status_seen = false;
                     replaced
                 }
                 PeerKind::Browser => {
@@ -3023,6 +3332,7 @@ impl RelayState {
     async fn unregister_connection(&self, key: &str, peer_kind: PeerKind, connection_id: u64) {
         let mut browsers_to_notify = Vec::new();
         let mut failed_api_requests = Vec::new();
+        let mut failed_api_stream_requests = Vec::new();
         let mut failed_preview_requests = Vec::new();
         let mut remove_pending_for_device = false;
         let mut remove_channel = false;
@@ -3039,6 +3349,7 @@ impl RelayState {
                             .is_some_and(|record| record.id == connection_id)
                         {
                             channel.bridge = None;
+                            channel.active_bridge_status_seen = false;
                             let status = channel
                                 .last_status
                                 .clone()
@@ -3047,12 +3358,14 @@ impl RelayState {
                                     os: last.os,
                                     connected: false,
                                     version: last.version,
+                                    capabilities: last.capabilities,
                                 })
                                 .unwrap_or(BridgeStatus {
                                     hostname: host_name(),
                                     os: env::consts::OS.to_string(),
                                     connected: false,
                                     version: None,
+                                    capabilities: Vec::new(),
                                 });
                             channel.last_status = Some(status.clone());
                             status_to_broadcast = Some(status);
@@ -3091,6 +3404,18 @@ impl RelayState {
                     }
                 }
 
+                let pending_stream_ids = inner
+                    .pending_api_stream_requests
+                    .iter()
+                    .filter(|(_, pending)| pending.device_id == key)
+                    .map(|(request_id, _)| request_id.clone())
+                    .collect::<Vec<_>>();
+                for request_id in pending_stream_ids {
+                    if let Some(pending) = inner.take_pending_api_stream(&request_id) {
+                        failed_api_stream_requests.push(pending.tx);
+                    }
+                }
+
                 let preview_ids = inner
                     .pending_preview_requests
                     .iter()
@@ -3112,6 +3437,12 @@ impl RelayState {
             });
         }
 
+        for pending in failed_api_stream_requests {
+            let _ = pending.try_send(ProxiedApiStreamEvent::End {
+                error: Some("Device disconnected.".to_string()),
+            });
+        }
+
         for pending in failed_preview_requests {
             let _ = pending.send(ProxiedPreviewResponse {
                 status: StatusCode::SERVICE_UNAVAILABLE.as_u16(),
@@ -3126,6 +3457,7 @@ impl RelayState {
                 os: status.os,
                 connected: status.connected,
                 version: status.version,
+                capabilities: status.capabilities,
             }) {
                 for browser in browsers_to_notify {
                     let _ = browser.try_send(Message::Text(text.clone().into()));
@@ -3313,6 +3645,155 @@ impl RelayState {
             }
         }
 
+        if let BridgeToBrowserMessage::ApiStreamStart {
+            id,
+            status,
+            headers,
+        } = &message
+        {
+            let (pending, duplicate_pending, wrong_device) = {
+                let mut inner = self.inner.lock().await;
+                if !inner.bridge_connection_is_current(key, connection_id) {
+                    return false;
+                }
+                let wrong_device = inner
+                    .pending_api_stream_requests
+                    .get(id)
+                    .is_some_and(|pending| pending.device_id != key);
+                if wrong_device {
+                    (None, None, true)
+                } else if inner
+                    .pending_api_stream_requests
+                    .get(id)
+                    .is_some_and(|pending| pending.started)
+                {
+                    (
+                        None,
+                        inner.take_pending_api_stream_for_device(id, key),
+                        false,
+                    )
+                } else {
+                    let pending = inner
+                        .pending_api_stream_requests
+                        .get_mut(id)
+                        .map(|pending| {
+                            pending.started = true;
+                            pending.tx.clone()
+                        });
+                    (pending, None, false)
+                }
+            };
+
+            if let Some(pending) = duplicate_pending {
+                let _ = pending.tx.try_send(ProxiedApiStreamEvent::End {
+                    error: Some("received duplicate stream start event".to_string()),
+                });
+                self.send_api_stream_cancel(key, id).await;
+                return true;
+            }
+            if let Some(pending) = pending {
+                match pending.try_send(ProxiedApiStreamEvent::Start {
+                    status: *status,
+                    headers: headers.clone(),
+                }) {
+                    Ok(()) => return true,
+                    Err(_) => {
+                        let should_cancel = {
+                            let mut inner = self.inner.lock().await;
+                            inner.take_pending_api_stream_for_device(id, key).is_some()
+                        };
+                        if should_cancel {
+                            self.send_api_stream_cancel(key, id).await;
+                        }
+                        return true;
+                    }
+                }
+            }
+            if wrong_device {
+                return true;
+            }
+        }
+
+        if let BridgeToBrowserMessage::ApiStreamChunk { id, chunk_base64 } = &message {
+            let (pending, wrong_device) = {
+                let inner = self.inner.lock().await;
+                if !inner.bridge_connection_is_current(key, connection_id) {
+                    return false;
+                }
+                let wrong_device = inner
+                    .pending_api_stream_requests
+                    .get(id)
+                    .is_some_and(|pending| pending.device_id != key);
+                (
+                    inner
+                        .pending_api_stream_requests
+                        .get(id)
+                        .map(|pending| pending.tx.clone()),
+                    wrong_device,
+                )
+            };
+
+            if let Some(pending) = pending {
+                let chunk = match base64::engine::general_purpose::STANDARD.decode(chunk_base64) {
+                    Ok(chunk) => chunk,
+                    Err(err) => {
+                        warn!(request_id = %id, error = %err, "invalid proxied API stream chunk");
+                        let should_cancel = {
+                            let mut inner = self.inner.lock().await;
+                            inner.take_pending_api_stream_for_device(id, key).is_some()
+                        };
+                        if should_cancel {
+                            self.send_api_stream_cancel(key, id).await;
+                        }
+                        return true;
+                    }
+                };
+                match pending.try_send(ProxiedApiStreamEvent::Chunk(chunk)) {
+                    Ok(()) => return true,
+                    Err(_) => {
+                        let should_cancel = {
+                            let mut inner = self.inner.lock().await;
+                            inner.take_pending_api_stream_for_device(id, key).is_some()
+                        };
+                        if should_cancel {
+                            self.send_api_stream_cancel(key, id).await;
+                        }
+                        return true;
+                    }
+                }
+            }
+            if wrong_device {
+                return true;
+            }
+        }
+
+        if let BridgeToBrowserMessage::ApiStreamEnd { id, error } = &message {
+            let (pending, wrong_device) = {
+                let mut inner = self.inner.lock().await;
+                if !inner.bridge_connection_is_current(key, connection_id) {
+                    return false;
+                }
+                let wrong_device = inner
+                    .pending_api_stream_requests
+                    .get(id)
+                    .is_some_and(|pending| pending.device_id != key);
+                (
+                    inner.take_pending_api_stream_for_device(id, key),
+                    wrong_device,
+                )
+            };
+
+            if let Some(pending) = pending {
+                let _ = pending.tx.try_send(ProxiedApiStreamEvent::End {
+                    error: error.clone(),
+                });
+                return true;
+            }
+            if wrong_device {
+                return true;
+            }
+        }
+
         if let BridgeToBrowserMessage::PreviewResponse {
             id,
             status,
@@ -3367,6 +3848,7 @@ impl RelayState {
                 os,
                 connected,
                 version,
+                capabilities,
             } = &message
             {
                 channel.last_status = Some(BridgeStatus {
@@ -3374,7 +3856,9 @@ impl RelayState {
                     os: os.clone(),
                     connected: *connected,
                     version: normalize_bridge_version(version.clone()),
+                    capabilities: normalize_bridge_capabilities(capabilities.clone()),
                 });
+                channel.active_bridge_status_seen = true;
             }
 
             channel
@@ -3389,6 +3873,31 @@ impl RelayState {
             let _ = browser.try_send(Message::Text(raw_text.clone().into()));
         }
         true
+    }
+
+    async fn send_api_stream_cancel(&self, device_id: &str, request_id: &str) {
+        let payload = match serde_json::to_string(&BrowserToBridgeMessage::ApiStreamCancel {
+            id: request_id.to_string(),
+        }) {
+            Ok(payload) => payload,
+            Err(err) => {
+                warn!(request_id = %request_id, error = %err, "failed to serialize API stream cancel");
+                return;
+            }
+        };
+        let bridge = {
+            let inner = self.inner.lock().await;
+            inner
+                .channels
+                .get(device_id)
+                .and_then(|channel| channel.bridge.as_ref())
+                .map(|record| record.tx.clone())
+        };
+        if let Some(bridge) = bridge {
+            if bridge.try_send(Message::Text(payload.into())).is_err() {
+                warn!(request_id = %request_id, device_id = %device_id, "failed to enqueue API stream cancel");
+            }
+        }
     }
 
     async fn broadcast_bridge_status(&self, key: &str, connection_id: u64, connected: bool) {
@@ -3413,12 +3922,14 @@ impl RelayState {
                     os: last.os,
                     connected,
                     version: last.version,
+                    capabilities: last.capabilities,
                 })
                 .unwrap_or(BridgeStatus {
                     hostname: host_name(),
                     os: env::consts::OS.to_string(),
                     connected,
                     version: None,
+                    capabilities: Vec::new(),
                 });
 
             channel.last_status = Some(status.clone());
@@ -3435,6 +3946,7 @@ impl RelayState {
             os: status.os,
             connected: status.connected,
             version: status.version,
+            capabilities: status.capabilities,
         }) {
             for browser in browsers {
                 let _ = browser.try_send(Message::Text(text.clone().into()));
@@ -3454,6 +3966,7 @@ impl RelayState {
                     os: env::consts::OS.to_string(),
                     connected: false,
                     version: None,
+                    capabilities: Vec::new(),
                 })
         };
 
@@ -3462,6 +3975,7 @@ impl RelayState {
             os: status.os,
             connected: status.connected,
             version: status.version,
+            capabilities: status.capabilities,
         }) {
             let _ = tx.try_send(Message::Text(text.into()));
         }
@@ -3534,12 +4048,14 @@ impl RelayState {
         Vec<MessageSender>,
         Vec<MessageSender>,
         Vec<oneshot::Sender<ProxiedApiResponse>>,
+        Vec<ApiStreamEventSender>,
         Vec<oneshot::Sender<ProxiedPreviewResponse>>,
         bool,
     ) {
         let mut bridge_txs = Vec::new();
         let mut browser_txs = Vec::new();
         let mut pending_api_requests = Vec::new();
+        let mut pending_api_stream_requests = Vec::new();
         let mut pending_preview_requests = Vec::new();
         let mut removed = false;
 
@@ -3568,6 +4084,12 @@ impl RelayState {
             .filter(|(_, pending)| keys.iter().any(|key| key == &pending.device_id))
             .map(|(request_id, _)| request_id.clone())
             .collect::<Vec<_>>();
+        let pending_stream_ids = inner
+            .pending_api_stream_requests
+            .iter()
+            .filter(|(_, pending)| keys.iter().any(|key| key == &pending.device_id))
+            .map(|(request_id, _)| request_id.clone())
+            .collect::<Vec<_>>();
 
         for key in keys {
             if let Some(channel) = inner.channels.remove(&key) {
@@ -3584,6 +4106,11 @@ impl RelayState {
                 pending_api_requests.push(pending.tx);
             }
         }
+        for request_id in pending_stream_ids {
+            if let Some(pending) = inner.take_pending_api_stream(&request_id) {
+                pending_api_stream_requests.push(pending.tx);
+            }
+        }
         for request_id in pending_preview_ids {
             if let Some(pending) = inner.take_pending_preview(&request_id) {
                 pending_preview_requests.push(pending.tx);
@@ -3594,6 +4121,7 @@ impl RelayState {
             bridge_txs,
             browser_txs,
             pending_api_requests,
+            pending_api_stream_requests,
             pending_preview_requests,
             removed,
         )
@@ -3948,6 +4476,7 @@ impl RelayState {
                                 os: format_device_os(&device.os, &device.arch),
                                 connected: false,
                                 version: None,
+                                capabilities: Vec::new(),
                             })
                         });
 
@@ -4007,7 +4536,7 @@ impl RelayState {
             ));
         }
 
-        let (connection_closes, pending_requests, pending_previews) =
+        let (connection_closes, pending_requests, pending_streams, pending_previews) =
             self.disconnect_device_runtime(device_id).await;
         close_senders(connection_closes).await;
         fail_pending_api_requests(
@@ -4015,6 +4544,7 @@ impl RelayState {
             StatusCode::SERVICE_UNAVAILABLE,
             "Device disconnected.",
         );
+        fail_pending_api_stream_requests(pending_streams, Some("Device disconnected.".to_string()));
         fail_pending_preview_requests(pending_previews, StatusCode::SERVICE_UNAVAILABLE);
 
         Ok(true)
@@ -4026,10 +4556,12 @@ impl RelayState {
     ) -> (
         Vec<MessageSender>,
         Vec<oneshot::Sender<ProxiedApiResponse>>,
+        Vec<ApiStreamEventSender>,
         Vec<oneshot::Sender<ProxiedPreviewResponse>>,
     ) {
         let mut connection_closes = Vec::new();
         let mut pending_api = Vec::new();
+        let mut pending_api_streams = Vec::new();
         let mut pending_preview = Vec::new();
         let mut inner = self.inner.lock().await;
 
@@ -4049,6 +4581,18 @@ impl RelayState {
         for request_id in api_ids {
             if let Some(pending) = inner.take_pending_api(&request_id) {
                 pending_api.push(pending.tx);
+            }
+        }
+
+        let stream_ids = inner
+            .pending_api_stream_requests
+            .iter()
+            .filter(|(_, pending)| pending.device_id == device_id)
+            .map(|(request_id, _)| request_id.clone())
+            .collect::<Vec<_>>();
+        for request_id in stream_ids {
+            if let Some(pending) = inner.take_pending_api_stream(&request_id) {
+                pending_api_streams.push(pending.tx);
             }
         }
 
@@ -4089,13 +4633,61 @@ impl RelayState {
             .values()
             .map(|claim| claim.request_bytes)
             .sum();
-        (connection_closes, pending_api, pending_preview)
+        (
+            connection_closes,
+            pending_api,
+            pending_api_streams,
+            pending_preview,
+        )
     }
 
     async fn resolve_device_auth(&self, refresh_token: &str) -> Option<DeviceRecord> {
         let inner = self.inner.lock().await;
         let device_id = inner.refresh_tokens.get(refresh_token)?;
         inner.devices.get(device_id).cloned()
+    }
+
+    async fn bridge_supports_device_api_stream(
+        &self,
+        user_id: &str,
+        device_id: &str,
+    ) -> std::result::Result<BridgeApiStreamSupport, (StatusCode, String)> {
+        let inner = self.inner.lock().await;
+        match inner.devices.get(device_id) {
+            Some(device) if device.owner_user_id == user_id => {}
+            Some(_) => {
+                return Err((
+                    StatusCode::FORBIDDEN,
+                    "You do not own this device.".to_string(),
+                ))
+            }
+            None => return Err((StatusCode::NOT_FOUND, "Device not found.".to_string())),
+        }
+
+        let Some(channel) = inner.channels.get(device_id) else {
+            return Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Device is offline.".to_string(),
+            ));
+        };
+        let Some(_bridge_tx) = channel
+            .bridge
+            .as_ref()
+            .filter(|record| record.user_id == user_id)
+        else {
+            return Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Device is offline.".to_string(),
+            ));
+        };
+        if !channel.active_bridge_status_seen {
+            return Ok(BridgeApiStreamSupport::Unknown);
+        }
+        if bridge_supports_api_stream_v1(channel.last_status.as_ref()) {
+            Ok(BridgeApiStreamSupport::Supported)
+        } else {
+            Ok(BridgeApiStreamSupport::Unsupported)
+        }
     }
 
     async fn forward_device_api_request(
@@ -4243,6 +4835,199 @@ impl RelayState {
                 normalized_path = normalized_path
             ),
         ))
+    }
+
+    async fn forward_device_api_stream_request(
+        &self,
+        user_id: &str,
+        device_id: &str,
+        method: &str,
+        path: &str,
+        headers: BTreeMap<String, String>,
+        body: Option<Value>,
+    ) -> std::result::Result<ProxiedApiStreamResponse, (StatusCode, String)> {
+        let normalized_method = method.trim().to_ascii_uppercase();
+        let normalized_path = path.trim();
+        if normalized_method.is_empty() || normalized_path.is_empty() {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "Missing proxy method or path.".to_string(),
+            ));
+        }
+        match self
+            .bridge_supports_device_api_stream(user_id, device_id)
+            .await?
+        {
+            BridgeApiStreamSupport::Supported => {}
+            BridgeApiStreamSupport::Unknown => {
+                return Err((
+                    StatusCode::TOO_EARLY,
+                    "Paired bridge status is not ready yet. Retry the event stream shortly."
+                        .to_string(),
+                ));
+            }
+            BridgeApiStreamSupport::Unsupported => {
+                return Err((
+                    StatusCode::UPGRADE_REQUIRED,
+                    "Paired bridge must support api_stream_v1. Upgrade the bridge and retry."
+                        .to_string(),
+                ));
+            }
+        }
+
+        let request_id = Uuid::new_v4().to_string();
+        let message = serde_json::to_string(&BrowserToBridgeMessage::ApiStreamRequest {
+            id: request_id.clone(),
+            method: normalized_method,
+            path: normalized_path.to_string(),
+            headers,
+            body,
+        })
+        .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?;
+        let request_bytes = message.len();
+        if request_bytes > MAX_WS_MESSAGE_BYTES {
+            return Err((
+                StatusCode::PAYLOAD_TOO_LARGE,
+                "Device API stream request exceeds the relay byte limit.".to_string(),
+            ));
+        }
+
+        let request_timeout = device_proxy_timeout_for_url(normalized_path);
+        let (bridge_tx, mut receiver) = {
+            let mut inner = self.inner.lock().await;
+            match inner.devices.get(device_id) {
+                Some(device) if device.owner_user_id == user_id => {}
+                Some(_) => {
+                    return Err((
+                        StatusCode::FORBIDDEN,
+                        "You do not own this device.".to_string(),
+                    ))
+                }
+                None => return Err((StatusCode::NOT_FOUND, "Device not found.".to_string())),
+            }
+
+            let Some(channel) = inner.channels.get(device_id) else {
+                return Err((
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "Device is offline.".to_string(),
+                ));
+            };
+            let Some(bridge_tx) = channel
+                .bridge
+                .as_ref()
+                .filter(|record| record.user_id == user_id)
+                .map(|record| record.tx.clone())
+            else {
+                return Err((
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "Device is offline.".to_string(),
+                ));
+            };
+            if !channel.active_bridge_status_seen {
+                return Err((
+                    StatusCode::TOO_EARLY,
+                    "Paired bridge status is not ready yet. Retry the event stream shortly."
+                        .to_string(),
+                ));
+            }
+            if !bridge_supports_api_stream_v1(channel.last_status.as_ref()) {
+                return Err((
+                    StatusCode::UPGRADE_REQUIRED,
+                    "Paired bridge must support api_stream_v1. Upgrade the bridge and retry."
+                        .to_string(),
+                ));
+            }
+
+            let (tx, rx) = api_stream_event_channel(
+                API_STREAM_EVENT_QUEUE_CAPACITY,
+                API_STREAM_EVENT_QUEUE_BYTE_CAPACITY,
+                Arc::clone(&self.api_stream_queue_budget),
+            );
+            if inner.pending_api_stream_requests.len() >= MAX_PENDING_API_STREAM_REQUESTS
+                || inner.pending_api_stream_bytes.saturating_add(request_bytes)
+                    > MAX_PENDING_API_STREAM_REQUEST_BYTES
+            {
+                return Err((
+                    StatusCode::TOO_MANY_REQUESTS,
+                    "Too many in-flight device API streams.".to_string(),
+                ));
+            }
+            inner.pending_api_stream_requests.insert(
+                request_id.clone(),
+                PendingApiStreamRequest {
+                    device_id: device_id.to_string(),
+                    request_bytes,
+                    tx,
+                    started: false,
+                },
+            );
+            inner.pending_api_stream_bytes =
+                inner.pending_api_stream_bytes.saturating_add(request_bytes);
+            (bridge_tx, rx)
+        };
+
+        if bridge_tx.try_send(Message::Text(message.into())).is_err() {
+            let mut inner = self.inner.lock().await;
+            inner.take_pending_api_stream(&request_id);
+            return Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Device connection is unavailable.".to_string(),
+            ));
+        }
+
+        let (status, response_headers) =
+            match await_proxied_api_stream_start(request_timeout, &mut receiver).await {
+                Ok(start) => start,
+                Err(ProxyStreamWaitError::Closed(message)) => {
+                    let mut inner = self.inner.lock().await;
+                    inner.take_pending_api_stream(&request_id);
+                    return Err((
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        message.unwrap_or_else(|| "Device connection closed.".to_string()),
+                    ));
+                }
+                Err(ProxyStreamWaitError::TimedOut) => {
+                    let should_cancel = {
+                        let mut inner = self.inner.lock().await;
+                        inner.take_pending_api_stream(&request_id).is_some()
+                    };
+                    if should_cancel {
+                        self.send_api_stream_cancel(device_id, &request_id).await;
+                    }
+                    return Err((
+                        StatusCode::GATEWAY_TIMEOUT,
+                        format!(
+                            "Device request timed out after {timeout_secs}s for {normalized_path}",
+                            timeout_secs = request_timeout.as_secs(),
+                            normalized_path = normalized_path
+                        ),
+                    ));
+                }
+                Err(ProxyStreamWaitError::Protocol(message)) => {
+                    let should_cancel = {
+                        let mut inner = self.inner.lock().await;
+                        inner.take_pending_api_stream(&request_id).is_some()
+                    };
+                    if should_cancel {
+                        self.send_api_stream_cancel(device_id, &request_id).await;
+                    }
+                    return Err((StatusCode::BAD_GATEWAY, message.to_string()));
+                }
+            };
+
+        Ok(ProxiedApiStreamResponse {
+            status,
+            headers: response_headers,
+            body: ProxiedApiStreamBody {
+                cleanup: Some(PendingApiStreamCleanup {
+                    state: self.clone(),
+                    device_id: device_id.to_string(),
+                    request_id,
+                }),
+                receiver,
+                finished: false,
+            },
+        })
     }
 
     async fn forward_device_preview_request(
@@ -4503,6 +5288,14 @@ impl RelayInner {
         Some(pending)
     }
 
+    fn take_pending_api_stream(&mut self, request_id: &str) -> Option<PendingApiStreamRequest> {
+        let pending = self.pending_api_stream_requests.remove(request_id)?;
+        self.pending_api_stream_bytes = self
+            .pending_api_stream_bytes
+            .saturating_sub(pending.request_bytes);
+        Some(pending)
+    }
+
     fn take_pending_api_for_device(
         &mut self,
         request_id: &str,
@@ -4516,6 +5309,21 @@ impl RelayInner {
             return None;
         }
         self.take_pending_api(request_id)
+    }
+
+    fn take_pending_api_stream_for_device(
+        &mut self,
+        request_id: &str,
+        device_id: &str,
+    ) -> Option<PendingApiStreamRequest> {
+        if self
+            .pending_api_stream_requests
+            .get(request_id)
+            .is_none_or(|pending| pending.device_id != device_id)
+        {
+            return None;
+        }
+        self.take_pending_api_stream(request_id)
     }
 
     fn take_pending_preview(&mut self, request_id: &str) -> Option<PendingPreviewRequest> {
@@ -4581,6 +5389,20 @@ enum ProxyResponseWaitError {
     TimedOut,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ProxyStreamWaitError {
+    Closed(Option<String>),
+    TimedOut,
+    Protocol(&'static str),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BridgeApiStreamSupport {
+    Unknown,
+    Supported,
+    Unsupported,
+}
+
 async fn await_proxied_api_response(
     request_timeout: Duration,
     receiver: oneshot::Receiver<ProxiedApiResponse>,
@@ -4589,6 +5411,21 @@ async fn await_proxied_api_response(
         Ok(Ok(response)) => Ok(response),
         Ok(Err(_)) => Err(ProxyResponseWaitError::Closed),
         Err(_) => Err(ProxyResponseWaitError::TimedOut),
+    }
+}
+
+async fn await_proxied_api_stream_start(
+    request_timeout: Duration,
+    receiver: &mut ApiStreamEventReceiver,
+) -> std::result::Result<(u16, BTreeMap<String, String>), ProxyStreamWaitError> {
+    match tokio::time::timeout(request_timeout, receiver.recv()).await {
+        Ok(Some(ProxiedApiStreamEvent::Start { status, headers })) => Ok((status, headers)),
+        Ok(Some(ProxiedApiStreamEvent::End { error })) => Err(ProxyStreamWaitError::Closed(error)),
+        Ok(Some(ProxiedApiStreamEvent::Chunk(_))) => Err(ProxyStreamWaitError::Protocol(
+            "received stream chunk before start",
+        )),
+        Ok(None) => Err(ProxyStreamWaitError::Closed(None)),
+        Err(_) => Err(ProxyStreamWaitError::TimedOut),
     }
 }
 
@@ -4601,6 +5438,14 @@ fn fail_pending_api_requests(
         let _ = request.send(ProxiedApiResponse {
             status: status.as_u16(),
             body: json!({ "error": message }),
+        });
+    }
+}
+
+fn fail_pending_api_stream_requests(requests: Vec<ApiStreamEventSender>, error: Option<String>) {
+    for request in requests {
+        let _ = request.try_send(ProxiedApiStreamEvent::End {
+            error: error.clone(),
         });
     }
 }
@@ -4679,6 +5524,21 @@ fn response_from_proxied_api(status: u16, body: Value) -> Response {
         }
         _ => (status_code, Json(body)).into_response(),
     }
+}
+
+fn response_from_proxied_api_stream(response: ProxiedApiStreamResponse) -> Response {
+    let status_code = StatusCode::from_u16(response.status).unwrap_or(StatusCode::BAD_GATEWAY);
+    let mut headers = HeaderMap::new();
+    for (name, value) in response.headers {
+        let Ok(header_name) = axum::http::header::HeaderName::from_bytes(name.as_bytes()) else {
+            continue;
+        };
+        let Ok(header_value) = HeaderValue::from_str(&value) else {
+            continue;
+        };
+        headers.insert(header_name, header_value);
+    }
+    (status_code, headers, Body::from_stream(response.body)).into_response()
 }
 
 async fn send_bridge_error(tx: &MessageSender, id: &str, status: StatusCode, message: &str) {
@@ -4783,6 +5643,26 @@ fn normalize_bridge_version(version: Option<String>) -> Option<String> {
     version
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
+}
+
+fn normalize_bridge_capabilities(capabilities: Vec<String>) -> Vec<String> {
+    let mut normalized = capabilities
+        .into_iter()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>();
+    normalized.sort();
+    normalized.dedup();
+    normalized
+}
+
+fn bridge_supports_api_stream_v1(status: Option<&BridgeStatus>) -> bool {
+    status.is_some_and(|status| {
+        status
+            .capabilities
+            .iter()
+            .any(|capability| capability == API_STREAM_V1_CAPABILITY)
+    })
 }
 
 fn format_device_os(os: &str, arch: &str) -> String {
@@ -4943,6 +5823,7 @@ fn generate_claim_token() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures_util::StreamExt;
     use std::sync::LazyLock;
 
     static RELAY_STATE_ENV_LOCK: LazyLock<tokio::sync::Mutex<()>> =
@@ -5061,6 +5942,30 @@ mod tests {
         assert_eq!(aggregate.usage(&scope_b), (0, 0, 0));
     }
 
+    #[test]
+    fn api_stream_event_queue_enforces_aggregate_byte_budget() {
+        let aggregate = Arc::new(ApiStreamQueueByteBudget::new(8));
+        let (tx_a, rx_a) = api_stream_event_channel(4, 8, Arc::clone(&aggregate));
+        let (tx_b, rx_b) = api_stream_event_channel(4, 8, Arc::clone(&aggregate));
+
+        tx_a.try_send(ProxiedApiStreamEvent::Chunk(vec![1; 5]))
+            .expect("first stream should reserve bytes");
+        assert_eq!(aggregate.usage(), 5);
+        assert!(
+            tx_b.try_send(ProxiedApiStreamEvent::Chunk(vec![2; 4]))
+                .is_err(),
+            "aggregate bytes must be enforced across concurrent slow streams"
+        );
+
+        drop(rx_a);
+        assert_eq!(aggregate.usage(), 0);
+        tx_b.try_send(ProxiedApiStreamEvent::Chunk(vec![3; 4]))
+            .expect("dropping a slow stream should release its queued reservation");
+
+        drop(rx_b);
+        assert_eq!(aggregate.usage(), 0);
+    }
+
     #[tokio::test]
     async fn rate_limit_storage_is_bounded_and_expired_buckets_are_pruned() {
         let state = RelayState::default();
@@ -5134,6 +6039,779 @@ mod tests {
             pending_browser_frames: Vec::new(),
             pending_browser_frame_bytes: 0,
         }
+    }
+
+    fn bridge_message_text(message: Message) -> String {
+        match message {
+            Message::Text(text) => text.to_string(),
+            other => panic!("expected text websocket message, got {other:?}"),
+        }
+    }
+
+    fn test_api_stream_bridge_status(connected: bool) -> BridgeStatus {
+        BridgeStatus {
+            hostname: "test-bridge".to_string(),
+            os: "darwin".to_string(),
+            connected,
+            version: Some("0.3.4".to_string()),
+            capabilities: vec![API_STREAM_V1_CAPABILITY.to_string()],
+        }
+    }
+
+    async fn report_api_stream_bridge_status(
+        state: &RelayState,
+        device_id: &str,
+        connection_id: u64,
+        connected: bool,
+    ) {
+        let message = BridgeToBrowserMessage::BridgeStatus {
+            hostname: "test-bridge".to_string(),
+            os: "darwin".to_string(),
+            connected,
+            version: Some("0.3.4".to_string()),
+            capabilities: vec![API_STREAM_V1_CAPABILITY.to_string()],
+        };
+        let raw = serde_json::to_string(&message).expect("serialize bridge status");
+        assert!(
+            state
+                .route_bridge_message(device_id, connection_id, message, raw)
+                .await,
+            "bridge status frame should be accepted"
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_device_api_stream_returns_425_before_first_bridge_status_and_sends_no_request()
+    {
+        let state = RelayState::default();
+        {
+            let mut inner = state.inner.lock().await;
+            inner
+                .devices
+                .insert("device-1".to_string(), test_device("device-1", "owner-a"));
+        }
+        let (bridge_tx, mut bridge_rx) = test_message_channel(CONTROL_WS_QUEUE_CAPACITY);
+        state
+            .register_connection(
+                "device-1",
+                PeerKind::Bridge,
+                "owner-a".to_string(),
+                bridge_tx,
+                None,
+            )
+            .await
+            .expect("bridge registration");
+
+        let err = state
+            .forward_device_api_stream_request(
+                "owner-a",
+                "device-1",
+                "GET",
+                "/api/stream",
+                BTreeMap::from([("accept".to_string(), "text/event-stream".to_string())]),
+                None,
+            )
+            .await
+            .expect_err("bridge without a status should force EventSource retry");
+        assert_eq!(err.0, StatusCode::TOO_EARLY);
+        assert!(err.1.contains("Retry"));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), bridge_rx.recv())
+                .await
+                .is_err(),
+            "relay should not send any upstream request before the bridge reports status"
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_device_api_stream_returns_426_for_legacy_bridge_status_and_sends_no_request() {
+        let state = RelayState::default();
+        {
+            let mut inner = state.inner.lock().await;
+            inner
+                .devices
+                .insert("device-1".to_string(), test_device("device-1", "owner-a"));
+        }
+        let (bridge_tx, mut bridge_rx) = test_message_channel(CONTROL_WS_QUEUE_CAPACITY);
+        let connection_id = state
+            .register_connection(
+                "device-1",
+                PeerKind::Bridge,
+                "owner-a".to_string(),
+                bridge_tx,
+                None,
+            )
+            .await
+            .expect("bridge registration");
+
+        let legacy_status = BridgeToBrowserMessage::BridgeStatus {
+            hostname: "legacy-bridge".to_string(),
+            os: "darwin".to_string(),
+            connected: true,
+            version: Some("0.3.3".to_string()),
+            capabilities: Vec::new(),
+        };
+        let legacy_status_raw =
+            serde_json::to_string(&legacy_status).expect("serialize legacy bridge status");
+        assert!(
+            state
+                .route_bridge_message("device-1", connection_id, legacy_status, legacy_status_raw,)
+                .await
+        );
+
+        let err = state
+            .forward_device_api_stream_request(
+                "owner-a",
+                "device-1",
+                "GET",
+                "/api/stream",
+                BTreeMap::from([("accept".to_string(), "text/event-stream".to_string())]),
+                None,
+            )
+            .await
+            .expect_err("legacy bridge status should fail closed with 426");
+        assert_eq!(err.0, StatusCode::UPGRADE_REQUIRED);
+        assert!(err.1.contains(API_STREAM_V1_CAPABILITY));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), bridge_rx.recv())
+                .await
+                .is_err(),
+            "legacy bridges must not receive a fallback buffered API request"
+        );
+    }
+
+    #[tokio::test]
+    async fn bridge_reconnect_with_seeded_status_still_waits_for_an_explicit_status_frame() {
+        let state = RelayState::default();
+        {
+            let mut inner = state.inner.lock().await;
+            inner
+                .devices
+                .insert("device-1".to_string(), test_device("device-1", "owner-a"));
+        }
+
+        let (old_bridge_tx, _old_bridge_rx) = test_message_channel(CONTROL_WS_QUEUE_CAPACITY);
+        let old_connection_id = state
+            .register_connection(
+                "device-1",
+                PeerKind::Bridge,
+                "owner-a".to_string(),
+                old_bridge_tx,
+                None,
+            )
+            .await
+            .expect("initial bridge registration");
+        report_api_stream_bridge_status(&state, "device-1", old_connection_id, true).await;
+
+        let (new_bridge_tx, mut new_bridge_rx) = test_message_channel(CONTROL_WS_QUEUE_CAPACITY);
+        state
+            .register_connection(
+                "device-1",
+                PeerKind::Bridge,
+                "owner-a".to_string(),
+                new_bridge_tx,
+                Some(test_api_stream_bridge_status(true)),
+            )
+            .await
+            .expect("replacement bridge registration");
+
+        let err = state
+            .forward_device_api_stream_request(
+                "owner-a",
+                "device-1",
+                "GET",
+                "/api/stream",
+                BTreeMap::from([("accept".to_string(), "text/event-stream".to_string())]),
+                None,
+            )
+            .await
+            .expect_err("replacement bridge should wait for a fresh status frame");
+        assert_eq!(err.0, StatusCode::TOO_EARLY);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), new_bridge_rx.recv())
+                .await
+                .is_err(),
+            "replacement bridge should not receive a stream request until it reports fresh status"
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_device_api_stream_delivers_headers_and_chunks_before_end() {
+        let state = RelayState::default();
+        {
+            let mut inner = state.inner.lock().await;
+            inner
+                .devices
+                .insert("device-1".to_string(), test_device("device-1", "owner-a"));
+        }
+        let (bridge_tx, mut bridge_rx) = test_message_channel(CONTROL_WS_QUEUE_CAPACITY);
+        let connection_id = state
+            .register_connection(
+                "device-1",
+                PeerKind::Bridge,
+                "owner-a".to_string(),
+                bridge_tx,
+                None,
+            )
+            .await
+            .expect("bridge registration");
+        report_api_stream_bridge_status(&state, "device-1", connection_id, true).await;
+
+        let state_for_request = state.clone();
+        let response_task = tokio::spawn(async move {
+            state_for_request
+                .forward_device_api_stream_request(
+                    "owner-a",
+                    "device-1",
+                    "GET",
+                    "/api/projects/demo/dispatcher/feed/stream?limit=120",
+                    BTreeMap::from([("accept".to_string(), "text/event-stream".to_string())]),
+                    None,
+                )
+                .await
+                .expect("stream request should start")
+        });
+
+        let request = serde_json::from_str::<BrowserToBridgeMessage>(&bridge_message_text(
+            bridge_rx
+                .recv()
+                .await
+                .expect("bridge should receive stream request"),
+        ))
+        .expect("decode stream request");
+        let request_id = match request {
+            BrowserToBridgeMessage::ApiStreamRequest { id, .. } => id,
+            other => panic!("expected stream request, got {other:?}"),
+        };
+
+        let start = BridgeToBrowserMessage::ApiStreamStart {
+            id: request_id.clone(),
+            status: 200,
+            headers: BTreeMap::from([
+                ("content-type".to_string(), "text/event-stream".to_string()),
+                (
+                    "cache-control".to_string(),
+                    "no-cache, no-transform".to_string(),
+                ),
+                ("x-accel-buffering".to_string(), "no".to_string()),
+            ]),
+        };
+        let start_raw = serde_json::to_string(&start).expect("serialize start");
+        assert!(
+            state
+                .route_bridge_message("device-1", connection_id, start, start_raw)
+                .await
+        );
+
+        let mut response = response_task.await.expect("stream task join");
+        assert_eq!(response.status, 200);
+        assert_eq!(
+            response.headers.get("content-type").map(String::as_str),
+            Some("text/event-stream")
+        );
+
+        let chunk_one = BridgeToBrowserMessage::ApiStreamChunk {
+            id: request_id.clone(),
+            chunk_base64: base64::engine::general_purpose::STANDARD.encode(b"chunk-1"),
+        };
+        let chunk_one_raw = serde_json::to_string(&chunk_one).expect("serialize chunk");
+        assert!(
+            state
+                .route_bridge_message("device-1", connection_id, chunk_one, chunk_one_raw)
+                .await
+        );
+
+        let first = response
+            .body
+            .next()
+            .await
+            .expect("first chunk should arrive")
+            .expect("first chunk should decode");
+        assert_eq!(first.as_ref(), b"chunk-1");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), response.body.next())
+                .await
+                .is_err(),
+            "downstream reader should still be waiting for the second chunk"
+        );
+
+        let chunk_two = BridgeToBrowserMessage::ApiStreamChunk {
+            id: request_id.clone(),
+            chunk_base64: base64::engine::general_purpose::STANDARD.encode(b"chunk-2"),
+        };
+        let chunk_two_raw = serde_json::to_string(&chunk_two).expect("serialize second chunk");
+        assert!(
+            state
+                .route_bridge_message("device-1", connection_id, chunk_two, chunk_two_raw)
+                .await
+        );
+        let end = BridgeToBrowserMessage::ApiStreamEnd {
+            id: request_id.clone(),
+            error: None,
+        };
+        let end_raw = serde_json::to_string(&end).expect("serialize end");
+        assert!(
+            state
+                .route_bridge_message("device-1", connection_id, end, end_raw)
+                .await
+        );
+
+        let second = response
+            .body
+            .next()
+            .await
+            .expect("second chunk should arrive")
+            .expect("second chunk should decode");
+        assert_eq!(second.as_ref(), b"chunk-2");
+        assert!(response.body.next().await.is_none());
+        let inner = state.inner.lock().await;
+        assert!(!inner.pending_api_stream_requests.contains_key(&request_id));
+        assert_eq!(inner.pending_api_stream_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn api_stream_disconnect_cleans_pending_state_and_closes_body() {
+        let state = RelayState::default();
+        {
+            let mut inner = state.inner.lock().await;
+            inner
+                .devices
+                .insert("device-1".to_string(), test_device("device-1", "owner-a"));
+        }
+        let (bridge_tx, mut bridge_rx) = test_message_channel(CONTROL_WS_QUEUE_CAPACITY);
+        let connection_id = state
+            .register_connection(
+                "device-1",
+                PeerKind::Bridge,
+                "owner-a".to_string(),
+                bridge_tx,
+                None,
+            )
+            .await
+            .expect("bridge registration");
+        report_api_stream_bridge_status(&state, "device-1", connection_id, true).await;
+
+        let state_for_request = state.clone();
+        let response_task = tokio::spawn(async move {
+            state_for_request
+                .forward_device_api_stream_request(
+                    "owner-a",
+                    "device-1",
+                    "GET",
+                    "/api/stream",
+                    BTreeMap::new(),
+                    None,
+                )
+                .await
+                .expect("stream request should start")
+        });
+
+        let request = serde_json::from_str::<BrowserToBridgeMessage>(&bridge_message_text(
+            bridge_rx
+                .recv()
+                .await
+                .expect("bridge should receive stream request"),
+        ))
+        .expect("decode stream request");
+        let request_id = match request {
+            BrowserToBridgeMessage::ApiStreamRequest { id, .. } => id,
+            other => panic!("expected stream request, got {other:?}"),
+        };
+        let start = BridgeToBrowserMessage::ApiStreamStart {
+            id: request_id.clone(),
+            status: 200,
+            headers: BTreeMap::from([(
+                "content-type".to_string(),
+                "text/event-stream".to_string(),
+            )]),
+        };
+        let start_raw = serde_json::to_string(&start).expect("serialize start");
+        assert!(
+            state
+                .route_bridge_message("device-1", connection_id, start, start_raw)
+                .await
+        );
+        let mut response = response_task.await.expect("stream task join");
+
+        state
+            .unregister_connection("device-1", PeerKind::Bridge, connection_id)
+            .await;
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), response.body.next())
+                .await
+                .expect("body should observe disconnect")
+                .is_none()
+        );
+        let inner = state.inner.lock().await;
+        assert!(!inner.pending_api_stream_requests.contains_key(&request_id));
+    }
+
+    #[tokio::test]
+    async fn api_stream_drop_sends_cancel_to_bridge() {
+        let state = RelayState::default();
+        {
+            let mut inner = state.inner.lock().await;
+            inner
+                .devices
+                .insert("device-1".to_string(), test_device("device-1", "owner-a"));
+        }
+        let (bridge_tx, mut bridge_rx) = test_message_channel(CONTROL_WS_QUEUE_CAPACITY);
+        let connection_id = state
+            .register_connection(
+                "device-1",
+                PeerKind::Bridge,
+                "owner-a".to_string(),
+                bridge_tx,
+                None,
+            )
+            .await
+            .expect("bridge registration");
+        report_api_stream_bridge_status(&state, "device-1", connection_id, true).await;
+
+        let state_for_request = state.clone();
+        let response_task = tokio::spawn(async move {
+            state_for_request
+                .forward_device_api_stream_request(
+                    "owner-a",
+                    "device-1",
+                    "GET",
+                    "/api/stream",
+                    BTreeMap::new(),
+                    None,
+                )
+                .await
+                .expect("stream request should start")
+        });
+
+        let request = serde_json::from_str::<BrowserToBridgeMessage>(&bridge_message_text(
+            bridge_rx
+                .recv()
+                .await
+                .expect("bridge should receive stream request"),
+        ))
+        .expect("decode stream request");
+        let request_id = match request {
+            BrowserToBridgeMessage::ApiStreamRequest { id, .. } => id,
+            other => panic!("expected stream request, got {other:?}"),
+        };
+        let start = BridgeToBrowserMessage::ApiStreamStart {
+            id: request_id.clone(),
+            status: 200,
+            headers: BTreeMap::from([(
+                "content-type".to_string(),
+                "text/event-stream".to_string(),
+            )]),
+        };
+        let start_raw = serde_json::to_string(&start).expect("serialize start");
+        assert!(
+            state
+                .route_bridge_message("device-1", connection_id, start, start_raw)
+                .await
+        );
+        let response = response_task.await.expect("stream task join");
+        drop(response);
+
+        let cancel = serde_json::from_str::<BrowserToBridgeMessage>(&bridge_message_text(
+            bridge_rx
+                .recv()
+                .await
+                .expect("bridge should receive stream cancel"),
+        ))
+        .expect("decode stream cancel");
+        assert_eq!(
+            cancel,
+            BrowserToBridgeMessage::ApiStreamCancel {
+                id: request_id.clone(),
+            }
+        );
+
+        let inner = state.inner.lock().await;
+        assert!(!inner.pending_api_stream_requests.contains_key(&request_id));
+    }
+
+    #[tokio::test]
+    async fn api_stream_backpressure_removes_pending_state() {
+        let state = RelayState::default();
+        {
+            let mut inner = state.inner.lock().await;
+            inner
+                .devices
+                .insert("device-1".to_string(), test_device("device-1", "owner-a"));
+        }
+        let (bridge_tx, mut bridge_rx) = test_message_channel(CONTROL_WS_QUEUE_CAPACITY);
+        let connection_id = state
+            .register_connection(
+                "device-1",
+                PeerKind::Bridge,
+                "owner-a".to_string(),
+                bridge_tx,
+                None,
+            )
+            .await
+            .expect("bridge registration");
+        report_api_stream_bridge_status(&state, "device-1", connection_id, true).await;
+
+        let state_for_request = state.clone();
+        let response_task = tokio::spawn(async move {
+            state_for_request
+                .forward_device_api_stream_request(
+                    "owner-a",
+                    "device-1",
+                    "GET",
+                    "/api/stream",
+                    BTreeMap::new(),
+                    None,
+                )
+                .await
+                .expect("stream request should start")
+        });
+
+        let request = serde_json::from_str::<BrowserToBridgeMessage>(&bridge_message_text(
+            bridge_rx
+                .recv()
+                .await
+                .expect("bridge should receive stream request"),
+        ))
+        .expect("decode stream request");
+        let request_id = match request {
+            BrowserToBridgeMessage::ApiStreamRequest { id, .. } => id,
+            other => panic!("expected stream request, got {other:?}"),
+        };
+        let start = BridgeToBrowserMessage::ApiStreamStart {
+            id: request_id.clone(),
+            status: 200,
+            headers: BTreeMap::from([(
+                "content-type".to_string(),
+                "text/event-stream".to_string(),
+            )]),
+        };
+        let start_raw = serde_json::to_string(&start).expect("serialize start");
+        assert!(
+            state
+                .route_bridge_message("device-1", connection_id, start, start_raw)
+                .await
+        );
+        let response = response_task.await.expect("stream task join");
+
+        for _ in 0..=API_STREAM_EVENT_QUEUE_CAPACITY {
+            let chunk = BridgeToBrowserMessage::ApiStreamChunk {
+                id: request_id.clone(),
+                chunk_base64: base64::engine::general_purpose::STANDARD.encode(b"x"),
+            };
+            let raw = serde_json::to_string(&chunk).expect("serialize chunk");
+            assert!(
+                state
+                    .route_bridge_message("device-1", connection_id, chunk, raw)
+                    .await
+            );
+        }
+
+        let inner = state.inner.lock().await;
+        assert!(!inner.pending_api_stream_requests.contains_key(&request_id));
+        drop(inner);
+        drop(response);
+
+        let cancel = serde_json::from_str::<BrowserToBridgeMessage>(&bridge_message_text(
+            bridge_rx
+                .recv()
+                .await
+                .expect("bridge should receive stream cancel"),
+        ))
+        .expect("decode stream cancel");
+        assert_eq!(
+            cancel,
+            BrowserToBridgeMessage::ApiStreamCancel { id: request_id }
+        );
+    }
+
+    #[tokio::test]
+    async fn api_stream_error_end_cleans_pending_state() {
+        let state = RelayState::default();
+        {
+            let mut inner = state.inner.lock().await;
+            inner
+                .devices
+                .insert("device-1".to_string(), test_device("device-1", "owner-a"));
+        }
+        let (bridge_tx, mut bridge_rx) = test_message_channel(CONTROL_WS_QUEUE_CAPACITY);
+        let connection_id = state
+            .register_connection(
+                "device-1",
+                PeerKind::Bridge,
+                "owner-a".to_string(),
+                bridge_tx,
+                None,
+            )
+            .await
+            .expect("bridge registration");
+        report_api_stream_bridge_status(&state, "device-1", connection_id, true).await;
+
+        let state_for_request = state.clone();
+        let response_task = tokio::spawn(async move {
+            state_for_request
+                .forward_device_api_stream_request(
+                    "owner-a",
+                    "device-1",
+                    "GET",
+                    "/api/stream",
+                    BTreeMap::new(),
+                    None,
+                )
+                .await
+                .expect("stream request should start")
+        });
+
+        let request = serde_json::from_str::<BrowserToBridgeMessage>(&bridge_message_text(
+            bridge_rx
+                .recv()
+                .await
+                .expect("bridge should receive stream request"),
+        ))
+        .expect("decode stream request");
+        let request_id = match request {
+            BrowserToBridgeMessage::ApiStreamRequest { id, .. } => id,
+            other => panic!("expected stream request, got {other:?}"),
+        };
+        let start = BridgeToBrowserMessage::ApiStreamStart {
+            id: request_id.clone(),
+            status: 200,
+            headers: BTreeMap::from([(
+                "content-type".to_string(),
+                "text/event-stream".to_string(),
+            )]),
+        };
+        let start_raw = serde_json::to_string(&start).expect("serialize start");
+        assert!(
+            state
+                .route_bridge_message("device-1", connection_id, start, start_raw)
+                .await
+        );
+        let mut response = response_task.await.expect("stream task join");
+
+        let end = BridgeToBrowserMessage::ApiStreamEnd {
+            id: request_id.clone(),
+            error: Some("upstream aborted".to_string()),
+        };
+        let end_raw = serde_json::to_string(&end).expect("serialize end");
+        assert!(
+            state
+                .route_bridge_message("device-1", connection_id, end, end_raw)
+                .await
+        );
+        assert!(response.body.next().await.is_none());
+        let inner = state.inner.lock().await;
+        assert!(!inner.pending_api_stream_requests.contains_key(&request_id));
+    }
+
+    #[tokio::test]
+    async fn duplicate_api_stream_start_cleans_pending_state_closes_body_and_sends_cancel() {
+        let state = RelayState::default();
+        {
+            let mut inner = state.inner.lock().await;
+            inner
+                .devices
+                .insert("device-1".to_string(), test_device("device-1", "owner-a"));
+        }
+        let (bridge_tx, mut bridge_rx) = test_message_channel(CONTROL_WS_QUEUE_CAPACITY);
+        let connection_id = state
+            .register_connection(
+                "device-1",
+                PeerKind::Bridge,
+                "owner-a".to_string(),
+                bridge_tx,
+                None,
+            )
+            .await
+            .expect("bridge registration");
+        report_api_stream_bridge_status(&state, "device-1", connection_id, true).await;
+
+        let state_for_request = state.clone();
+        let response_task = tokio::spawn(async move {
+            state_for_request
+                .forward_device_api_stream_request(
+                    "owner-a",
+                    "device-1",
+                    "GET",
+                    "/api/stream",
+                    BTreeMap::new(),
+                    None,
+                )
+                .await
+                .expect("stream request should start")
+        });
+
+        let request = serde_json::from_str::<BrowserToBridgeMessage>(&bridge_message_text(
+            bridge_rx
+                .recv()
+                .await
+                .expect("bridge should receive stream request"),
+        ))
+        .expect("decode stream request");
+        let request_id = match request {
+            BrowserToBridgeMessage::ApiStreamRequest { id, .. } => id,
+            other => panic!("expected stream request, got {other:?}"),
+        };
+
+        let start = BridgeToBrowserMessage::ApiStreamStart {
+            id: request_id.clone(),
+            status: 200,
+            headers: BTreeMap::from([(
+                "content-type".to_string(),
+                "text/event-stream".to_string(),
+            )]),
+        };
+        let start_raw = serde_json::to_string(&start).expect("serialize start");
+        assert!(
+            state
+                .route_bridge_message("device-1", connection_id, start, start_raw)
+                .await
+        );
+        let mut response = response_task.await.expect("stream task join");
+
+        let duplicate_start = BridgeToBrowserMessage::ApiStreamStart {
+            id: request_id.clone(),
+            status: 200,
+            headers: BTreeMap::from([(
+                "content-type".to_string(),
+                "text/event-stream".to_string(),
+            )]),
+        };
+        let duplicate_start_raw =
+            serde_json::to_string(&duplicate_start).expect("serialize duplicate start");
+        assert!(
+            state
+                .route_bridge_message(
+                    "device-1",
+                    connection_id,
+                    duplicate_start,
+                    duplicate_start_raw,
+                )
+                .await
+        );
+
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), response.body.next())
+                .await
+                .expect("body should close after duplicate start")
+                .is_none()
+        );
+        let cancel = serde_json::from_str::<BrowserToBridgeMessage>(&bridge_message_text(
+            bridge_rx
+                .recv()
+                .await
+                .expect("bridge should receive stream cancel"),
+        ))
+        .expect("decode stream cancel");
+        assert_eq!(
+            cancel,
+            BrowserToBridgeMessage::ApiStreamCancel {
+                id: request_id.clone(),
+            }
+        );
+
+        let inner = state.inner.lock().await;
+        assert!(!inner.pending_api_stream_requests.contains_key(&request_id));
+        assert_eq!(inner.pending_api_stream_bytes, 0);
     }
 
     #[tokio::test]
@@ -5587,6 +7265,7 @@ mod tests {
                     }),
                     browsers: HashMap::new(),
                     last_status: None,
+                    active_bridge_status_seen: false,
                 },
             );
         }
@@ -5770,6 +7449,7 @@ mod tests {
                     }),
                     browsers: HashMap::new(),
                     last_status: None,
+                    active_bridge_status_seen: false,
                 },
             );
             inner.terminal_sessions.insert(
@@ -5852,6 +7532,7 @@ mod tests {
                     }),
                     browsers: HashMap::new(),
                     last_status: None,
+                    active_bridge_status_seen: false,
                 },
             );
             inner.terminal_sessions.insert(
@@ -5923,6 +7604,7 @@ mod tests {
                     }),
                     browsers: HashMap::new(),
                     last_status: None,
+                    active_bridge_status_seen: false,
                 },
             );
             inner.terminal_sessions.insert(
@@ -6832,6 +8514,7 @@ mod tests {
                         },
                     )]),
                     last_status: None,
+                    active_bridge_status_seen: false,
                 },
             );
             inner.pending_api_requests.insert(

--- a/crates/conductor-types/src/lib.rs
+++ b/crates/conductor-types/src/lib.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeMap;
 
+pub const API_STREAM_V1_CAPABILITY: &str = "api_stream_v1";
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum BrowserToBridgeMessage {
@@ -18,6 +20,18 @@ pub enum BrowserToBridgeMessage {
         path: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         body: Option<Value>,
+    },
+    ApiStreamRequest {
+        id: String,
+        method: String,
+        path: String,
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        headers: BTreeMap<String, String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        body: Option<Value>,
+    },
+    ApiStreamCancel {
+        id: String,
     },
     PreviewRequest {
         id: String,
@@ -50,6 +64,21 @@ pub enum BridgeToBrowserMessage {
         status: u16,
         body: Value,
     },
+    ApiStreamStart {
+        id: String,
+        status: u16,
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        headers: BTreeMap<String, String>,
+    },
+    ApiStreamChunk {
+        id: String,
+        chunk_base64: String,
+    },
+    ApiStreamEnd {
+        id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
     PreviewResponse {
         id: String,
         status: u16,
@@ -68,6 +97,8 @@ pub enum BridgeToBrowserMessage {
         connected: bool,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         version: Option<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        capabilities: Vec<String>,
     },
     Pong,
 }
@@ -95,6 +126,8 @@ pub struct BridgeStatus {
     pub connected: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capabilities: Vec<String>,
 }
 
 #[cfg(test)]
@@ -152,6 +185,7 @@ mod tests {
             os: "darwin".to_string(),
             connected: true,
             version: Some("0.3.4".to_string()),
+            capabilities: vec![API_STREAM_V1_CAPABILITY.to_string()],
         };
 
         let value = serde_json::to_value(msg).expect("serialize");
@@ -162,8 +196,128 @@ mod tests {
                 "hostname": "Mac",
                 "os": "darwin",
                 "connected": true,
-                "version": "0.3.4"
+                "version": "0.3.4",
+                "capabilities": ["api_stream_v1"]
             })
+        );
+    }
+
+    #[test]
+    fn bridge_stream_messages_roundtrip_in_contract_shape() {
+        let request = BrowserToBridgeMessage::ApiStreamRequest {
+            id: "stream-1".to_string(),
+            method: "GET".to_string(),
+            path: "/api/feed/stream".to_string(),
+            headers: BTreeMap::from([
+                ("accept".to_string(), "text/event-stream".to_string()),
+                ("cache-control".to_string(), "no-cache".to_string()),
+            ]),
+            body: None,
+        };
+        let request_value = serde_json::to_value(request).expect("serialize stream request");
+        assert_eq!(
+            request_value,
+            json!({
+                "type": "api_stream_request",
+                "id": "stream-1",
+                "method": "GET",
+                "path": "/api/feed/stream",
+                "headers": {
+                    "accept": "text/event-stream",
+                    "cache-control": "no-cache"
+                }
+            })
+        );
+
+        let encoded = serde_json::to_string(&BridgeToBrowserMessage::ApiStreamStart {
+            id: "stream-1".to_string(),
+            status: 200,
+            headers: BTreeMap::from([(
+                "content-type".to_string(),
+                "text/event-stream".to_string(),
+            )]),
+        })
+        .expect("serialize stream start");
+        let decoded: BridgeToBrowserMessage =
+            serde_json::from_str(&encoded).expect("deserialize stream start");
+        assert_eq!(
+            decoded,
+            BridgeToBrowserMessage::ApiStreamStart {
+                id: "stream-1".to_string(),
+                status: 200,
+                headers: BTreeMap::from([(
+                    "content-type".to_string(),
+                    "text/event-stream".to_string(),
+                )]),
+            }
+        );
+
+        let cancel = serde_json::to_value(BrowserToBridgeMessage::ApiStreamCancel {
+            id: "stream-1".to_string(),
+        })
+        .expect("serialize stream cancel");
+        assert_eq!(
+            cancel,
+            json!({
+                "type": "api_stream_cancel",
+                "id": "stream-1",
+            })
+        );
+    }
+
+    #[test]
+    fn legacy_api_messages_remain_backward_compatible() {
+        let request: BrowserToBridgeMessage = serde_json::from_value(json!({
+            "type": "api_request",
+            "id": "req-1",
+            "method": "POST",
+            "path": "/api/test",
+            "body": {"hello": "world"}
+        }))
+        .expect("deserialize legacy api request");
+        assert_eq!(
+            request,
+            BrowserToBridgeMessage::ApiRequest {
+                id: "req-1".to_string(),
+                method: "POST".to_string(),
+                path: "/api/test".to_string(),
+                body: Some(json!({"hello":"world"})),
+            }
+        );
+
+        let response: BridgeToBrowserMessage = serde_json::from_value(json!({
+            "type": "api_response",
+            "id": "req-1",
+            "status": 202,
+            "body": {"ok": true}
+        }))
+        .expect("deserialize legacy api response");
+        assert_eq!(
+            response,
+            BridgeToBrowserMessage::ApiResponse {
+                id: "req-1".to_string(),
+                status: 202,
+                body: json!({"ok": true}),
+            }
+        );
+
+        let status: BridgeToBrowserMessage = serde_json::from_value(json!({
+            "type": "bridge_status",
+            "hostname": "Mac",
+            "os": "darwin",
+            "connected": true,
+            "version": "0.3.4"
+        }))
+        .expect("deserialize legacy bridge status");
+        assert_eq!(
+            status,
+            BridgeToBrowserMessage::BridgeStatus {
+                hostname: "Mac".to_string(),
+                os: "darwin".to_string(),
+                connected: true,
+                version: Some("0.3.4".to_string()),
+                capabilities: Vec::new(),
+            }
         );
     }
 }

--- a/docs/dispatcher-streaming-SPEC.md
+++ b/docs/dispatcher-streaming-SPEC.md
@@ -22,6 +22,86 @@ Implement and ship a focused streaming change from `origin/main`. Any separate d
 8. The React client updates only the changed entry, preserves tool cards and scroll behavior, and does not reconnect or refetch the whole feed per token.
 9. Do not include unrelated mobile shell, notes, board, bridge, layout, or visual changes.
 
+## Hosted Paired-Device Transport Contract
+
+The hosted paired-device path must not downgrade `text/event-stream` into a buffered JSON response. The browser-facing route, relay HTTP proxy, paired-device bridge WebSocket, and local backend must all preserve a live byte stream.
+
+### HTTP relay request shape
+
+Hosted event-stream routes call the relay device proxy with a JSON body shaped like:
+
+```json
+{
+  "method": "GET",
+  "path": "/api/projects/<project>/dispatcher/feed/stream?...",
+  "stream": true,
+  "headers": {
+    "accept": "text/event-stream",
+    "cache-control": "no-cache"
+  }
+}
+```
+
+- `stream: true` selects the streamed paired-device transport.
+- Existing buffered `method` / `path` / `body` requests remain unchanged when `stream` is omitted or false.
+- Request headers are optional and must be sanitized. Never forward cookies, authorization headers, hop-by-hop headers, or injected forwarded headers through the bridge protocol.
+
+### Bridge WebSocket lifecycle
+
+The paired-device bridge protocol now has a first-class streamed API request flow:
+
+- Bridge capability negotiation:
+  - The bridge advertises streamed API support by including `api_stream_v1` in every `bridge_status.capabilities` payload.
+  - The relay normalizes capabilities per active bridge connection and must reset capability knowledge on every bridge reconnect so stale capabilities cannot be reused.
+  - Before the active bridge has reported its first `bridge_status`, streamed HTTP requests fail closed with `425 Too Early` or `503 Service Unavailable` so EventSource retries without sending any fallback `api_request`.
+  - After the active bridge has reported status, the relay uses the streamed transport only when that status explicitly includes `api_stream_v1`.
+  - Bridges that report status without `api_stream_v1` fail streamed HTTP requests immediately with `426 Upgrade Required`. Do not downgrade `text/event-stream` requests into buffered `api_request` traffic.
+- Browser/relay to bridge:
+  - `api_stream_request { id, method, path, headers?, body? }`
+  - `api_stream_cancel { id }`
+- Bridge to relay/browser:
+  - `api_stream_start { id, status, headers }`
+  - `api_stream_chunk { id, chunk_base64 }`
+  - `api_stream_end { id, error? }`
+
+Rules:
+
+- Every streamed request is keyed by a unique `id`.
+- `api_stream_start` must be the first response message for that `id`.
+- `api_stream_chunk` payloads are raw upstream bytes encoded as base64. The bridge must not buffer the full response to reassemble text.
+- `api_stream_end` always terminates the lifecycle for that `id`.
+- `api_stream_cancel` aborts only the currently registered in-flight stream for the same `id`. The bridge must remove that registration atomically with the abort decision so a completed stream cannot leave a stale later handle behind.
+- Unknown, already-completed, or already-cancelled `api_stream_cancel` IDs are ignored.
+- A request ID may only be completed, chunked, or ended by the pending stream entry registered for the same device. Wrong-device or stale-connection messages are ignored and must not complete another request.
+
+### Header and body preservation
+
+- Preserve upstream status code from the paired machine.
+- Preserve safe response headers from the paired machine, especially:
+  - `content-type: text/event-stream`
+  - `cache-control: no-cache, no-transform`
+  - `x-accel-buffering: no`
+- Strip hop-by-hop headers, `content-length`, `content-encoding`, cookies, and any unsafe or malformed header values.
+- The hosted Next route must pass the upstream `ReadableStream` through directly instead of wrapping it in a buffering transform.
+
+## Failure Recovery
+
+The streamed paired-device path must fail closed and clean up pending state on every exit path.
+
+- Before `api_stream_start`:
+  - If the bridge cannot reach the paired backend, it synthesizes a short 5xx JSON error response through the stream lifecycle.
+  - If the relay has not processed bridge status yet, it returns `425 Too Early` or `503 Service Unavailable` without sending any upstream request so EventSource can retry cleanly.
+  - If the relay has processed bridge status and the bridge does not advertise `api_stream_v1`, it returns `426 Upgrade Required` without sending any upstream request.
+  - If the relay forwards `api_stream_request` but never receives `api_stream_start`, it returns a 503 or 504 HTTP error and removes the pending stream entry.
+- After `api_stream_start`:
+  - If the paired backend errors mid-stream, the bridge sends `api_stream_end { error }` and stops reading upstream bytes.
+  - If the hosted client disconnects, the relay drops the pending stream registration immediately. Later chunks for that ID are discarded.
+  - If the hosted route times out, closes early, or detects a protocol failure after forwarding `api_stream_request`, the relay removes the pending request first and then best-effort sends `api_stream_cancel { id }` so only the matching paired stream is aborted.
+  - If the bridge disconnects or a device is deleted, the relay removes all pending streamed requests for that device and closes their bodies.
+  - If the hosted reader stops consuming and the per-stream relay queue fills, the relay removes the pending stream entry instead of buffering without bound.
+- The bridge receive loop must never await a whole streamed response. Stream forwarding runs in its own bounded task so Ping, file browse, preview, and terminal control traffic keep flowing while the stream is open.
+- Dispatcher SSE reconnect behavior remains the user-visible recovery path after a mid-stream close. Do not add polling as a workaround.
+
 ## Acceptance tests
 
 - Rust unit tests for byte-exact delta parsing and no duplicate final output across supported structured adapters.
@@ -29,6 +109,9 @@ Implement and ship a focused streaming change from `origin/main`. Any separate d
 - Dispatcher regressions proving Codex ignores stale persisted native resume targets and app-server thread-start metadata exposes `codexThreadId` telemetry without claiming native resume.
 - Dispatcher-state tests proving exact user/assistant/tool chronology, one stable assistant row per contiguous segment, stable updates within each segment, tool completion updates in place, final-only snapshot fallback, and duplicate or no-op behavior.
 - SSE tests for non-tail single-entry patching, multi-entry replacement fallback, UTF-16 emoji offsets, lag refresh recovery, and keepalive.
+- Bridge transport tests for streamed request serialization, `start` / `chunk` / `end` correlation, and in-flight control-message handling while a stream stays open.
+- Relay tests that prove chunk 1 reaches the hosted reader before chunk 2 and `end`, and that pending stream state is cleaned up on `end`, `error`, disconnect, and backpressure.
+- Hosted web proxy tests that prove bridge-backed dispatcher feed routes return a live streaming body rather than waiting for completion.
 - Frontend reducer tests for delta apply, duplicate replay, offset mismatch replacement, non-tail entry update, and stable tool entries.
 - `cargo fmt --check`
 - `cargo test -p conductor-executors`

--- a/packages/web/src/app/api/projects/[id]/dispatcher/feed/stream/route.test.ts
+++ b/packages/web/src/app/api/projects/[id]/dispatcher/feed/stream/route.test.ts
@@ -94,3 +94,101 @@ test("GET proxies dispatcher feed streams with streaming-safe headers", async ()
   assert.equal(response.headers.get("x-accel-buffering"), "no");
   assert.equal(await response.text(), SSE_PAYLOAD);
 });
+
+test("GET keeps the hosted bridge-backed dispatcher feed streaming before completion", async () => {
+  resetEnv();
+  process.env.CONDUCTOR_BRIDGE_RELAY_URL = "https://relay.example.com";
+  process.env.RELAY_JWT_SECRET = "dispatcher-feed-stream-route-test-secret-at-least-32-bytes";
+
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  let streamController: ReadableStreamDefaultController<Uint8Array> | null = null;
+  let requestBody: Record<string, unknown> | null = null;
+
+  global.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" || input instanceof URL ? String(input) : input.url;
+    assert.equal(url, "https://relay.example.com/api/devices/bridge-1/proxy");
+    requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    return new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        streamController = controller;
+      },
+    }), {
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        "X-Accel-Buffering": "no",
+      },
+    });
+  }) as typeof fetch;
+
+  const response = await GET(
+    new NextRequest(
+      "http://127.0.0.1:3000/api/projects/demo/dispatcher/feed/stream?limit=120&bridgeId=bridge-1",
+      {
+        headers: {
+          Accept: "text/event-stream",
+          "Cache-Control": "no-cache",
+          "Last-Event-ID": "evt-7",
+          Forwarded: "for=198.51.100.20",
+          "X-Forwarded-For": "198.51.100.21",
+          "X-Real-IP": "198.51.100.22",
+          "Proxy-Authorization": "Basic test",
+          "Client-IP": "198.51.100.23",
+        },
+      },
+    ),
+    { params: Promise.resolve({ id: "demo" }) },
+  );
+
+  if (!requestBody) {
+    throw new Error("expected bridge proxy request body");
+  }
+  const bridgeRequest = requestBody as Record<string, unknown>;
+  assert.equal(bridgeRequest.stream, true);
+  assert.equal(bridgeRequest.method, "GET");
+  assert.equal(
+    bridgeRequest.path,
+    "/api/projects/demo/dispatcher/feed/stream?limit=120&bridgeId=bridge-1",
+  );
+  assert.deepEqual(bridgeRequest.headers, {
+    accept: "text/event-stream",
+    "cache-control": "no-cache",
+    "last-event-id": "evt-7",
+  });
+  assert.equal(response.headers.get("content-type"), "text/event-stream");
+  const reader = response.body?.getReader();
+  if (!reader) {
+    throw new Error("streaming route should expose a readable body");
+  }
+  if (!streamController) {
+    throw new Error("upstream bridge stream controller should be available");
+  }
+  const controller = streamController as ReadableStreamDefaultController<Uint8Array>;
+
+  controller.enqueue(encoder.encode('data: {"type":"append","entries":["first"]}\n\n'));
+  const first = await reader.read();
+  assert.equal(
+    decoder.decode(first.value),
+    'data: {"type":"append","entries":["first"]}\n\n',
+  );
+
+  let secondResolved = false;
+  const secondRead = reader.read().then((value) => {
+    secondResolved = true;
+    return value;
+  });
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  assert.equal(secondResolved, false);
+
+  controller.enqueue(encoder.encode('data: {"type":"append","entries":["second"]}\n\n'));
+  controller.close();
+  const second = await secondRead;
+  assert.equal(
+    decoder.decode(second.value),
+    'data: {"type":"append","entries":["second"]}\n\n',
+  );
+  const done = await reader.read();
+  assert.equal(done.done, true);
+});

--- a/packages/web/src/app/api/sessions/[id]/output/stream/route.test.ts
+++ b/packages/web/src/app/api/sessions/[id]/output/stream/route.test.ts
@@ -89,14 +89,34 @@ test("GET proxies bridge-backed output streams with streaming-safe headers", asy
     const body = JSON.parse(String(init?.body)) as {
       method: string;
       path: string;
+      headers: Record<string, string>;
     };
     assert.equal(body.method, "GET");
     seenPath = body.path;
+    assert.deepEqual(body.headers, {
+      accept: "text/event-stream",
+      "cache-control": "no-cache",
+      "last-event-id": "evt-99",
+    });
     return buildEventStreamResponse();
   }) as typeof fetch;
 
   const response = await GET(
-    new NextRequest("http://127.0.0.1:3000/api/sessions/bridge%3Abridge-1%3Asession-1/output/stream?lines=80"),
+    new NextRequest(
+      "http://127.0.0.1:3000/api/sessions/bridge%3Abridge-1%3Asession-1/output/stream?lines=80",
+      {
+        headers: {
+          Accept: "text/event-stream",
+          "Cache-Control": "no-cache",
+          "Last-Event-ID": "evt-99",
+          Forwarded: "for=198.51.100.10",
+          "X-Forwarded-For": "198.51.100.11",
+          "X-Real-IP": "198.51.100.12",
+          "Proxy-Authorization": "Basic test",
+          "Client-IP": "198.51.100.13",
+        },
+      },
+    ),
     { params: Promise.resolve({ id: "bridge:bridge-1:session-1" }) },
   );
 

--- a/packages/web/src/lib/bridgeApiProxy.test.ts
+++ b/packages/web/src/lib/bridgeApiProxy.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { createServer } from "node:http";
 import test from "node:test";
-import { requestBridgePreview } from "./bridgeApiProxy";
+import { proxyEventStreamToBridgeDevice, requestBridgePreview } from "./bridgeApiProxy";
 
 test("bridge preview reads are cancelled by their absolute deadline", async () => {
   const previousRelayUrl = process.env.CONDUCTOR_BRIDGE_RELAY_URL;
@@ -49,5 +49,107 @@ test("bridge preview reads are cancelled by their absolute deadline", async () =
     await new Promise<void>((resolve, reject) => {
       server.close((error) => error ? reject(error) : resolve());
     });
+  }
+});
+
+test("proxyEventStreamToBridgeDevice keeps bridge SSE bodies streaming instead of waiting for completion", async () => {
+  const previousRelayUrl = process.env.CONDUCTOR_BRIDGE_RELAY_URL;
+  const previousRelayJwtSecret = process.env.RELAY_JWT_SECRET;
+  const originalFetch = global.fetch;
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  let streamController: ReadableStreamDefaultController<Uint8Array> | null = null;
+  let requestBody: Record<string, unknown> | null = null;
+
+  try {
+    process.env.CONDUCTOR_BRIDGE_RELAY_URL = "https://relay.example.com";
+    process.env.RELAY_JWT_SECRET = "bridge-api-proxy-test-secret-at-least-32-bytes";
+    global.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" || input instanceof URL ? String(input) : input.url;
+      assert.equal(url, "https://relay.example.com/api/devices/bridge-1/proxy");
+      requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response(new ReadableStream<Uint8Array>({
+        start(controller) {
+          streamController = controller;
+        },
+      }), {
+        status: 200,
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache, no-transform",
+          "X-Accel-Buffering": "no",
+        },
+      });
+    }) as typeof fetch;
+
+    const response = await proxyEventStreamToBridgeDevice(
+      new Request("http://127.0.0.1:3000/api/projects/demo/dispatcher/feed/stream?limit=120", {
+        headers: {
+          Accept: "text/event-stream",
+          "Cache-Control": "no-cache",
+          "Content-Type": "text/event-stream",
+          "Last-Event-ID": "evt-42",
+          Forwarded: "for=198.51.100.10",
+          "X-Forwarded-For": "198.51.100.11",
+          "X-Real-IP": "198.51.100.12",
+          "Proxy-Authorization": "Basic test",
+          "Client-IP": "198.51.100.13",
+        },
+      }),
+      "bridge-1",
+      "/api/projects/demo/dispatcher/feed/stream",
+    );
+
+    if (!requestBody) {
+      throw new Error("expected bridge proxy request body");
+    }
+    const bridgeRequest = requestBody as Record<string, unknown>;
+    assert.equal(bridgeRequest.stream, true);
+    assert.deepEqual(bridgeRequest.headers, {
+      accept: "text/event-stream",
+      "cache-control": "no-cache",
+      "content-type": "text/event-stream",
+      "last-event-id": "evt-42",
+    });
+    assert.equal(response.headers.get("content-type"), "text/event-stream");
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new Error("response should expose a readable body");
+    }
+    if (!streamController) {
+      throw new Error("upstream stream controller should be captured");
+    }
+    const controller = streamController as ReadableStreamDefaultController<Uint8Array>;
+
+    controller.enqueue(encoder.encode("data: chunk-1\n\n"));
+    const first = await reader.read();
+    assert.equal(decoder.decode(first.value), "data: chunk-1\n\n");
+
+    let secondResolved = false;
+    const secondRead = reader.read().then((value) => {
+      secondResolved = true;
+      return value;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    assert.equal(secondResolved, false);
+
+    controller.enqueue(encoder.encode("data: chunk-2\n\n"));
+    controller.close();
+    const second = await secondRead;
+    assert.equal(decoder.decode(second.value), "data: chunk-2\n\n");
+    const done = await reader.read();
+    assert.equal(done.done, true);
+  } finally {
+    if (previousRelayUrl === undefined) {
+      delete process.env.CONDUCTOR_BRIDGE_RELAY_URL;
+    } else {
+      process.env.CONDUCTOR_BRIDGE_RELAY_URL = previousRelayUrl;
+    }
+    if (previousRelayJwtSecret === undefined) {
+      delete process.env.RELAY_JWT_SECRET;
+    } else {
+      process.env.RELAY_JWT_SECRET = previousRelayJwtSecret;
+    }
+    global.fetch = originalFetch;
   }
 });

--- a/packages/web/src/lib/bridgeApiProxy.ts
+++ b/packages/web/src/lib/bridgeApiProxy.ts
@@ -13,6 +13,12 @@ const BLOCKED_RESPONSE_HEADERS = new Set([
   "keep-alive",
   "transfer-encoding",
 ]);
+const SAFE_EVENT_STREAM_REQUEST_HEADERS = new Set([
+  "accept",
+  "cache-control",
+  "content-type",
+  "last-event-id",
+]);
 
 const BRIDGE_PROXY_REQUEST_META_KEY = "$bridgeRequest";
 
@@ -152,6 +158,23 @@ function buildEventStreamHeaders(response: Response): Headers {
   return headers;
 }
 
+function buildSafeEventStreamRequestHeaders(request: Request): Record<string, string> {
+  const headers: Record<string, string> = {};
+  request.headers.forEach((value, key) => {
+    const normalized = key.toLowerCase();
+    if (SAFE_EVENT_STREAM_REQUEST_HEADERS.has(normalized)) {
+      headers[normalized] = value;
+    }
+  });
+  if (!headers.accept) {
+    headers.accept = "text/event-stream";
+  }
+  if (!headers["cache-control"]) {
+    headers["cache-control"] = "no-cache";
+  }
+  return headers;
+}
+
 async function readProxyBody(request: Request, bodyOverride?: unknown): Promise<unknown> {
   if (bodyOverride !== undefined) {
     return bodyOverride;
@@ -250,7 +273,27 @@ export async function proxyEventStreamToBridgeDevice(
   bridgeId: string,
   pathname: string,
 ): Promise<Response> {
-  const response = await proxyToBridgeDevice(request, bridgeId, pathname);
+  const relayUrl = requireBridgeRelayUrl();
+  const incomingUrl = new URL(request.url);
+  const target = new URL(`/api/devices/${encodeURIComponent(bridgeId)}/proxy`, relayUrl);
+  const headers = await buildBridgeRelayAuthHeaders(request);
+  headers.set("Content-Type", "application/json");
+  headers.set("x-forwarded-proto", incomingUrl.protocol.replace(":", ""));
+  headers.set("x-forwarded-host", incomingUrl.host);
+
+  const response = await fetch(target, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      method: "GET",
+      path: `${pathname}${incomingUrl.search}`,
+      stream: true,
+      headers: buildSafeEventStreamRequestHeaders(request),
+    }),
+    cache: "no-store",
+    redirect: "manual",
+    signal: request.signal,
+  });
 
   if (!response.ok || !response.body || !isEventStreamResponse(response)) {
     return response;


### PR DESCRIPTION
## User-Facing Release Notes

- Paired-device dispatcher and session output now streams visibly instead of arriving after completion.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [x] Documentation Update
- [ ] Refactor / Chore

## Summary

Adds chunked SSE transport across the hosted web route, relay, and local bridge. Includes capability negotiation, cancellation, priority queues, header filtering, and byte budgets.

## Testing

- Rust workspace tests and Clippy
- 355 web tests, typecheck, production build
- Held-open stream tests at web, bridge, and relay layers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streamed API responses for paired devices, including incremental chunks, preserved headers, and cancellation support.
  * Added capability negotiation so streaming is available only when supported.
  * Added support for forwarding event-stream requests and receiving live dispatcher and session updates.

* **Bug Fixes**
  * Improved reliability during disconnects, timeouts, failures, and shutdowns.
  * Sanitized forwarded headers and added queue limits to improve safety and responsiveness.

* **Tests**
  * Expanded coverage for streaming, cancellation, backpressure, compatibility, and cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->