### PR TITLE
fix: clean stale relay readiness probes before snapshot

### DIFF
--- a/scripts/conductor-relay-deploy-host.sh
+++ b/scripts/conductor-relay-deploy-host.sh
@@ -18,6 +18,7 @@ state_filename_current=""
 public_health_url="https://relay.conductross.com/health"
 docker_command_timeout_seconds=45
 state_backup_max_bytes=67108864
+state_backup_tmpfs_root="/dev/shm"
 state_backup_dir=""
 state_backup_owner=""
 state_backup_size=0
@@ -41,13 +42,13 @@ cleanup_state_backup() {
 }
 
 backup_relay_state() {
-  if [ ! -d /dev/shm ] || [ ! -w /dev/shm ] \
+  if [ ! -d "$state_backup_tmpfs_root" ] || [ ! -w "$state_backup_tmpfs_root" ] \
     || ! command -v findmnt >/dev/null 2>&1 \
-    || [ "$(findmnt -n -o FSTYPE --target /dev/shm 2>/dev/null || true)" != "tmpfs" ]; then
-    echo "A writable memory-backed /dev/shm is required for the relay rollback snapshot." >&2
+    || [ "$(findmnt -n -o FSTYPE --target "$state_backup_tmpfs_root" 2>/dev/null || true)" != "tmpfs" ]; then
+    echo "A writable memory-backed $state_backup_tmpfs_root is required for the relay rollback snapshot." >&2
     return 1
   fi
-  state_backup_available_bytes=$(df -PB1 /dev/shm | awk 'NR == 2 { print $4 }')
+  state_backup_available_bytes=$(df -PB1 "$state_backup_tmpfs_root" | awk 'NR == 2 { print $4 }')
   if [[ ! "$state_backup_available_bytes" =~ ^[0-9]+$ ]] \
     || [ "$state_backup_available_bytes" -lt "$state_backup_max_bytes" ]; then
     echo "Insufficient memory-backed capacity for the relay rollback snapshot." >&2
@@ -55,7 +56,7 @@ backup_relay_state() {
   fi
 
   umask 077
-  state_backup_dir=$(mktemp -d /dev/shm/conductor-relay-state.XXXXXX)
+  state_backup_dir=$(mktemp -d "${state_backup_tmpfs_root%/}/conductor-relay-state.XXXXXX")
   if ! backup_result=$(run_docker run --rm \
     --network none \
     --read-only \
@@ -63,7 +64,7 @@ backup_relay_state() {
     --security-opt no-new-privileges:true \
     --cap-drop ALL \
     --cap-add DAC_OVERRIDE \
-    --mount "type=volume,src=${state_volume},dst=/state,readonly" \
+    --mount "type=volume,src=${state_volume},dst=/state" \
     --mount "type=bind,src=${state_backup_dir},dst=/backup" \
     --entrypoint /bin/sh \
     "$current_image_id" \
@@ -83,16 +84,42 @@ backup_relay_state() {
         || [ "$(stat -c %u:%g /state)" != "$expected_owner" ]; then
         exit 2
       fi
+      probe_entries=""
+      probe_count=0
       entry_count=0
       for entry in /state/.[!.]* /state/..?* /state/*; do
         if [ ! -e "$entry" ] && [ ! -L "$entry" ]; then
           continue
         fi
         entry_count=$((entry_count + 1))
-        if [ "$entry" != "$source_path" ]; then
-          exit 2
+        if [ "$entry" = "$source_path" ]; then
+          continue
         fi
+        case "$entry" in
+          /state/state.[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f].readiness)
+            if [ -L "$entry" ] \
+              || [ ! -f "$entry" ] \
+              || [ "$(stat -c %h "$entry")" != "1" ] \
+              || [ "$(stat -c %u:%g "$entry")" != "$expected_owner" ] \
+              || [ "$(stat -c %a "$entry")" != "600" ] \
+              || [ "$(stat -c %s "$entry")" != "15" ]; then
+              exit 2
+            fi
+            if ! printf relay-readiness | cmp -s -- "$entry" -; then
+              exit 2
+            fi
+            probe_entries="${probe_entries}${probe_entries:+ }$entry"
+            probe_count=$((probe_count + 1))
+            ;;
+          *)
+            exit 2
+            ;;
+        esac
       done
+      for probe_entry in $probe_entries; do
+        rm -f -- "$probe_entry"
+      done
+      entry_count=$((entry_count - probe_count))
       if [ -L "$source_path" ] || [ -L "$other_path" ]; then
         exit 2
       fi
@@ -379,6 +406,10 @@ finalize_relay_state_layout() {
   done
   return 1
 }
+
+if [ "${CONDUCTOR_RELAY_DEPLOY_HOST_SOURCE_ONLY:-0}" = "1" ]; then
+  return 0 2>/dev/null || exit 0
+fi
 
 original_command="${SSH_ORIGINAL_COMMAND:-}"
 if [[ "$original_command" =~ ^verify-script\ ([0-9a-f]{64})$ ]]; then

--- a/scripts/conductor-relay-deploy-host.sh
+++ b/scripts/conductor-relay-deploy-host.sh
@@ -79,6 +79,7 @@ backup_relay_state() {
       esac
       source_path="/state/$source_name"
       other_path="/state/$other_name"
+      readiness_prefix="/state/${source_name%.json}."
       if [ ! -d /state ] \
         || [ "$(stat -c %a /state)" != "700" ] \
         || [ "$(stat -c %u:%g /state)" != "$expected_owner" ]; then
@@ -96,7 +97,7 @@ backup_relay_state() {
           continue
         fi
         case "$entry" in
-          /state/state.[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f].readiness)
+          "$readiness_prefix"[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f].readiness)
             if [ -L "$entry" ] \
               || [ ! -f "$entry" ] \
               || [ "$(stat -c %h "$entry")" != "1" ] \

--- a/scripts/conductor-relay-deploy-host.test.mjs
+++ b/scripts/conductor-relay-deploy-host.test.mjs
@@ -1,0 +1,390 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const scriptPath = resolve(__dirname, "conductor-relay-deploy-host.sh");
+const expectedOwner = "999:999";
+const readinessBytes = "relay-readiness";
+const stateContent = '{"claims":[]}\n';
+const validProbeName = "state.0123456789abcdef0123456789abcdef.readiness";
+const secondValidProbeName = "state.abcdef0123456789abcdef0123456789.readiness";
+
+function metaPathFor(metaDir, targetPath) {
+  return join(metaDir, targetPath.replaceAll("/", "__"));
+}
+
+function writeMetadata(metaDir, targetPath, metadata) {
+  const lines = [
+    `mode=${metadata.mode}`,
+    `owner=${metadata.owner}`,
+    `links=${metadata.links}`,
+    `size=${metadata.size}`,
+  ];
+  writeFileSync(metaPathFor(metaDir, targetPath), `${lines.join("\n")}\n`, "utf8");
+}
+
+function writeFileWithMetadata(metaDir, targetPath, content, metadata = {}) {
+  writeFileSync(targetPath, content);
+  if (metadata.mode !== undefined) {
+    chmodSync(targetPath, Number.parseInt(metadata.mode, 8));
+  }
+  writeMetadata(metaDir, targetPath, {
+    mode: metadata.mode ?? "600",
+    owner: metadata.owner ?? expectedOwner,
+    links: metadata.links ?? "1",
+    size: metadata.size ?? String(Buffer.byteLength(content)),
+  });
+}
+
+function writeDirectoryMetadata(metaDir, targetPath, metadata = {}) {
+  writeMetadata(metaDir, targetPath, {
+    mode: metadata.mode ?? "700",
+    owner: metadata.owner ?? expectedOwner,
+    links: metadata.links ?? "1",
+    size: metadata.size ?? "0",
+  });
+}
+
+function installFakeCoreutils(binDir) {
+  const findmntPath = join(binDir, "findmnt");
+  writeFileSync(
+    findmntPath,
+    "#!/usr/bin/env bash\nset -euo pipefail\nprintf 'tmpfs\\n'\n",
+    "utf8",
+  );
+  chmodSync(findmntPath, 0o755);
+
+  const dfPath = join(binDir, "df");
+  writeFileSync(
+    dfPath,
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      "printf 'Filesystem 1B-blocks Used Available Use%% Mounted on\\n'",
+      "printf 'tmpfs 200000000 1 199999999 1%% %s\\n' \"${@: -1}\"",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  chmodSync(dfPath, 0o755);
+
+  const mktempPath = join(binDir, "mktemp");
+  writeFileSync(
+    mktempPath,
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      "root=${TEST_MKTEMP_ROOT:?}",
+      "mkdir -p -- \"$root\"",
+      "while :; do",
+      "  candidate=\"$root/conductor-relay-state.$RANDOM$RANDOM\"",
+      "  if mkdir -- \"$candidate\" 2>/dev/null; then",
+      "    printf '%s\\n' \"$candidate\"",
+      "    exit 0",
+      "  fi",
+      "done",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  chmodSync(mktempPath, 0o755);
+
+  const statPath = join(binDir, "stat");
+  writeFileSync(
+    statPath,
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      "if [ \"$#\" -ne 3 ] || [ \"$1\" != \"-c\" ]; then",
+      "  echo 'unsupported stat invocation' >&2",
+      "  exit 2",
+      "fi",
+      "format=$2",
+      "target=$3",
+      "meta_key=${target//\\//__}",
+      "meta_file=\"${TEST_META_DIR:?}/$meta_key\"",
+      "if [ ! -f \"$meta_file\" ]; then",
+      "  echo \"missing metadata for $target\" >&2",
+      "  exit 2",
+      "fi",
+      ". \"$meta_file\"",
+      "case \"$format\" in",
+      "  %a) printf '%s\\n' \"$mode\" ;;",
+      "  %u:%g) printf '%s\\n' \"$owner\" ;;",
+      "  %h) printf '%s\\n' \"$links\" ;;",
+      "  %s) printf '%s\\n' \"$size\" ;;",
+      "  *) echo \"unsupported stat format: $format\" >&2; exit 2 ;;",
+      "esac",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  chmodSync(statPath, 0o755);
+}
+
+function runBackupScenario(prepareScenario) {
+  const rootDir = mkdtempSync(join(tmpdir(), "conductor-relay-deploy-host-test-"));
+  const stateDir = join(rootDir, "state");
+  const shmDir = join(rootDir, "shm");
+  const binDir = join(rootDir, "bin");
+  const metaDir = join(rootDir, "meta");
+  mkdirSync(stateDir, { recursive: true });
+  mkdirSync(shmDir, { recursive: true });
+  mkdirSync(binDir, { recursive: true });
+  mkdirSync(metaDir, { recursive: true });
+  installFakeCoreutils(binDir);
+  writeDirectoryMetadata(metaDir, stateDir);
+
+  const statePath = join(stateDir, "state.json");
+  writeFileWithMetadata(metaDir, statePath, stateContent);
+
+  prepareScenario({
+    metaDir,
+    rootDir,
+    stateDir,
+    statePath,
+  });
+
+  const harness = [
+    "set -euo pipefail",
+    `TEST_STATE_DIR=${JSON.stringify(stateDir)}`,
+    `TEST_BIN_DIR=${JSON.stringify(binDir)}`,
+    `TEST_MKTEMP_ROOT=${JSON.stringify(shmDir)}`,
+    `TEST_META_DIR=${JSON.stringify(metaDir)}`,
+    "export TEST_STATE_DIR TEST_BIN_DIR TEST_MKTEMP_ROOT TEST_META_DIR",
+    'PATH="$TEST_BIN_DIR:$PATH"',
+    "export PATH",
+    `CONDUCTOR_RELAY_DEPLOY_HOST_SOURCE_ONLY=1 source ${JSON.stringify(scriptPath)}`,
+    `state_backup_tmpfs_root=${JSON.stringify(shmDir)}`,
+    'current_image_id="fake-image"',
+    `candidate_state_owner=${JSON.stringify(expectedOwner)}`,
+    'state_filename_current="state.json"',
+    "run_docker() {",
+    '  if [ "$1" != "run" ]; then',
+    '    echo "unsupported run_docker invocation: $*" >&2',
+    "    return 97",
+    "  fi",
+    "  shift",
+    '  local inner_script=""',
+    '  while [ "$#" -gt 0 ]; do',
+    '    if [ "$1" = "-ec" ]; then',
+    '      inner_script="$2"',
+    "      shift 2",
+    "      break",
+    "    fi",
+    "    shift",
+    "  done",
+    '  if [ -z "$inner_script" ] || [ "$#" -lt 1 ]; then',
+    '    echo "malformed run_docker invocation" >&2',
+    "    return 98",
+    "  fi",
+    "  shift",
+    '  local translated_script="${inner_script//\\/state\\//__TEST_STATE_DIR_SLASH__}"',
+    '  translated_script="${translated_script//\\/backup\\//__TEST_BACKUP_DIR_SLASH__}"',
+    '  translated_script="${translated_script//\\/state/__TEST_STATE_DIR__}"',
+    '  translated_script="${translated_script//\\/backup/__TEST_BACKUP_DIR__}"',
+    '  translated_script="${translated_script//__TEST_STATE_DIR_SLASH__/$TEST_STATE_DIR/}"',
+    '  translated_script="${translated_script//__TEST_BACKUP_DIR_SLASH__/$state_backup_dir/}"',
+    '  translated_script="${translated_script//__TEST_STATE_DIR__/$TEST_STATE_DIR}"',
+    '  translated_script="${translated_script//__TEST_BACKUP_DIR__/$state_backup_dir}"',
+    '  PATH="$TEST_BIN_DIR:$PATH" sh -ec "$translated_script" sh "$@"',
+    "}",
+    "if backup_relay_state; then",
+    "  printf 'backup_dir=%s\\n' \"$state_backup_dir\"",
+    "  printf 'backup_ready=%s\\n' \"$state_backup_ready\"",
+    "  printf 'backup_existed=%s\\n' \"$state_backup_existed\"",
+    "  printf 'backup_owner=%s\\n' \"$state_backup_owner\"",
+    "  printf 'backup_size=%s\\n' \"$state_backup_size\"",
+    "else",
+    "  exit $?",
+    "fi",
+    "",
+  ].join("\n");
+
+  const result = spawnSync("bash", ["-s"], {
+    cwd: rootDir,
+    env: { ...process.env },
+    input: harness,
+    encoding: "utf8",
+  });
+
+  return {
+    ...result,
+    rootDir,
+    stateDir,
+  };
+}
+
+function parseKeyValueOutput(stdout) {
+  const output = {};
+  for (const line of stdout.trim().split("\n")) {
+    if (!line) {
+      continue;
+    }
+    const separator = line.indexOf("=");
+    output[line.slice(0, separator)] = line.slice(separator + 1);
+  }
+  return output;
+}
+
+function assertBackupFailed(result) {
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Could not create a secure relay state rollback snapshot/);
+}
+
+test("backup_relay_state removes validated stale readiness probes and snapshots state", () => {
+  const result = runBackupScenario(({ metaDir, stateDir }) => {
+    writeFileWithMetadata(metaDir, join(stateDir, validProbeName), readinessBytes);
+    writeFileWithMetadata(metaDir, join(stateDir, secondValidProbeName), readinessBytes);
+  });
+
+  try {
+    assert.equal(result.status, 0, result.stderr);
+    const output = parseKeyValueOutput(result.stdout);
+    assert.equal(output.backup_ready, "1");
+    assert.equal(output.backup_existed, "1");
+    assert.equal(output.backup_owner, expectedOwner);
+    assert.equal(output.backup_size, String(Buffer.byteLength(stateContent)));
+    assert.equal(existsSync(join(result.stateDir, validProbeName)), false);
+    assert.equal(existsSync(join(result.stateDir, secondValidProbeName)), false);
+    assert.equal(readFileSync(join(output.backup_dir, "state.json"), "utf8"), stateContent);
+    assert.deepEqual(readdirSync(result.stateDir), ["state.json"]);
+  } finally {
+    rmSync(result.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("backup_relay_state rejects lookalike readiness filenames", () => {
+  const probeName = "state.0123456789abcdef0123456789abcdef.readiness.tmp";
+  const result = runBackupScenario(({ metaDir, stateDir }) => {
+    writeFileWithMetadata(metaDir, join(stateDir, probeName), readinessBytes);
+  });
+
+  try {
+    assertBackupFailed(result);
+    assert.equal(existsSync(join(result.stateDir, probeName)), true);
+  } finally {
+    rmSync(result.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("backup_relay_state rejects readiness probe symlinks", () => {
+  const result = runBackupScenario(({ stateDir, statePath }) => {
+    symlinkSync(statePath, join(stateDir, validProbeName));
+  });
+
+  try {
+    assertBackupFailed(result);
+    assert.equal(lstatSync(join(result.stateDir, validProbeName)).isSymbolicLink(), true);
+  } finally {
+    rmSync(result.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("backup_relay_state rejects readiness probes with the wrong mode", () => {
+  const result = runBackupScenario(({ metaDir, stateDir }) => {
+    writeFileWithMetadata(metaDir, join(stateDir, validProbeName), readinessBytes, { mode: "644" });
+  });
+
+  try {
+    assertBackupFailed(result);
+    assert.equal(existsSync(join(result.stateDir, validProbeName)), true);
+  } finally {
+    rmSync(result.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("backup_relay_state rejects readiness probes with the wrong owner", () => {
+  const result = runBackupScenario(({ metaDir, stateDir }) => {
+    writeFileWithMetadata(metaDir, join(stateDir, validProbeName), readinessBytes, {
+      owner: "1000:1000",
+    });
+  });
+
+  try {
+    assertBackupFailed(result);
+  } finally {
+    rmSync(result.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("backup_relay_state rejects readiness probes with the wrong link count", () => {
+  const result = runBackupScenario(({ metaDir, stateDir }) => {
+    writeFileWithMetadata(metaDir, join(stateDir, validProbeName), readinessBytes, { links: "2" });
+  });
+
+  try {
+    assertBackupFailed(result);
+  } finally {
+    rmSync(result.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("backup_relay_state rejects readiness probes with the wrong size", () => {
+  const result = runBackupScenario(({ metaDir, stateDir }) => {
+    writeFileWithMetadata(metaDir, join(stateDir, validProbeName), readinessBytes, { size: "14" });
+  });
+
+  try {
+    assertBackupFailed(result);
+  } finally {
+    rmSync(result.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("backup_relay_state rejects readiness probes with the wrong content", () => {
+  const result = runBackupScenario(({ metaDir, stateDir }) => {
+    writeFileWithMetadata(metaDir, join(stateDir, validProbeName), "relay-readinesx");
+  });
+
+  try {
+    assertBackupFailed(result);
+  } finally {
+    rmSync(result.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("backup_relay_state rejects unrelated extra files", () => {
+  const result = runBackupScenario(({ metaDir, stateDir }) => {
+    writeFileWithMetadata(metaDir, join(stateDir, "unrelated.txt"), "not allowed");
+  });
+
+  try {
+    assertBackupFailed(result);
+    assert.equal(existsSync(join(result.stateDir, "unrelated.txt")), true);
+  } finally {
+    rmSync(result.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("backup_relay_state validates every entry before deleting stale probes", () => {
+  const unrelatedName = "zz-unrelated.txt";
+  const result = runBackupScenario(({ metaDir, stateDir }) => {
+    writeFileWithMetadata(metaDir, join(stateDir, validProbeName), readinessBytes);
+    writeFileWithMetadata(metaDir, join(stateDir, unrelatedName), "not allowed");
+  });
+
+  try {
+    assertBackupFailed(result);
+    assert.equal(existsSync(join(result.stateDir, validProbeName)), true);
+    assert.equal(existsSync(join(result.stateDir, unrelatedName)), true);
+  } finally {
+    rmSync(result.rootDir, { recursive: true, force: true });
+  }
+});

--- a/scripts/conductor-relay-deploy-host.test.mjs
+++ b/scripts/conductor-relay-deploy-host.test.mjs
@@ -138,7 +138,7 @@ function installFakeCoreutils(binDir) {
   chmodSync(statPath, 0o755);
 }
 
-function runBackupScenario(prepareScenario) {
+function runBackupScenario(prepareScenario, { sourceName = "state.json" } = {}) {
   const rootDir = mkdtempSync(join(tmpdir(), "conductor-relay-deploy-host-test-"));
   const stateDir = join(rootDir, "state");
   const shmDir = join(rootDir, "shm");
@@ -151,7 +151,7 @@ function runBackupScenario(prepareScenario) {
   installFakeCoreutils(binDir);
   writeDirectoryMetadata(metaDir, stateDir);
 
-  const statePath = join(stateDir, "state.json");
+  const statePath = join(stateDir, sourceName);
   writeFileWithMetadata(metaDir, statePath, stateContent);
 
   prepareScenario({
@@ -174,7 +174,7 @@ function runBackupScenario(prepareScenario) {
     `state_backup_tmpfs_root=${JSON.stringify(shmDir)}`,
     'current_image_id="fake-image"',
     `candidate_state_owner=${JSON.stringify(expectedOwner)}`,
-    'state_filename_current="state.json"',
+    `state_filename_current=${JSON.stringify(sourceName)}`,
     "run_docker() {",
     '  if [ "$1" != "run" ]; then',
     '    echo "unsupported run_docker invocation: $*" >&2',
@@ -265,6 +265,29 @@ test("backup_relay_state removes validated stale readiness probes and snapshots 
     assert.equal(existsSync(join(result.stateDir, secondValidProbeName)), false);
     assert.equal(readFileSync(join(output.backup_dir, "state.json"), "utf8"), stateContent);
     assert.deepEqual(readdirSync(result.stateDir), ["state.json"]);
+  } finally {
+    rmSync(result.rootDir, { recursive: true, force: true });
+  }
+});
+
+test("backup_relay_state removes validated legacy relay-state readiness probes", () => {
+  const sourceName = "relay-state.json";
+  const probeName = "relay-state.0123456789abcdef0123456789abcdef.readiness";
+  const result = runBackupScenario(
+    ({ metaDir, stateDir }) => {
+      writeFileWithMetadata(metaDir, join(stateDir, probeName), readinessBytes);
+    },
+    { sourceName },
+  );
+
+  try {
+    assert.equal(result.status, 0, result.stderr);
+    const output = parseKeyValueOutput(result.stdout);
+    assert.equal(output.backup_ready, "1");
+    assert.equal(output.backup_existed, "1");
+    assert.equal(existsSync(join(result.stateDir, probeName)), false);
+    assert.equal(readFileSync(join(output.backup_dir, "state.json"), "utf8"), stateContent);
+    assert.deepEqual(readdirSync(result.stateDir), [sourceName]);
   } finally {
     rmSync(result.rootDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Fixes the production relay rollout rollback snapshot failure caused by stale `state.<32 hex>.readiness` probe files left beside `state.json` after interrupted health checks.

The host script now removes only probes that pass strict filename, type, mode, owner, link-count, size, and content checks. Any lookalike or unrelated entry still fails closed. Snapshot and rollback behavior remain unchanged.

Adds focused script tests covering safe cleanup and every rejection path.

## User-Facing Release Notes

N/A - internal maintenance only

## Type of Change

- [ ] Breaking Change
- [ ] New Feature
- [ ] Plugin Addition / Modification
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Refactor / Chore

## Testing

- `bash -n scripts/conductor-relay-deploy-host.sh`
- `node --test scripts/conductor-relay-deploy-host.test.mjs`, 11 passed
- `node --test scripts/*.test.mjs`, 31 passed
- `cargo fmt --check`
- `git diff --check`

## Production evidence

The failed rollout restored the prior healthy relay. Public health remained ready while this fix was prepared.