### PR TITLE
fix: stream SSE through installed Go bridge

### DIFF
--- a/bridge-cmd/daemon/daemon_test.go
+++ b/bridge-cmd/daemon/daemon_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,8 +12,20 @@ import (
 	"time"
 )
 
+func newIPv4TestServer(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("sandbox blocks loopback listeners: %v", err)
+	}
+	server := httptest.NewUnstartedServer(handler)
+	server.Listener = listener
+	server.Start()
+	return server
+}
+
 func TestValidateSavedPairingBestEffortContinuesOnNetworkFailure(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	server := newIPv4TestServer(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	server.Close()
 
 	var stderr bytes.Buffer
@@ -32,7 +45,7 @@ func TestValidateSavedPairingBestEffortContinuesOnNetworkFailure(t *testing.T) {
 }
 
 func TestValidateSavedPairingBestEffortStopsOnRejectedPairing(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newIPv4TestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"invalid token"}`, http.StatusUnauthorized)
 	}))
 	defer server.Close()

--- a/bridge-cmd/relay/client.go
+++ b/bridge-cmd/relay/client.go
@@ -29,6 +29,7 @@ const (
 	defaultHeartbeatInterval       = 30 * time.Second
 	maxReconnectBackoff            = 30 * time.Second
 	terminalAttachMaxAttempts      = 12
+	apiStreamV1Capability          = "api_stream_v1"
 	ttydPortRangeStart             = 7681
 	ttydPortRangeEnd               = 8699
 	bridgeProxyMetaKey             = "$bridgeProxy"
@@ -39,6 +40,7 @@ const (
 	maxPreviewRequestBodyBytes     = 10 * 1024 * 1024
 	maxProxyRequestBodyBytes       = 10 * 1024 * 1024
 	maxBackendResponseBytes        = 10 * 1024 * 1024
+	maxAPIStreamChunkBytes         = 48 * 1024
 	maxTerminalTokenResponseBytes  = 64 * 1024
 	maxBridgeInstallScriptBytes    = 512 * 1024
 	maxFileBrowseEntries           = 2000
@@ -65,14 +67,15 @@ type bridgeEnvelope struct {
 	Data string `json:"data,omitempty"`
 
 	// api_request / api_response
-	ID         string            `json:"id,omitempty"`
-	Method     string            `json:"method,omitempty"`
-	Path       string            `json:"path,omitempty"`
-	URL        string            `json:"url,omitempty"`
-	Status     int               `json:"status,omitempty"`
-	Body       interface{}       `json:"body,omitempty"`
-	Headers    map[string]string `json:"headers,omitempty"`
-	BodyBase64 string            `json:"body_base64,omitempty"`
+	ID          string            `json:"id,omitempty"`
+	Method      string            `json:"method,omitempty"`
+	Path        string            `json:"path,omitempty"`
+	URL         string            `json:"url,omitempty"`
+	Status      int               `json:"status,omitempty"`
+	Body        interface{}       `json:"body,omitempty"`
+	Headers     map[string]string `json:"headers,omitempty"`
+	BodyBase64  string            `json:"body_base64,omitempty"`
+	ChunkBase64 string            `json:"chunk_base64,omitempty"`
 
 	// terminal_proxy_start
 	TerminalID string `json:"terminal_id,omitempty"`
@@ -87,10 +90,11 @@ type bridgeEnvelope struct {
 	Rows int `json:"rows,omitempty"`
 
 	// bridge_status
-	Hostname  string `json:"hostname,omitempty"`
-	OS        string `json:"os,omitempty"`
-	Connected bool   `json:"connected,omitempty"`
-	Version   string `json:"version,omitempty"`
+	Hostname     string   `json:"hostname,omitempty"`
+	OS           string   `json:"os,omitempty"`
+	Connected    bool     `json:"connected,omitempty"`
+	Version      string   `json:"version,omitempty"`
+	Capabilities []string `json:"capabilities,omitempty"`
 }
 
 type backendHealthPayload struct {
@@ -192,6 +196,7 @@ func Run(ctx context.Context, opts Options) error {
 			version:           version,
 			stderr:            stderr,
 			heartbeatInterval: heartbeat,
+			backendBaseURL:    "http://127.0.0.1:4749",
 		})
 		if ctx.Err() != nil {
 			return nil
@@ -227,9 +232,77 @@ type sessionOptions struct {
 	version           string
 	stderr            io.Writer
 	heartbeatInterval time.Duration
+	backendBaseURL    string
 }
 
-var backendEnsureMu sync.Mutex
+var backendEnsureGate = func() chan struct{} {
+	gate := make(chan struct{}, 1)
+	gate <- struct{}{}
+	return gate
+}()
+
+type apiStreamHandle struct {
+	cancel context.CancelFunc
+}
+
+type apiStreamRegistry struct {
+	mu      sync.Mutex
+	handles map[string]*apiStreamHandle
+}
+
+func (r *apiStreamRegistry) register(id string, handle *apiStreamHandle) *apiStreamHandle {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.handles == nil {
+		r.handles = make(map[string]*apiStreamHandle)
+	}
+	previous := r.handles[id]
+	r.handles[id] = handle
+	return previous
+}
+
+func (r *apiStreamRegistry) cancel(id string) {
+	var handle *apiStreamHandle
+	r.mu.Lock()
+	if r.handles != nil {
+		handle = r.handles[id]
+		delete(r.handles, id)
+	}
+	r.mu.Unlock()
+	if handle != nil {
+		handle.cancel()
+	}
+}
+
+func (r *apiStreamRegistry) removeIfMatch(id string, handle *apiStreamHandle) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.handles == nil {
+		return
+	}
+	if current := r.handles[id]; current == handle {
+		delete(r.handles, id)
+	}
+}
+
+func (r *apiStreamRegistry) cancelAll() {
+	r.mu.Lock()
+	if len(r.handles) == 0 {
+		r.mu.Unlock()
+		return
+	}
+	handles := make([]*apiStreamHandle, 0, len(r.handles))
+	for id, handle := range r.handles {
+		delete(r.handles, id)
+		handles = append(handles, handle)
+	}
+	r.mu.Unlock()
+	for _, handle := range handles {
+		if handle != nil {
+			handle.cancel()
+		}
+	}
+}
 
 func legacyTTYDMirrorEnabled() bool {
 	value := strings.TrimSpace(strings.ToLower(os.Getenv(legacyTTYDMirrorEnv)))
@@ -270,6 +343,66 @@ func readAllBounded(reader io.Reader, maxBytes int, label string) ([]byte, error
 	return data, nil
 }
 
+func sanitizeHeaderValue(value string) string {
+	return strings.NewReplacer("\r", "", "\n", "").Replace(value)
+}
+
+func sanitizeProxyRequestHeaders(headers map[string]string) (http.Header, error) {
+	sanitized := http.Header{}
+	for name, value := range headers {
+		lower := strings.ToLower(strings.TrimSpace(name))
+		switch lower {
+		case "", "authorization", "cookie", "host", "connection", "content-length", "transfer-encoding", "x-forwarded-host", "x-forwarded-proto", "x-forwarded-for", "forwarded", "proxy-authorization", "proxy-authenticate":
+			continue
+		}
+		if strings.ContainsAny(lower, "\r\n") {
+			return nil, fmt.Errorf("invalid proxy request header name")
+		}
+		sanitized.Set(lower, sanitizeHeaderValue(value))
+	}
+	return sanitized, nil
+}
+
+func sanitizeProxyResponseHeaders(headers http.Header) map[string]string {
+	sanitized := map[string]string{}
+	for name, values := range headers {
+		if len(values) == 0 {
+			continue
+		}
+		lower := strings.ToLower(strings.TrimSpace(name))
+		switch lower {
+		case "", "connection", "proxy-connection", "keep-alive", "transfer-encoding", "content-length", "content-encoding", "upgrade", "proxy-authenticate", "proxy-authentication-info", "proxy-authorization", "te", "trailers", "set-cookie", "set-cookie2":
+			continue
+		}
+		value := sanitizeHeaderValue(values[len(values)-1])
+		if strings.ContainsAny(value, "\r\n") {
+			continue
+		}
+		sanitized[lower] = value
+	}
+	return sanitized
+}
+
+func encodeProxyRequestBody(body interface{}) ([]byte, string, error) {
+	if body == nil {
+		return nil, "", nil
+	}
+	if rawBody, rawContentType, ok, err := decodeProxyRequestBody(body); ok {
+		if err != nil {
+			return nil, "", err
+		}
+		if rawContentType != "" {
+			return rawBody, rawContentType, nil
+		}
+		return rawBody, "application/octet-stream", nil
+	}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, "", fmt.Errorf("encode backend request body: %w", err)
+	}
+	return bodyBytes, "application/json", nil
+}
+
 func normalizeHTTPMethod(method string) (string, error) {
 	normalized := strings.ToUpper(strings.TrimSpace(method))
 	if normalized == "" {
@@ -284,6 +417,10 @@ func normalizeHTTPMethod(method string) (string, error) {
 }
 
 func buildLocalBackendURL(rawPath string) (*url.URL, error) {
+	return buildLocalBackendURLWithBase("http://127.0.0.1:4749", rawPath)
+}
+
+func buildLocalBackendURLWithBase(baseURL, rawPath string) (*url.URL, error) {
 	trimmed := strings.TrimSpace(rawPath)
 	if trimmed == "" {
 		trimmed = "/"
@@ -301,12 +438,14 @@ func buildLocalBackendURL(rawPath string) (*url.URL, error) {
 	if parsed.Path == "" || !strings.HasPrefix(parsed.Path, "/") || parsed.Scheme != "" || parsed.Host != "" || parsed.User != nil {
 		return nil, fmt.Errorf("backend path must not include a scheme or host")
 	}
-	return &url.URL{
-		Scheme:   "http",
-		Host:     "127.0.0.1:4749",
+	base, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil {
+		return nil, fmt.Errorf("parse backend base url: %w", err)
+	}
+	return base.ResolveReference(&url.URL{
 		Path:     parsed.Path,
 		RawQuery: parsed.RawQuery,
-	}, nil
+	}), nil
 }
 
 func requireLoopbackDialTarget(ctx context.Context, address string) error {
@@ -516,13 +655,17 @@ func runSession(ctx context.Context, opts sessionOptions) (bool, error) {
 		defer relayMu.Unlock()
 		return relayConn.WriteMessage(websocket.TextMessage, data)
 	}
-	if err := send(bridgeEnvelope{
-		Type:      "bridge_status",
-		Hostname:  opts.hostname,
-		OS:        opts.osName,
-		Connected: true,
-		Version:   opts.version,
-	}); err != nil {
+	statusEnvelope := func() bridgeEnvelope {
+		return bridgeEnvelope{
+			Type:         "bridge_status",
+			Hostname:     opts.hostname,
+			OS:           opts.osName,
+			Connected:    true,
+			Version:      opts.version,
+			Capabilities: []string{apiStreamV1Capability},
+		}
+	}
+	if err := send(statusEnvelope()); err != nil {
 		stopTtyd()
 		return false, fmt.Errorf("send bridge_status: %w", err)
 	}
@@ -530,6 +673,8 @@ func runSession(ctx context.Context, opts sessionOptions) (bool, error) {
 	// 4. Bidirectional bridge loop.
 	errCh := make(chan error, 2)
 	var activeTerminals sync.Map
+	var activeAPIStreams apiStreamRegistry
+	defer activeAPIStreams.cancelAll()
 
 	// relay → ttyd
 	go func() {
@@ -565,7 +710,7 @@ func runSession(ctx context.Context, opts sessionOptions) (bool, error) {
 
 			case "api_request":
 				// Proxy to localhost:4749 (conductor backend).
-				apiResp, apiErr := proxyAPI(env.ID, env.Method, env.Path, env.Body)
+				apiResp, apiErr := proxyAPI(opts.backendBaseURL, env.ID, env.Method, env.Path, env.Body)
 				if apiErr != nil {
 					_ = send(bridgeEnvelope{
 						Type:   "api_response",
@@ -581,6 +726,35 @@ func runSession(ctx context.Context, opts sessionOptions) (bool, error) {
 						Body:   apiResp.Body,
 					})
 				}
+
+			case "api_stream_request":
+				requestID := strings.TrimSpace(env.ID)
+				if requestID == "" {
+					continue
+				}
+				streamCtx, streamCancel := context.WithCancel(ctx)
+				handle := &apiStreamHandle{cancel: streamCancel}
+				if previous := activeAPIStreams.register(requestID, handle); previous != nil {
+					previous.cancel()
+				}
+				go func(request bridgeEnvelope, requestID string, handle *apiStreamHandle) {
+					defer activeAPIStreams.removeIfMatch(requestID, handle)
+					if err := proxyAPIStream(
+						streamCtx,
+						opts.backendBaseURL,
+						send,
+						requestID,
+						request.Method,
+						request.Path,
+						request.Headers,
+						request.Body,
+					); err != nil && ctx.Err() == nil && streamCtx.Err() == nil {
+						fmt.Fprintf(opts.stderr, "api stream proxy failed id=%s error=%v\n", requestID, err)
+					}
+				}(env, requestID, handle)
+
+			case "api_stream_cancel":
+				activeAPIStreams.cancel(strings.TrimSpace(env.ID))
 
 			case "preview_request":
 				previewResp, previewErr := proxyPreview(env.ID, env.SessionID, env.Method, env.URL, env.Headers, env.BodyBase64)
@@ -715,13 +889,7 @@ func runSession(ctx context.Context, opts sessionOptions) (bool, error) {
 			// backoff before retrying a dropped long-lived session.
 			return true, err
 		case <-heartbeat.C:
-			if err := send(bridgeEnvelope{
-				Type:      "bridge_status",
-				Hostname:  opts.hostname,
-				OS:        opts.osName,
-				Connected: true,
-				Version:   opts.version,
-			}); err != nil {
+			if err := send(statusEnvelope()); err != nil {
 				stopTtyd()
 				return true, fmt.Errorf("send bridge_status: %w", err)
 			}
@@ -945,7 +1113,7 @@ func connectBackendTerminal(
 			break
 		}
 
-		if ensureErr := ensureLocalBackendForProxy(); ensureErr != nil {
+		if ensureErr := ensureLocalBackendForProxy(ctx); ensureErr != nil {
 			lastErr = ensureErr
 			break
 		}
@@ -1382,7 +1550,114 @@ func proxyPreview(
 	}, nil
 }
 
-func proxyAPI(id, method, path string, body interface{}) (apiResponse, error) {
+func sendAPIStreamFailureResponse(send func(bridgeEnvelope) error, id string, status int, message string) error {
+	if err := send(bridgeEnvelope{
+		Type:    "api_stream_start",
+		ID:      id,
+		Status:  status,
+		Headers: map[string]string{"content-type": "application/json"},
+	}); err != nil {
+		return err
+	}
+	body, err := json.Marshal(map[string]string{"error": message})
+	if err != nil {
+		return fmt.Errorf("encode api stream failure response: %w", err)
+	}
+	if err := send(bridgeEnvelope{
+		Type:        "api_stream_chunk",
+		ID:          id,
+		ChunkBase64: base64.StdEncoding.EncodeToString(body),
+	}); err != nil {
+		return err
+	}
+	return send(bridgeEnvelope{
+		Type: "api_stream_end",
+		ID:   id,
+	})
+}
+
+func proxyAPIStream(
+	ctx context.Context,
+	backendBaseURL string,
+	send func(bridgeEnvelope) error,
+	id string,
+	method string,
+	path string,
+	headers map[string]string,
+	body interface{},
+) error {
+	requestBodyBytes, contentType, err := encodeProxyRequestBody(body)
+	if err != nil {
+		return sendAPIStreamFailureResponse(send, id, http.StatusBadGateway, err.Error())
+	}
+
+	sanitizedHeaders, err := sanitizeProxyRequestHeaders(headers)
+	if err != nil {
+		return sendAPIStreamFailureResponse(send, id, http.StatusBadGateway, err.Error())
+	}
+	if len(requestBodyBytes) > 0 && sanitizedHeaders.Get("content-type") == "" && contentType != "" {
+		sanitizedHeaders.Set("content-type", contentType)
+	}
+
+	resp, err := doBackendAPIStreamRequest(ctx, backendBaseURL, method, path, requestBodyBytes, sanitizedHeaders)
+	if err != nil && shouldRetryAfterEnsuringBackend(err) {
+		if ensureErr := ensureLocalBackendForProxy(ctx); ensureErr != nil {
+			return sendAPIStreamFailureResponse(send, id, http.StatusBadGateway, ensureErr.Error())
+		}
+		resp, err = doBackendAPIStreamRequest(ctx, backendBaseURL, method, path, requestBodyBytes, sanitizedHeaders)
+	}
+	if err != nil {
+		if ctx.Err() != nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil
+		}
+		return sendAPIStreamFailureResponse(send, id, http.StatusBadGateway, err.Error())
+	}
+	defer resp.Body.Close()
+
+	if err := send(bridgeEnvelope{
+		Type:    "api_stream_start",
+		ID:      id,
+		Status:  resp.StatusCode,
+		Headers: sanitizeProxyResponseHeaders(resp.Header),
+	}); err != nil {
+		return err
+	}
+
+	buffer := make([]byte, maxAPIStreamChunkBytes)
+	for {
+		n, readErr := resp.Body.Read(buffer)
+		if n > 0 {
+			chunk := make([]byte, n)
+			copy(chunk, buffer[:n])
+			if err := send(bridgeEnvelope{
+				Type:        "api_stream_chunk",
+				ID:          id,
+				ChunkBase64: base64.StdEncoding.EncodeToString(chunk),
+			}); err != nil {
+				return err
+			}
+		}
+		if readErr == nil {
+			continue
+		}
+		if readErr == io.EOF {
+			return send(bridgeEnvelope{
+				Type: "api_stream_end",
+				ID:   id,
+			})
+		}
+		if ctx.Err() != nil || errors.Is(readErr, context.Canceled) || errors.Is(readErr, context.DeadlineExceeded) {
+			return nil
+		}
+		return send(bridgeEnvelope{
+			Type:  "api_stream_end",
+			ID:    id,
+			Error: readErr.Error(),
+		})
+	}
+}
+
+func proxyAPI(backendBaseURL, id, method, path string, body interface{}) (apiResponse, error) {
 	if handled, resp := maybeHandleBridgeControlRequest(method, path, body); handled {
 		return resp, nil
 	}
@@ -1392,33 +1667,19 @@ func proxyAPI(id, method, path string, body interface{}) (apiResponse, error) {
 	}
 
 	// Proxy to local conductor backend at localhost:4749.
-	var requestBodyBytes []byte
-	contentType := "application/json"
-	if body != nil {
-		if rawBody, rawContentType, ok, err := decodeProxyRequestBody(body); ok {
-			if err != nil {
-				return apiResponse{Status: 0, Body: nil}, err
-			}
-			requestBodyBytes = rawBody
-			if rawContentType != "" {
-				contentType = rawContentType
-			} else {
-				contentType = "application/octet-stream"
-			}
-		} else {
-			bodyBytes, _ := json.Marshal(body)
-			requestBodyBytes = bodyBytes
-		}
+	requestBodyBytes, contentType, err := encodeProxyRequestBody(body)
+	if err != nil {
+		return apiResponse{Status: 0, Body: nil}, err
 	}
 
-	resp, err := doBackendAPIRequest(method, path, requestBodyBytes, contentType)
+	resp, err := doBackendAPIRequest(backendBaseURL, method, path, requestBodyBytes, contentType)
 	if err != nil && shouldRetryAfterEnsuringBackend(err) {
-		if ensureErr := ensureLocalBackendForProxy(); ensureErr != nil {
+		if ensureErr := ensureLocalBackendForProxy(context.Background()); ensureErr != nil {
 			return apiResponse{Status: http.StatusBadGateway, Body: map[string]any{
 				"error": ensureErr.Error(),
 			}}, ensureErr
 		}
-		resp, err = doBackendAPIRequest(method, path, requestBodyBytes, contentType)
+		resp, err = doBackendAPIRequest(backendBaseURL, method, path, requestBodyBytes, contentType)
 	}
 	if err != nil {
 		return apiResponse{Status: http.StatusBadGateway, Body: map[string]any{
@@ -1599,8 +1860,8 @@ func resolveLocalConductorVersion() string {
 	return strings.TrimSpace(payload.Version)
 }
 
-func doBackendAPIRequest(method, path string, requestBodyBytes []byte, contentType string) (*http.Response, error) {
-	backendURL, err := buildLocalBackendURL(path)
+func doBackendAPIRequest(backendBaseURL, method, path string, requestBodyBytes []byte, contentType string) (*http.Response, error) {
+	backendURL, err := buildLocalBackendURLWithBase(backendBaseURL, path)
 	if err != nil {
 		return nil, err
 	}
@@ -1630,11 +1891,51 @@ func doBackendAPIRequest(method, path string, requestBodyBytes []byte, contentTy
 	return client.Do(req)
 }
 
-func ensureLocalBackendForProxy() error {
-	backendEnsureMu.Lock()
-	defer backendEnsureMu.Unlock()
+func doBackendAPIStreamRequest(
+	ctx context.Context,
+	backendBaseURL string,
+	method string,
+	path string,
+	requestBodyBytes []byte,
+	headers http.Header,
+) (*http.Response, error) {
+	backendURL, err := buildLocalBackendURLWithBase(backendBaseURL, path)
+	if err != nil {
+		return nil, err
+	}
+	method, err = normalizeHTTPMethod(method)
+	if err != nil {
+		return nil, err
+	}
 
-	_, err := backend.Ensure(context.Background(), backend.Options{
+	var requestBody io.Reader
+	if len(requestBodyBytes) > 0 {
+		requestBody = bytes.NewReader(requestBodyBytes)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, backendURL.String(), requestBody)
+	if err != nil {
+		return nil, err
+	}
+	req.Header = headers.Clone()
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	return client.Do(req)
+}
+
+func ensureLocalBackendForProxy(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-backendEnsureGate:
+	}
+	defer func() { backendEnsureGate <- struct{}{} }()
+
+	_, err := backend.Ensure(ctx, backend.Options{
 		Stderr:         os.Stderr,
 		StartupTimeout: 45 * time.Second,
 	})

--- a/bridge-cmd/relay/client.go
+++ b/bridge-cmd/relay/client.go
@@ -738,6 +738,7 @@ func runSession(ctx context.Context, opts sessionOptions) (bool, error) {
 					previous.cancel()
 				}
 				go func(request bridgeEnvelope, requestID string, handle *apiStreamHandle) {
+					defer streamCancel()
 					defer activeAPIStreams.removeIfMatch(requestID, handle)
 					if err := proxyAPIStream(
 						streamCtx,

--- a/bridge-cmd/relay/client_test.go
+++ b/bridge-cmd/relay/client_test.go
@@ -754,6 +754,13 @@ func TestRunSessionAPIStreamCancelIsPerIDAndCleansUp(t *testing.T) {
 		}
 	}))
 	defer backend.Close()
+	defer func() {
+		select {
+		case <-releaseB:
+		default:
+			close(releaseB)
+		}
+	}()
 
 	upgrader := websocket.Upgrader{}
 	relay := newIPv4TestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -777,12 +784,13 @@ func TestRunSessionAPIStreamCancelIsPerIDAndCleansUp(t *testing.T) {
 			Path:   "/api/dispatcher/feed/stream?target=b",
 		})
 
-		waitForBridgeEnvelope(t, conn, func(env bridgeEnvelope) bool {
-			return env.Type == "api_stream_start" && env.ID == "stream-a"
-		})
-		waitForBridgeEnvelope(t, conn, func(env bridgeEnvelope) bool {
-			return env.Type == "api_stream_start" && env.ID == "stream-b"
-		})
+		started := map[string]bool{}
+		for len(started) < 2 {
+			env := readBridgeEnvelope(t, conn)
+			if env.Type == "api_stream_start" && (env.ID == "stream-a" || env.ID == "stream-b") {
+				started[env.ID] = true
+			}
+		}
 
 		writeBridgeEnvelope(t, conn, bridgeEnvelope{Type: "api_stream_cancel", ID: "stream-a"})
 		select {

--- a/bridge-cmd/relay/client_test.go
+++ b/bridge-cmd/relay/client_test.go
@@ -3,8 +3,10 @@ package relay
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -15,6 +17,95 @@ import (
 
 	"github.com/gorilla/websocket"
 )
+
+func newIPv4TestServer(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("sandbox blocks loopback listeners: %v", err)
+	}
+	server := httptest.NewUnstartedServer(handler)
+	server.Listener = listener
+	server.Start()
+	return server
+}
+
+func readBridgeEnvelope(t *testing.T, conn *websocket.Conn) bridgeEnvelope {
+	t.Helper()
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	_, data, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read websocket message: %v", err)
+	}
+	var env bridgeEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		t.Fatalf("decode bridge envelope %q: %v", string(data), err)
+	}
+	return env
+}
+
+func waitForBridgeEnvelope(t *testing.T, conn *websocket.Conn, predicate func(bridgeEnvelope) bool) bridgeEnvelope {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		env := readBridgeEnvelope(t, conn)
+		if predicate(env) {
+			return env
+		}
+	}
+	t.Fatal("timed out waiting for bridge message")
+	return bridgeEnvelope{}
+}
+
+func writeBridgeEnvelope(t *testing.T, conn *websocket.Conn, env bridgeEnvelope) {
+	t.Helper()
+	data, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("encode bridge envelope: %v", err)
+	}
+	if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
+		t.Fatalf("write websocket message: %v", err)
+	}
+}
+
+func assertStreamCapability(t *testing.T, env bridgeEnvelope) {
+	t.Helper()
+	if env.Type != "bridge_status" {
+		t.Fatalf("message type = %q, want bridge_status", env.Type)
+	}
+	if env.Hostname == "" || env.OS == "" {
+		t.Fatalf("bridge_status missing host metadata: %+v", env)
+	}
+	if !env.Connected {
+		t.Fatalf("bridge_status connected = false, want true")
+	}
+	for _, capability := range env.Capabilities {
+		if capability == apiStreamV1Capability {
+			return
+		}
+	}
+	t.Fatalf("bridge_status capabilities = %v, want %q", env.Capabilities, apiStreamV1Capability)
+}
+
+func runSessionAsync(ctx context.Context, opts sessionOptions) <-chan struct {
+	connected bool
+	err       error
+} {
+	done := make(chan struct {
+		connected bool
+		err       error
+	}, 1)
+	go func() {
+		connected, err := runSession(ctx, opts)
+		done <- struct {
+			connected bool
+			err       error
+		}{connected: connected, err: err}
+	}()
+	return done
+}
 
 func TestRelayAuthHeadersUsesAuthorizationBearer(t *testing.T) {
 	t.Parallel()
@@ -54,7 +145,7 @@ func TestRunSessionReportsEstablishedConnectionAfterRelayDrops(t *testing.T) {
 
 	serverErr := make(chan error, 1)
 	upgrader := websocket.Upgrader{}
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newIPv4TestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			serverErr <- err
@@ -62,10 +153,12 @@ func TestRunSessionReportsEstablishedConnectionAfterRelayDrops(t *testing.T) {
 		}
 		defer conn.Close()
 
-		if _, _, err := conn.ReadMessage(); err != nil {
-			serverErr <- err
+		env := readBridgeEnvelope(t, conn)
+		if env.Type != "bridge_status" {
+			serverErr <- errors.New("expected bridge_status handshake")
 			return
 		}
+		assertStreamCapability(t, env)
 		serverErr <- nil
 	}))
 	defer server.Close()
@@ -378,5 +471,469 @@ func TestBrowseFilesRestrictsToAllowedRoots(t *testing.T) {
 	outside := string(filepath.Separator) + "etc"
 	if _, err := browseFiles(outside); err == nil {
 		t.Fatalf("browseFiles(%q) succeeded, want root restriction error", outside)
+	}
+}
+
+func TestRunSessionStreamsHeldOpenSSEWithSanitizedHeaders(t *testing.T) {
+	t.Setenv(legacyTTYDMirrorEnv, "")
+
+	requestHeaders := make(chan http.Header, 1)
+	releaseSecondChunk := make(chan struct{})
+	backend := newIPv4TestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/dispatcher/feed/stream" {
+			http.NotFound(w, r)
+			return
+		}
+		requestHeaders <- r.Header.Clone()
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache, no-transform")
+		w.Header().Set("X-Accel-Buffering", "no")
+		w.Header().Set("Set-Cookie", "bridge-secret=1")
+		w.Header().Set("Connection", "keep-alive")
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("backend response writer is not flushable")
+		}
+		if _, err := io.WriteString(w, "data: first\n\n"); err != nil {
+			return
+		}
+		flusher.Flush()
+		<-releaseSecondChunk
+		_, _ = io.WriteString(w, "data: second\n\n")
+		flusher.Flush()
+	}))
+	defer backend.Close()
+
+	upgrader := websocket.Upgrader{}
+	relay := newIPv4TestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade relay websocket: %v", err)
+		}
+		defer conn.Close()
+
+		assertStreamCapability(t, readBridgeEnvelope(t, conn))
+		writeBridgeEnvelope(t, conn, bridgeEnvelope{
+			Type:   "api_stream_request",
+			ID:     "stream-1",
+			Method: http.MethodGet,
+			Path:   "/api/dispatcher/feed/stream",
+			Headers: map[string]string{
+				"accept":           "text/event-stream",
+				"cache-control":    "no-cache",
+				"authorization":    "Bearer should-not-forward",
+				"cookie":           "secret=1",
+				"x-forwarded-host": "evil.example",
+				"connection":       "keep-alive",
+			},
+		})
+
+		start := waitForBridgeEnvelope(t, conn, func(env bridgeEnvelope) bool {
+			return env.Type == "api_stream_start" && env.ID == "stream-1"
+		})
+		if start.Status != http.StatusOK {
+			t.Fatalf("stream start status = %d, want %d", start.Status, http.StatusOK)
+		}
+		if got := start.Headers["content-type"]; got != "text/event-stream" {
+			t.Fatalf("start content-type = %q, want text/event-stream", got)
+		}
+		if got := start.Headers["cache-control"]; got != "no-cache, no-transform" {
+			t.Fatalf("start cache-control = %q", got)
+		}
+		if got := start.Headers["x-accel-buffering"]; got != "no" {
+			t.Fatalf("start x-accel-buffering = %q, want no", got)
+		}
+		if _, ok := start.Headers["set-cookie"]; ok {
+			t.Fatal("start headers leaked set-cookie")
+		}
+		if _, ok := start.Headers["connection"]; ok {
+			t.Fatal("start headers leaked connection")
+		}
+
+		firstChunk := waitForBridgeEnvelope(t, conn, func(env bridgeEnvelope) bool {
+			return env.Type == "api_stream_chunk" && env.ID == "stream-1"
+		})
+		firstBytes, err := base64.StdEncoding.DecodeString(firstChunk.ChunkBase64)
+		if err != nil {
+			t.Fatalf("decode first stream chunk: %v", err)
+		}
+		if string(firstBytes) != "data: first\n\n" {
+			t.Fatalf("first chunk = %q", string(firstBytes))
+		}
+
+		close(releaseSecondChunk)
+
+		secondChunk := waitForBridgeEnvelope(t, conn, func(env bridgeEnvelope) bool {
+			return env.Type == "api_stream_chunk" && env.ID == "stream-1"
+		})
+		secondBytes, err := base64.StdEncoding.DecodeString(secondChunk.ChunkBase64)
+		if err != nil {
+			t.Fatalf("decode second stream chunk: %v", err)
+		}
+		if string(secondBytes) != "data: second\n\n" {
+			t.Fatalf("second chunk = %q", string(secondBytes))
+		}
+
+		end := waitForBridgeEnvelope(t, conn, func(env bridgeEnvelope) bool {
+			return env.Type == "api_stream_end" && env.ID == "stream-1"
+		})
+		if end.Error != "" {
+			t.Fatalf("stream end error = %q, want empty", end.Error)
+		}
+	}))
+	defer relay.Close()
+
+	done := runSessionAsync(context.Background(), sessionOptions{
+		relayURL:          relay.URL,
+		refreshToken:      "refresh-token",
+		scope:             "device-123",
+		hostname:          "test-host",
+		osName:            "test-os",
+		version:           "test-version",
+		stderr:            io.Discard,
+		heartbeatInterval: time.Hour,
+		backendBaseURL:    backend.URL,
+	})
+
+	select {
+	case headers := <-requestHeaders:
+		if got := headers.Get("Accept"); got != "text/event-stream" {
+			t.Fatalf("backend accept header = %q", got)
+		}
+		if got := headers.Get("Cache-Control"); got != "no-cache" {
+			t.Fatalf("backend cache-control header = %q", got)
+		}
+		if got := headers.Get("Authorization"); got != "" {
+			t.Fatalf("backend authorization header leaked: %q", got)
+		}
+		if got := headers.Get("Cookie"); got != "" {
+			t.Fatalf("backend cookie header leaked: %q", got)
+		}
+		if got := headers.Get("X-Forwarded-Host"); got != "" {
+			t.Fatalf("backend x-forwarded-host leaked: %q", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("backend did not receive streamed request")
+	}
+
+	select {
+	case result := <-done:
+		if !result.connected {
+			t.Fatal("runSession reported disconnected attempt after streamed request")
+		}
+		if result.err == nil {
+			t.Fatal("runSession returned nil error after relay closed")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("runSession did not exit after relay closed")
+	}
+}
+
+func TestRunSessionSendsHeartbeatWhileAPIStreamRemainsOpen(t *testing.T) {
+	t.Setenv(legacyTTYDMirrorEnv, "")
+
+	release := make(chan struct{})
+	backend := newIPv4TestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("backend response writer is not flushable")
+		}
+		_, _ = io.WriteString(w, "data: waiting\n\n")
+		flusher.Flush()
+		<-release
+	}))
+	defer backend.Close()
+
+	upgrader := websocket.Upgrader{}
+	relay := newIPv4TestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade relay websocket: %v", err)
+		}
+		defer conn.Close()
+
+		assertStreamCapability(t, readBridgeEnvelope(t, conn))
+		writeBridgeEnvelope(t, conn, bridgeEnvelope{
+			Type:   "api_stream_request",
+			ID:     "stream-heartbeat",
+			Method: http.MethodGet,
+			Path:   "/api/dispatcher/feed/stream",
+			Headers: map[string]string{
+				"accept": "text/event-stream",
+			},
+		})
+
+		waitForBridgeEnvelope(t, conn, func(env bridgeEnvelope) bool {
+			return env.Type == "api_stream_start" && env.ID == "stream-heartbeat"
+		})
+		waitForBridgeEnvelope(t, conn, func(env bridgeEnvelope) bool {
+			return env.Type == "api_stream_chunk" && env.ID == "stream-heartbeat"
+		})
+		heartbeat := waitForBridgeEnvelope(t, conn, func(env bridgeEnvelope) bool {
+			return env.Type == "bridge_status"
+		})
+		assertStreamCapability(t, heartbeat)
+
+		close(release)
+	}))
+	defer relay.Close()
+
+	done := runSessionAsync(context.Background(), sessionOptions{
+		relayURL:          relay.URL,
+		refreshToken:      "refresh-token",
+		scope:             "device-123",
+		hostname:          "test-host",
+		osName:            "test-os",
+		version:           "test-version",
+		stderr:            io.Discard,
+		heartbeatInterval: 40 * time.Millisecond,
+		backendBaseURL:    backend.URL,
+	})
+
+	select {
+	case result := <-done:
+		if !result.connected {
+			t.Fatal("runSession reported disconnected attempt after heartbeat stream")
+		}
+		if result.err == nil {
+			t.Fatal("runSession returned nil error after relay closed")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("runSession did not exit after heartbeat test")
+	}
+}
+
+func TestEnsureLocalBackendForProxyHonorsCancellationWhileWaiting(t *testing.T) {
+	<-backendEnsureGate
+	defer func() { backendEnsureGate <- struct{}{} }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	started := time.Now()
+	err := ensureLocalBackendForProxy(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ensure error = %v, want context.Canceled", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("cancelled ensure waited too long: %s", elapsed)
+	}
+}
+
+func TestRunSessionAPIStreamCancelIsPerIDAndCleansUp(t *testing.T) {
+	t.Setenv(legacyTTYDMirrorEnv, "")
+
+	a1Cancelled := make(chan struct{}, 1)
+	a2Cancelled := make(chan struct{}, 1)
+	releaseB := make(chan struct{})
+	backend := newIPv4TestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("backend response writer is not flushable")
+		}
+		switch r.URL.Query().Get("target") {
+		case "a1":
+			_, _ = io.WriteString(w, "data: a1\n\n")
+			flusher.Flush()
+			<-r.Context().Done()
+			a1Cancelled <- struct{}{}
+		case "a2":
+			_, _ = io.WriteString(w, "data: a2\n\n")
+			flusher.Flush()
+			<-r.Context().Done()
+			a2Cancelled <- struct{}{}
+		case "b":
+			_, _ = io.WriteString(w, "data: b1\n\n")
+			flusher.Flush()
+			<-releaseB
+			_, _ = io.WriteString(w, "data: b2\n\n")
+			flusher.Flush()
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer backend.Close()
+
+	upgrader := websocket.Upgrader{}
+	relay := newIPv4TestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade relay websocket: %v", err)
+		}
+		defer conn.Close()
+
+		assertStreamCapability(t, readBridgeEnvelope(t, conn))
+		writeBridgeEnvelope(t, conn, bridgeEnvelope{
+			Type:   "api_stream_request",
+			ID:     "stream-a",
+			Method: http.MethodGet,
+			Path:   "/api/dispatcher/feed/stream?target=a1",
+		})
+		writeBridgeEnvelope(t, conn, bridgeEnvelope{
+			Type:   "api_stream_request",
+			ID:     "stream-b",
+			Method: http.MethodGet,
+			Path:   "/api/dispatcher/feed/stream?target=b",
+		})
+
+		waitForBridgeEnvelope(t, conn, func(env bridgeEnvelope) bool {
+			return env.Type == "api_stream_start" && env.ID == "stream-a"
+		})
+		waitForBridgeEnvelope(t, conn, func(env bridgeEnvelope) bool {
+			return env.Type == "api_stream_start" && env.ID == "stream-b"
+		})
+
+		writeBridgeEnvelope(t, conn, bridgeEnvelope{Type: "api_stream_cancel", ID: "stream-a"})
+		select {
+		case <-a1Cancelled:
+		case <-time.After(5 * time.Second):
+			t.Fatal("first stream-a request was not cancelled")
+		}
+
+		writeBridgeEnvelope(t, conn, bridgeEnvelope{
+			Type:   "api_stream_request",
+			ID:     "stream-a",
+			Method: http.MethodGet,
+			Path:   "/api/dispatcher/feed/stream?target=a2",
+		})
+		waitForBridgeEnvelope(t, conn, func(env bridgeEnvelope) bool {
+			return env.Type == "api_stream_start" && env.ID == "stream-a"
+		})
+
+		writeBridgeEnvelope(t, conn, bridgeEnvelope{Type: "api_stream_cancel", ID: "stream-a"})
+		select {
+		case <-a2Cancelled:
+		case <-time.After(5 * time.Second):
+			t.Fatal("replacement stream-a request was not cancelled")
+		}
+
+		close(releaseB)
+		finalChunk := waitForBridgeEnvelope(t, conn, func(env bridgeEnvelope) bool {
+			if env.Type != "api_stream_chunk" || env.ID != "stream-b" {
+				return false
+			}
+			decoded, err := base64.StdEncoding.DecodeString(env.ChunkBase64)
+			return err == nil && string(decoded) == "data: b2\n\n"
+		})
+		decoded, err := base64.StdEncoding.DecodeString(finalChunk.ChunkBase64)
+		if err != nil {
+			t.Fatalf("decode stream-b chunk: %v", err)
+		}
+		if string(decoded) != "data: b2\n\n" {
+			t.Fatalf("stream-b final chunk = %q", string(decoded))
+		}
+		end := waitForBridgeEnvelope(t, conn, func(env bridgeEnvelope) bool {
+			return env.Type == "api_stream_end" && env.ID == "stream-b"
+		})
+		if end.Error != "" {
+			t.Fatalf("stream-b end error = %q, want empty", end.Error)
+		}
+		if err := conn.WriteControl(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, "test complete"),
+			time.Now().Add(time.Second),
+		); err != nil {
+			t.Fatalf("close relay websocket: %v", err)
+		}
+	}))
+	defer relay.Close()
+
+	done := runSessionAsync(context.Background(), sessionOptions{
+		relayURL:          relay.URL,
+		refreshToken:      "refresh-token",
+		scope:             "device-123",
+		hostname:          "test-host",
+		osName:            "test-os",
+		version:           "test-version",
+		stderr:            io.Discard,
+		heartbeatInterval: time.Hour,
+		backendBaseURL:    backend.URL,
+	})
+
+	select {
+	case result := <-done:
+		if !result.connected {
+			t.Fatal("runSession reported disconnected attempt after cancel test")
+		}
+		if result.err == nil {
+			t.Fatal("runSession returned nil error after relay closed")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("runSession did not exit after cancel test")
+	}
+}
+
+func TestRunSessionAPIStreamFailureSynthesizesErrorLifecycle(t *testing.T) {
+	t.Setenv(legacyTTYDMirrorEnv, "")
+
+	upgrader := websocket.Upgrader{}
+	relay := newIPv4TestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade relay websocket: %v", err)
+		}
+		defer conn.Close()
+
+		assertStreamCapability(t, readBridgeEnvelope(t, conn))
+		writeBridgeEnvelope(t, conn, bridgeEnvelope{
+			Type:   "api_stream_request",
+			ID:     "stream-fail",
+			Method: http.MethodGet,
+			Path:   "/api/dispatcher/feed/stream",
+		})
+
+		start := waitForBridgeEnvelope(t, conn, func(env bridgeEnvelope) bool {
+			return env.Type == "api_stream_start" && env.ID == "stream-fail"
+		})
+		if start.Status != http.StatusBadGateway {
+			t.Fatalf("failure start status = %d, want %d", start.Status, http.StatusBadGateway)
+		}
+		if got := start.Headers["content-type"]; got != "application/json" {
+			t.Fatalf("failure start content-type = %q", got)
+		}
+
+		chunk := waitForBridgeEnvelope(t, conn, func(env bridgeEnvelope) bool {
+			return env.Type == "api_stream_chunk" && env.ID == "stream-fail"
+		})
+		body, err := base64.StdEncoding.DecodeString(chunk.ChunkBase64)
+		if err != nil {
+			t.Fatalf("decode failure chunk: %v", err)
+		}
+		if !strings.Contains(string(body), `"error":`) {
+			t.Fatalf("failure chunk body = %q, want JSON error", string(body))
+		}
+
+		end := waitForBridgeEnvelope(t, conn, func(env bridgeEnvelope) bool {
+			return env.Type == "api_stream_end" && env.ID == "stream-fail"
+		})
+		if end.Error != "" {
+			t.Fatalf("failure end error = %q, want empty", end.Error)
+		}
+	}))
+	defer relay.Close()
+
+	done := runSessionAsync(context.Background(), sessionOptions{
+		relayURL:          relay.URL,
+		refreshToken:      "refresh-token",
+		scope:             "device-123",
+		hostname:          "test-host",
+		osName:            "test-os",
+		version:           "test-version",
+		stderr:            io.Discard,
+		heartbeatInterval: time.Hour,
+		backendBaseURL:    "http://127.0.0.1:1",
+	})
+
+	select {
+	case result := <-done:
+		if !result.connected {
+			t.Fatal("runSession reported disconnected attempt after failure lifecycle")
+		}
+		if result.err == nil {
+			t.Fatal("runSession returned nil error after relay closed")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("runSession did not exit after failure lifecycle test")
 	}
 }

--- a/bridge-cmd/relay/client_test.go
+++ b/bridge-cmd/relay/client_test.go
@@ -872,76 +872,36 @@ func TestRunSessionAPIStreamCancelIsPerIDAndCleansUp(t *testing.T) {
 	}
 }
 
-func TestRunSessionAPIStreamFailureSynthesizesErrorLifecycle(t *testing.T) {
-	t.Setenv(legacyTTYDMirrorEnv, "")
-
-	upgrader := websocket.Upgrader{}
-	relay := newIPv4TestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := upgrader.Upgrade(w, r, nil)
-		if err != nil {
-			t.Fatalf("upgrade relay websocket: %v", err)
-		}
-		defer conn.Close()
-
-		assertStreamCapability(t, readBridgeEnvelope(t, conn))
-		writeBridgeEnvelope(t, conn, bridgeEnvelope{
-			Type:   "api_stream_request",
-			ID:     "stream-fail",
-			Method: http.MethodGet,
-			Path:   "/api/dispatcher/feed/stream",
-		})
-
-		start := waitForBridgeEnvelope(t, conn, func(env bridgeEnvelope) bool {
-			return env.Type == "api_stream_start" && env.ID == "stream-fail"
-		})
-		if start.Status != http.StatusBadGateway {
-			t.Fatalf("failure start status = %d, want %d", start.Status, http.StatusBadGateway)
-		}
-		if got := start.Headers["content-type"]; got != "application/json" {
-			t.Fatalf("failure start content-type = %q", got)
-		}
-
-		chunk := waitForBridgeEnvelope(t, conn, func(env bridgeEnvelope) bool {
-			return env.Type == "api_stream_chunk" && env.ID == "stream-fail"
-		})
-		body, err := base64.StdEncoding.DecodeString(chunk.ChunkBase64)
-		if err != nil {
-			t.Fatalf("decode failure chunk: %v", err)
-		}
-		if !strings.Contains(string(body), `"error":`) {
-			t.Fatalf("failure chunk body = %q, want JSON error", string(body))
-		}
-
-		end := waitForBridgeEnvelope(t, conn, func(env bridgeEnvelope) bool {
-			return env.Type == "api_stream_end" && env.ID == "stream-fail"
-		})
-		if end.Error != "" {
-			t.Fatalf("failure end error = %q, want empty", end.Error)
-		}
-	}))
-	defer relay.Close()
-
-	done := runSessionAsync(context.Background(), sessionOptions{
-		relayURL:          relay.URL,
-		refreshToken:      "refresh-token",
-		scope:             "device-123",
-		hostname:          "test-host",
-		osName:            "test-os",
-		version:           "test-version",
-		stderr:            io.Discard,
-		heartbeatInterval: time.Hour,
-		backendBaseURL:    "http://127.0.0.1:1",
-	})
-
-	select {
-	case result := <-done:
-		if !result.connected {
-			t.Fatal("runSession reported disconnected attempt after failure lifecycle")
-		}
-		if result.err == nil {
-			t.Fatal("runSession returned nil error after relay closed")
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("runSession did not exit after failure lifecycle test")
+func TestSendAPIStreamFailureResponseSynthesizesErrorLifecycle(t *testing.T) {
+	var messages []bridgeEnvelope
+	err := sendAPIStreamFailureResponse(func(env bridgeEnvelope) error {
+		messages = append(messages, env)
+		return nil
+	}, "stream-fail", http.StatusBadGateway, "backend unavailable")
+	if err != nil {
+		t.Fatalf("send failure lifecycle: %v", err)
+	}
+	if len(messages) != 3 {
+		t.Fatalf("failure lifecycle message count = %d, want 3", len(messages))
+	}
+	start, chunk, end := messages[0], messages[1], messages[2]
+	if start.Type != "api_stream_start" || start.ID != "stream-fail" || start.Status != http.StatusBadGateway {
+		t.Fatalf("unexpected failure start: %+v", start)
+	}
+	if got := start.Headers["content-type"]; got != "application/json" {
+		t.Fatalf("failure start content-type = %q", got)
+	}
+	if chunk.Type != "api_stream_chunk" || chunk.ID != "stream-fail" {
+		t.Fatalf("unexpected failure chunk: %+v", chunk)
+	}
+	body, err := base64.StdEncoding.DecodeString(chunk.ChunkBase64)
+	if err != nil {
+		t.Fatalf("decode failure chunk: %v", err)
+	}
+	if !strings.Contains(string(body), `"error":`) {
+		t.Fatalf("failure chunk body = %q, want JSON error", string(body))
+	}
+	if end.Type != "api_stream_end" || end.ID != "stream-fail" || end.Error != "" {
+		t.Fatalf("unexpected failure end: %+v", end)
 	}
 }


### PR DESCRIPTION
## User-Facing Release Notes

- The installed paired-device bridge now streams dispatcher and session output incrementally instead of buffering it.

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Testing

- `go test ./... -timeout 120s`
- `go vet ./...`
- Held-open HTTP stream, cancellation, failure lifecycle, capability, and heartbeat tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for streaming API responses, including long-lived connections and heartbeat updates.
  * Added per-request cancellation for active streams.
* **Bug Fixes**
  * Improved cleanup when streamed requests are canceled or encounter backend errors.
  * Strengthened request handling with safer headers and bounded response payloads.
  * Improved reliability when starting local backend services and connecting over IPv4 loopback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->