### PR TITLE
fix: consolidate mobile UX and dispatcher durability

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -115,7 +115,7 @@
     "fast-uri": "3.1.2",
     "ip-address": "10.5.0",
     "js-yaml": "4.3.1",
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "picomatch": "2.3.2",
     "postcss": "8.5.18",
     "sharp": "0.35.3",
@@ -945,7 +945,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "netmask": ["netmask@2.0.2", "", {}, "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="],
 

--- a/crates/conductor-server/src/lib.rs
+++ b/crates/conductor-server/src/lib.rs
@@ -30,6 +30,7 @@ use uuid::Uuid;
 use crate::state::AppState;
 
 const TERMINAL_TOKEN_SECRET_ENV: &str = "CONDUCTOR_TERMINAL_SESSION_SECRET";
+const SERVER_GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ShutdownSignalKind {
@@ -197,15 +198,23 @@ Set the same secret in both the dashboard and backend processes so forwarded aut
     });
 
     // Graceful shutdown: Ctrl-C and Unix SIGTERM trigger GC stop + server drain.
-    let server = axum::serve(
-        listener,
-        app.into_make_service_with_connect_info::<SocketAddr>(),
-    );
+    let server_shutdown = std::sync::Arc::new(tokio::sync::Notify::new());
+    let server_shutdown_wait = server_shutdown.clone();
+    let mut server = tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .with_graceful_shutdown(async move {
+            server_shutdown_wait.notified().await;
+        })
+        .await
+    });
 
     tokio::select! {
-        result = server => {
+        result = &mut server => {
             finish_graceful_shutdown(&shutdown_state, &gc_cancel, gc_handle).await;
-            result.map_err(Into::into)
+            flatten_server_result(result)
         }
         shutdown = shutdown_signal() => {
             match shutdown {
@@ -215,8 +224,10 @@ Set the same secret in both the dashboard and backend processes so forwarded aut
                     "failed to install shutdown signal handler; proceeding with graceful shutdown"
                 ),
             }
+            server_shutdown.notify_one();
+            let server_result = await_graceful_server_shutdown(&mut server).await;
             finish_graceful_shutdown(&shutdown_state, &gc_cancel, gc_handle).await;
-            Ok(())
+            server_result
         }
     }
 }
@@ -231,10 +242,20 @@ async fn shutdown_signal() -> std::io::Result<ShutdownSignalKind> {
     {
         use tokio::signal::unix::{signal, SignalKind};
 
-        let mut terminate = signal(SignalKind::terminate())?;
-        tokio::select! {
-            result = ctrl_c => result,
-            _ = terminate.recv() => Ok(ShutdownSignalKind::Sigterm),
+        match signal(SignalKind::terminate()) {
+            Ok(mut terminate) => {
+                tokio::select! {
+                    result = ctrl_c => result,
+                    _ = terminate.recv() => Ok(ShutdownSignalKind::Sigterm),
+                }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "failed to install SIGTERM handler; falling back to Ctrl-C only"
+                );
+                ctrl_c.await
+            }
         }
     }
 
@@ -262,6 +283,29 @@ async fn finish_graceful_shutdown(
             "failed to flush pending dispatcher snapshots during shutdown"
         );
     }
+}
+
+async fn await_graceful_server_shutdown(
+    server: &mut tokio::task::JoinHandle<std::io::Result<()>>,
+) -> Result<()> {
+    match tokio::time::timeout(SERVER_GRACEFUL_SHUTDOWN_TIMEOUT, &mut *server).await {
+        Ok(result) => flatten_server_result(result),
+        Err(_) => {
+            tracing::warn!(
+                timeout_ms = SERVER_GRACEFUL_SHUTDOWN_TIMEOUT.as_millis(),
+                "graceful shutdown exceeded deadline; forcing server stop"
+            );
+            server.abort();
+            let _ = server.await;
+            Ok(())
+        }
+    }
+}
+
+fn flatten_server_result(
+    result: std::result::Result<std::io::Result<()>, tokio::task::JoinError>,
+) -> Result<()> {
+    Ok(result??)
 }
 
 fn ensure_terminal_token_secret(workspace_path: &Path) -> Result<()> {
@@ -372,7 +416,10 @@ fn harden_terminal_secret_permissions(_path: &Path) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{ensure_terminal_token_secret, ShutdownSignalKind, TERMINAL_TOKEN_SECRET_ENV};
+    use super::{
+        ensure_terminal_token_secret, shutdown_signal, ShutdownSignalKind,
+        TERMINAL_TOKEN_SECRET_ENV,
+    };
     use std::fs;
 
     struct TerminalSecretEnvScope {
@@ -467,10 +514,25 @@ mod tests {
     }
 
     #[cfg(unix)]
-    #[test]
-    fn shutdown_signal_source_listens_for_sigterm_on_unix() {
-        let source = include_str!("lib.rs");
-        assert!(source.contains("SignalKind::terminate()"));
-        assert!(source.contains("shutdown_signal()"));
+    #[tokio::test]
+    async fn shutdown_signal_returns_sigterm_on_unix() {
+        let _guard = crate::routes::TEST_ENV_LOCK.lock().await;
+        let shutdown = tokio::spawn(async { shutdown_signal().await });
+        tokio::task::yield_now().await;
+
+        // SAFETY: The test installs the process SIGTERM handler via `shutdown_signal`
+        // before raising SIGTERM to the current process.
+        let signal_result = unsafe { libc::raise(libc::SIGTERM) };
+        assert_eq!(
+            signal_result, 0,
+            "SIGTERM should be delivered to the test process"
+        );
+
+        let kind = tokio::time::timeout(std::time::Duration::from_secs(1), shutdown)
+            .await
+            .expect("shutdown signal future should resolve")
+            .expect("shutdown signal task should complete")
+            .expect("shutdown signal should resolve successfully");
+        assert_eq!(kind, ShutdownSignalKind::Sigterm);
     }
 }

--- a/crates/conductor-server/src/lib.rs
+++ b/crates/conductor-server/src/lib.rs
@@ -253,7 +253,10 @@ async fn finish_graceful_shutdown(
     if let Err(error) = gc_handle.await {
         tracing::warn!(error = %error, "session GC task panicked during shutdown");
     }
-    if let Err(error) = state.flush_pending_dispatcher_snapshots().await {
+    if let Err(error) = state
+        .flush_pending_dispatcher_snapshots_for_shutdown()
+        .await
+    {
         tracing::warn!(
             error = %error,
             "failed to flush pending dispatcher snapshots during shutdown"

--- a/crates/conductor-server/src/lib.rs
+++ b/crates/conductor-server/src/lib.rs
@@ -31,6 +31,23 @@ use crate::state::AppState;
 
 const TERMINAL_TOKEN_SECRET_ENV: &str = "CONDUCTOR_TERMINAL_SESSION_SECRET";
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ShutdownSignalKind {
+    CtrlC,
+    #[cfg(unix)]
+    Sigterm,
+}
+
+impl ShutdownSignalKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::CtrlC => "ctrl_c",
+            #[cfg(unix)]
+            Self::Sigterm => "sigterm",
+        }
+    }
+}
+
 #[cfg(unix)]
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
@@ -179,7 +196,7 @@ Set the same secret in both the dashboard and backend processes so forwarded aut
         session_gc::run_session_gc(gc_conductor_dir, gc_state, gc_cancel_clone).await;
     });
 
-    // Graceful shutdown: ctrl_c triggers GC stop + server drain
+    // Graceful shutdown: Ctrl-C and Unix SIGTERM trigger GC stop + server drain.
     let server = axum::serve(
         listener,
         app.into_make_service_with_connect_info::<SocketAddr>(),
@@ -190,11 +207,40 @@ Set the same secret in both the dashboard and backend processes so forwarded aut
             finish_graceful_shutdown(&shutdown_state, &gc_cancel, gc_handle).await;
             result.map_err(Into::into)
         }
-        _ = tokio::signal::ctrl_c() => {
-            tracing::info!("received shutdown signal");
+        shutdown = shutdown_signal() => {
+            match shutdown {
+                Ok(kind) => tracing::info!(signal = kind.as_str(), "received shutdown signal"),
+                Err(error) => tracing::warn!(
+                    error = %error,
+                    "failed to install shutdown signal handler; proceeding with graceful shutdown"
+                ),
+            }
             finish_graceful_shutdown(&shutdown_state, &gc_cancel, gc_handle).await;
             Ok(())
         }
+    }
+}
+
+async fn shutdown_signal() -> std::io::Result<ShutdownSignalKind> {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c().await?;
+        Ok(ShutdownSignalKind::CtrlC)
+    };
+
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+
+        let mut terminate = signal(SignalKind::terminate())?;
+        tokio::select! {
+            result = ctrl_c => result,
+            _ = terminate.recv() => Ok(ShutdownSignalKind::Sigterm),
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        ctrl_c.await
     }
 }
 
@@ -323,7 +369,7 @@ fn harden_terminal_secret_permissions(_path: &Path) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{ensure_terminal_token_secret, TERMINAL_TOKEN_SECRET_ENV};
+    use super::{ensure_terminal_token_secret, ShutdownSignalKind, TERMINAL_TOKEN_SECRET_ENV};
     use std::fs;
 
     struct TerminalSecretEnvScope {
@@ -408,5 +454,20 @@ mod tests {
         );
 
         fs::remove_dir_all(workspace_path).unwrap();
+    }
+
+    #[test]
+    fn shutdown_signal_kind_labels_are_stable() {
+        assert_eq!(ShutdownSignalKind::CtrlC.as_str(), "ctrl_c");
+        #[cfg(unix)]
+        assert_eq!(ShutdownSignalKind::Sigterm.as_str(), "sigterm");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shutdown_signal_source_listens_for_sigterm_on_unix() {
+        let source = include_str!("lib.rs");
+        assert!(source.contains("SignalKind::terminate()"));
+        assert!(source.contains("shutdown_signal()"));
     }
 }

--- a/crates/conductor-server/src/lib.rs
+++ b/crates/conductor-server/src/lib.rs
@@ -62,6 +62,7 @@ pub async fn serve(config: &ConductorConfig, db: Database, _event_bus: EventBus)
 
     // Clone for GC before state is moved into the router.
     let gc_state = state.clone();
+    let shutdown_state = state.clone();
 
     let app = Router::new()
         .merge(routes::app_update::router())
@@ -186,20 +187,31 @@ Set the same secret in both the dashboard and backend processes so forwarded aut
 
     tokio::select! {
         result = server => {
-            gc_cancel.notify_one();
-            if let Err(e) = gc_handle.await {
-                tracing::warn!(error = %e, "session GC task panicked during shutdown");
-            }
+            finish_graceful_shutdown(&shutdown_state, &gc_cancel, gc_handle).await;
             result.map_err(Into::into)
         }
         _ = tokio::signal::ctrl_c() => {
             tracing::info!("received shutdown signal");
-            gc_cancel.notify_one();
-            if let Err(e) = gc_handle.await {
-                tracing::warn!(error = %e, "session GC task panicked during shutdown");
-            }
+            finish_graceful_shutdown(&shutdown_state, &gc_cancel, gc_handle).await;
             Ok(())
         }
+    }
+}
+
+async fn finish_graceful_shutdown(
+    state: &AppState,
+    gc_cancel: &std::sync::Arc<tokio::sync::Notify>,
+    gc_handle: tokio::task::JoinHandle<()>,
+) {
+    gc_cancel.notify_one();
+    if let Err(error) = gc_handle.await {
+        tracing::warn!(error = %error, "session GC task panicked during shutdown");
+    }
+    if let Err(error) = state.flush_pending_dispatcher_snapshots().await {
+        tracing::warn!(
+            error = %error,
+            "failed to flush pending dispatcher snapshots during shutdown"
+        );
     }
 }
 

--- a/crates/conductor-server/src/state/acp_dispatcher.rs
+++ b/crates/conductor-server/src/state/acp_dispatcher.rs
@@ -1873,9 +1873,9 @@ impl AppState {
         self.dispatcher_feed_payload_cache.lock().await.clear();
     }
 
-    pub(crate) async fn persist_dispatcher_thread(&self, thread: &SessionRecord) -> Result<()> {
-        self.persist_current_dispatcher_snapshot(&thread.id).await?;
-        self.invalidate_dispatcher_caches(&thread.id).await;
+    pub(crate) async fn persist_dispatcher_thread(&self, thread_id: &str) -> Result<()> {
+        self.persist_current_dispatcher_snapshot(thread_id).await?;
+        self.invalidate_dispatcher_caches(thread_id).await;
         Ok(())
     }
 
@@ -2129,7 +2129,7 @@ impl AppState {
         let updated = thread.clone();
         drop(threads);
 
-        self.persist_dispatcher_thread(&updated).await?;
+        self.persist_dispatcher_thread(&updated.id).await?;
         self.publish_dispatcher_update(thread_id).await;
 
         let state = Arc::clone(self);
@@ -2258,7 +2258,7 @@ impl AppState {
         let updated = thread.clone();
         drop(threads);
 
-        self.persist_dispatcher_thread(&updated).await?;
+        self.persist_dispatcher_thread(&updated.id).await?;
         self.sync_acp_dispatcher_state(&updated).await?;
         self.publish_dispatcher_update(thread_id).await;
         Ok(())
@@ -3405,7 +3405,7 @@ impl AppState {
             thread.clone()
         };
 
-        self.persist_dispatcher_thread(&updated).await?;
+        self.persist_dispatcher_thread(&updated.id).await?;
         self.sync_acp_dispatcher_state(&updated).await?;
         self.publish_dispatcher_update(thread_id).await;
         Ok(())
@@ -3643,7 +3643,7 @@ impl AppState {
             }
         }
         if let Some(updated) = self.get_dispatcher_thread(&thread.id).await {
-            self.persist_dispatcher_thread(&updated).await?;
+            self.persist_dispatcher_thread(&updated.id).await?;
             self.publish_dispatcher_update(&thread.id).await;
         }
 
@@ -3981,11 +3981,11 @@ impl AppState {
 
         let should_sync_memory = should_sync_dispatcher_session_memory(thread, force_memory_sync);
         let memory_snapshot = should_sync_memory.then(|| thread.clone());
+        drop(threads);
         if clear_runtime {
             self.clear_dispatcher_runtime_if(thread_id, runtime_id)
                 .await;
         }
-        drop(threads);
         if feed_dirty {
             self.publish_dispatcher_update(thread_id).await;
         }
@@ -4131,7 +4131,7 @@ impl AppState {
         let updated = thread.clone();
         drop(threads);
 
-        self.persist_dispatcher_thread(&updated).await?;
+        self.persist_dispatcher_thread(&updated.id).await?;
         self.publish_dispatcher_update(thread_id).await;
 
         if let Err(err) = self
@@ -4256,7 +4256,7 @@ impl AppState {
                 session.clone()
             };
 
-            if let Err(err) = self.persist_dispatcher_thread(&updated).await {
+            if let Err(err) = self.persist_dispatcher_thread(&updated.id).await {
                 tracing::warn!(session_id = %session_id, error = %err, "failed to persist ACP heartbeat");
                 continue;
             }
@@ -5080,12 +5080,11 @@ mod tests {
         })
         .await
         .expect("producer should keep requeueing while shutdown drain is in flight");
-        drop(held_write);
-
         let shutdown_flush_result = timeout(Duration::from_millis(500), shutdown_flush)
             .await
             .expect("bounded shutdown flush should return instead of hanging")
             .expect("shutdown flush task should complete");
+        drop(held_write);
         if let Err(err) = shutdown_flush_result {
             assert!(
                 err.to_string()
@@ -5103,10 +5102,10 @@ mod tests {
         let persisted_summary = persisted
             .summary
             .expect("persisted dispatcher snapshot should include a summary");
-        assert_ne!(persisted_summary, "pre-shutdown snapshot");
         assert!(
-            persisted_summary.starts_with("shutdown update "),
-            "expected a best-effort shutdown update, got {persisted_summary:?}"
+            persisted_summary == "pre-shutdown snapshot"
+                || persisted_summary.starts_with("shutdown update "),
+            "expected the last durable snapshot to survive the bounded flush timeout, got {persisted_summary:?}"
         );
 
         state

--- a/crates/conductor-server/src/state/acp_dispatcher.rs
+++ b/crates/conductor-server/src/state/acp_dispatcher.rs
@@ -1906,11 +1906,14 @@ impl AppState {
     }
 
     pub(crate) async fn replace_dispatcher_thread(&self, thread: SessionRecord) -> Result<()> {
+        let snapshot_guard = self.dispatcher_snapshot_guard(&thread.id).await;
+        let _snapshot_lock = snapshot_guard.lock().await;
+        self.write_dispatcher_snapshot(&thread).await?;
         {
             let mut guard = self.dispatcher_threads.write().await;
             guard.insert(thread.id.clone(), thread.clone());
         }
-        self.persist_dispatcher_thread(&thread).await?;
+        self.invalidate_dispatcher_caches(&thread.id).await;
         self.publish_dispatcher_update(&thread.id).await;
         Ok(())
     }
@@ -1940,15 +1943,19 @@ impl AppState {
             }
         }
 
-        self.active_session_skills.lock().await.remove(thread_id);
-        self.pending_dispatcher_flushes
-            .lock()
-            .await
-            .remove(thread_id);
+        let snapshot_guard = self.dispatcher_snapshot_guard(thread_id).await;
+        let _snapshot_lock = snapshot_guard.lock().await;
+        remove_optional_file(self.dispatcher_snapshot_path(thread_id)).await?;
         {
             let mut guard = self.dispatcher_threads.write().await;
             guard.remove(thread_id);
         }
+        self.pending_dispatcher_flushes
+            .lock()
+            .await
+            .remove(thread_id);
+        drop(_snapshot_lock);
+        self.active_session_skills.lock().await.remove(thread_id);
         self.invalidate_dispatcher_caches(thread_id).await;
         self.publish_dispatcher_update(thread_id).await;
 
@@ -1956,14 +1963,12 @@ impl AppState {
         let cleanup_thread_id = thread_id.to_string();
         let cleanup_project_id = thread.project_id.clone();
         tokio::spawn(async move {
-            let snapshot_path = cleanup_state.dispatcher_snapshot_path(&cleanup_thread_id);
             let session_json_path =
                 cleanup_state.acp_session_memory_json_path(&cleanup_project_id, &cleanup_thread_id);
             let session_md_path = cleanup_state
                 .acp_session_memory_markdown_path(&cleanup_project_id, &cleanup_thread_id);
 
             if let Err(err) = tokio::try_join!(
-                remove_optional_file(snapshot_path),
                 remove_optional_file(session_json_path),
                 remove_optional_file(session_md_path),
             ) {
@@ -4947,6 +4952,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn replace_dispatcher_thread_does_not_advance_memory_when_persistence_fails() {
+        let (root, state) = build_test_state("dispatcher-replace-durability-first").await;
+        let mut baseline = state
+            .create_project_dispatcher_thread("demo", CreateDispatcherThreadOptions::default())
+            .await
+            .expect("dispatcher thread should be created");
+        baseline.status = SessionStatus::NeedsInput;
+        baseline.summary = Some("baseline durable state".to_string());
+        state
+            .replace_dispatcher_thread(baseline.clone())
+            .await
+            .expect("baseline dispatcher thread should persist");
+
+        let store_dir = state.dispatcher_store_dir();
+        let blocked_store = root.join("dispatchers-blocked");
+        let preserved_snapshot_path = blocked_store.join(format!("{}.json", baseline.id));
+        tokio::fs::rename(&store_dir, &blocked_store)
+            .await
+            .expect("dispatcher store should be movable");
+        tokio::fs::write(&store_dir, b"blocked store")
+            .await
+            .expect("dispatcher store path should be blockable");
+
+        let mut advanced = baseline.clone();
+        advanced.status = SessionStatus::Working;
+        advanced.summary = Some("should not advance".to_string());
+        state
+            .replace_dispatcher_thread(advanced)
+            .await
+            .expect_err("replace should fail when snapshot storage is unavailable");
+
+        let in_memory = state
+            .get_dispatcher_thread(&baseline.id)
+            .await
+            .expect("baseline dispatcher thread should remain in memory");
+        assert_eq!(in_memory.status, SessionStatus::NeedsInput);
+        assert_eq!(in_memory.summary.as_deref(), Some("baseline durable state"));
+
+        let preserved = read_json::<SessionRecord>(&preserved_snapshot_path)
+            .await
+            .expect("baseline dispatcher snapshot should remain durable");
+        assert_eq!(preserved.status, SessionStatus::NeedsInput);
+        assert_eq!(preserved.summary.as_deref(), Some("baseline durable state"));
+
+        tokio::fs::remove_file(&store_dir)
+            .await
+            .expect("blocking file should be removable");
+        tokio::fs::rename(&blocked_store, &store_dir)
+            .await
+            .expect("dispatcher store should be restorable");
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
     async fn shutdown_dispatcher_flush_stays_bounded_while_runtime_keeps_requeueing() {
         let (root, state) = build_test_state("dispatcher-flush-shutdown-bounded").await;
         let thread = state
@@ -5117,40 +5177,57 @@ mod tests {
             .expect("dispatcher thread should exist");
 
         let write_guard = state.dispatcher_snapshot_guard(&thread.id).await;
-        let held_write = write_guard.lock().await;
+        let (writer_started_tx, writer_started_rx) = oneshot::channel();
+        let (writer_release_tx, writer_release_rx) = oneshot::channel();
         let persist_state = Arc::clone(&state);
         let persist_thread = stale_snapshot.clone();
         let persist_task = tokio::spawn(async move {
+            let _write_lock = write_guard.lock().await;
+            let _ = writer_started_tx.send(());
+            writer_release_rx
+                .await
+                .expect("writer release signal should arrive");
             persist_state
-                .persist_dispatcher_thread(&persist_thread)
+                .write_dispatcher_snapshot(&persist_thread)
                 .await
         });
-        tokio::task::yield_now().await;
-
-        state
-            .delete_dispatcher_thread(&thread.id)
+        writer_started_rx
             .await
-            .expect("dispatcher thread should be deleted");
-        timeout(Duration::from_secs(1), async {
-            loop {
-                if !snapshot_path.exists() {
-                    break;
-                }
-                tokio::time::sleep(Duration::from_millis(10)).await;
-            }
-        })
-        .await
-        .expect("dispatcher snapshot should be removed after delete");
+            .expect("stale writer should acquire the snapshot guard");
 
-        drop(held_write);
+        let delete_state = Arc::clone(&state);
+        let delete_thread_id = thread.id.clone();
+        let delete_task = tokio::spawn(async move {
+            delete_state
+                .delete_dispatcher_thread(&delete_thread_id)
+                .await
+        });
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        assert!(
+            !delete_task.is_finished(),
+            "delete should wait for the in-flight snapshot writer"
+        );
+
+        writer_release_tx
+            .send(())
+            .expect("writer release signal should be sendable");
         persist_task
             .await
             .expect("stale persist task")
-            .expect("stale persist should succeed without rewriting");
+            .expect("stale persist should succeed before delete removes the snapshot");
+        delete_task
+            .await
+            .expect("delete task should join cleanly")
+            .expect("dispatcher thread should be deleted");
 
         tokio::time::sleep(Duration::from_millis(50)).await;
         assert!(state.get_dispatcher_thread(&thread.id).await.is_none());
         assert!(!snapshot_path.exists());
+        assert!(!state
+            .pending_dispatcher_flushes
+            .lock()
+            .await
+            .contains(&thread.id));
 
         let _ = fs::remove_dir_all(root);
     }
@@ -5167,28 +5244,46 @@ mod tests {
         let write_guard = state.dispatcher_snapshot_guard(&thread.id).await;
         let held_write = write_guard.lock().await;
         state.queue_dispatcher_flush(&thread.id).await;
-        tokio::time::sleep(Duration::from_millis(175)).await;
+        let flush_state = Arc::clone(&state);
+        let flush_task =
+            tokio::spawn(
+                async move { flush_state.flush_pending_dispatcher_snapshots_once().await },
+            );
+        tokio::task::yield_now().await;
 
-        state
-            .delete_dispatcher_thread(&thread.id)
-            .await
-            .expect("dispatcher thread should be deleted");
-        timeout(Duration::from_secs(1), async {
-            loop {
-                if !snapshot_path.exists() {
-                    break;
-                }
-                tokio::time::sleep(Duration::from_millis(10)).await;
-            }
-        })
-        .await
-        .expect("dispatcher snapshot should be removed after delete");
+        let delete_state = Arc::clone(&state);
+        let delete_thread_id = thread.id.clone();
+        let delete_task = tokio::spawn(async move {
+            delete_state
+                .delete_dispatcher_thread(&delete_thread_id)
+                .await
+        });
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        assert!(
+            !delete_task.is_finished(),
+            "delete should wait for the queued snapshot flush writer"
+        );
 
         drop(held_write);
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(
+            flush_task
+                .await
+                .expect("flush task should join cleanly")
+                .expect("flush task should succeed once the guard is released"),
+            1
+        );
+        delete_task
+            .await
+            .expect("delete task should join cleanly")
+            .expect("dispatcher thread should be deleted");
 
         assert!(state.get_dispatcher_thread(&thread.id).await.is_none());
         assert!(!snapshot_path.exists());
+        assert!(!state
+            .pending_dispatcher_flushes
+            .lock()
+            .await
+            .contains(&thread.id));
 
         let _ = fs::remove_dir_all(root);
     }

--- a/crates/conductor-server/src/state/acp_dispatcher.rs
+++ b/crates/conductor-server/src/state/acp_dispatcher.rs
@@ -1874,19 +1874,43 @@ impl AppState {
     }
 
     pub(crate) async fn persist_dispatcher_thread(&self, thread: &SessionRecord) -> Result<()> {
-        let path = self.dispatcher_snapshot_path(&thread.id);
-        let content = serde_json::to_string_pretty(thread)?;
-        tokio::fs::write(path, content).await?;
+        self.persist_current_dispatcher_snapshot(&thread.id).await?;
         self.invalidate_dispatcher_caches(&thread.id).await;
         Ok(())
     }
 
+    async fn write_dispatcher_snapshot(&self, thread: &SessionRecord) -> Result<()> {
+        let path = self.dispatcher_snapshot_path(&thread.id);
+        let content = serde_json::to_string_pretty(thread)?;
+        tokio::fs::write(path, content).await?;
+        Ok(())
+    }
+
+    async fn dispatcher_snapshot_guard(&self, thread_id: &str) -> Arc<Mutex<()>> {
+        let mut guards = self.dispatcher_snapshot_guards.lock().await;
+        Arc::clone(
+            guards
+                .entry(thread_id.to_string())
+                .or_insert_with(|| Arc::new(Mutex::new(()))),
+        )
+    }
+
+    pub(crate) async fn persist_current_dispatcher_snapshot(&self, thread_id: &str) -> Result<()> {
+        let guard = self.dispatcher_snapshot_guard(thread_id).await;
+        let _write_lock = guard.lock().await;
+        let snapshot = self.dispatcher_threads.read().await.get(thread_id).cloned();
+        if let Some(snapshot) = snapshot {
+            self.write_dispatcher_snapshot(&snapshot).await?;
+        }
+        Ok(())
+    }
+
     pub(crate) async fn replace_dispatcher_thread(&self, thread: SessionRecord) -> Result<()> {
-        self.persist_dispatcher_thread(&thread).await?;
         {
             let mut guard = self.dispatcher_threads.write().await;
             guard.insert(thread.id.clone(), thread.clone());
         }
+        self.persist_dispatcher_thread(&thread).await?;
         self.publish_dispatcher_update(&thread.id).await;
         Ok(())
     }
@@ -1917,6 +1941,10 @@ impl AppState {
         }
 
         self.active_session_skills.lock().await.remove(thread_id);
+        self.pending_dispatcher_flushes
+            .lock()
+            .await
+            .remove(thread_id);
         {
             let mut guard = self.dispatcher_threads.write().await;
             guard.remove(thread_id);
@@ -1963,32 +1991,23 @@ impl AppState {
 
     pub(crate) async fn publish_dispatcher_update(&self, thread_id: &str) {
         self.invalidate_dispatcher_caches(thread_id).await;
-        let pending_updates: Arc<tokio::sync::Mutex<HashMap<String, u64>>> =
+        let pending_updates: Arc<tokio::sync::Mutex<HashSet<String>>> =
             Arc::clone(&self.pending_dispatcher_updates);
         let dispatcher_updates = self.dispatcher_updates.clone();
-        let notify_seq = {
+        let should_schedule = {
             let mut pending = self.pending_dispatcher_updates.lock().await;
-            let next_seq = pending
-                .get(thread_id)
-                .copied()
-                .unwrap_or_default()
-                .saturating_add(1);
-            pending.insert(thread_id.to_string(), next_seq);
-            next_seq
+            pending.insert(thread_id.to_string())
         };
+        if !should_schedule {
+            return;
+        }
 
         let thread_id = thread_id.to_string();
         tokio::spawn(async move {
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
             let should_send = {
                 let mut pending = pending_updates.lock().await;
-                match pending.get(&thread_id).copied() {
-                    Some(current) if current == notify_seq => {
-                        pending.remove(&thread_id);
-                        true
-                    }
-                    _ => false,
-                }
+                pending.remove(&thread_id)
             };
 
             if should_send {
@@ -3956,18 +3975,22 @@ impl AppState {
         }
 
         let should_sync_memory = should_sync_dispatcher_session_memory(thread, force_memory_sync);
-        let updated = thread.clone();
+        let memory_snapshot = should_sync_memory.then(|| thread.clone());
         if clear_runtime {
             self.clear_dispatcher_runtime_if(thread_id, runtime_id)
                 .await;
         }
         drop(threads);
-        self.persist_dispatcher_thread(&updated).await?;
-        if should_sync_memory {
-            self.sync_acp_dispatcher_state(&updated).await?;
-        }
         if feed_dirty {
             self.publish_dispatcher_update(thread_id).await;
+        }
+        if force_memory_sync {
+            self.persist_current_dispatcher_snapshot(thread_id).await?;
+        } else {
+            self.queue_dispatcher_flush(thread_id).await;
+        }
+        if let Some(memory_snapshot) = memory_snapshot.as_ref() {
+            self.sync_acp_dispatcher_state(memory_snapshot).await?;
         }
         Ok(())
     }
@@ -4520,6 +4543,32 @@ mod tests {
         (root, state)
     }
 
+    async fn reopen_test_state(root: &Path) -> Arc<AppState> {
+        let repo = root.join("repo");
+        let config = ConductorConfig {
+            workspace: root.to_path_buf(),
+            preferences: PreferencesConfig {
+                coding_agent: "codex".to_string(),
+                ..PreferencesConfig::default()
+            },
+            projects: BTreeMap::from([(
+                "demo".to_string(),
+                ProjectConfig {
+                    path: repo.to_string_lossy().to_string(),
+                    agent: Some("codex".to_string()),
+                    runtime: Some("direct".to_string()),
+                    default_branch: "main".to_string(),
+                    ..ProjectConfig::default()
+                },
+            )]),
+            ..ConductorConfig::default()
+        };
+        let db = Database::in_memory()
+            .await
+            .expect("test db should initialize");
+        AppState::new(root.join("conductor.yaml"), config, db).await
+    }
+
     async fn register_test_dispatcher_runtime(
         state: &Arc<AppState>,
         thread_id: &str,
@@ -4683,6 +4732,427 @@ mod tests {
             dispatcher_resume_target(&thread, &AgentKind::ClaudeCode),
             Some("session-123".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn continuous_dispatcher_deltas_publish_inside_the_fixed_update_window() {
+        let (root, state) = build_test_state("dispatcher-update-window").await;
+        let mut updates = state.dispatcher_updates.subscribe();
+        let probe_id = "continuous-stream-probe".to_string();
+        let publisher_state = Arc::clone(&state);
+        let publisher_id = probe_id.clone();
+        let publisher = tokio::spawn(async move {
+            for _ in 0..12 {
+                publisher_state
+                    .publish_dispatcher_update(&publisher_id)
+                    .await;
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        });
+
+        timeout(Duration::from_millis(200), async {
+            loop {
+                if updates.recv().await.expect("dispatcher update channel") == probe_id {
+                    break;
+                }
+            }
+        })
+        .await
+        .expect("continuous deltas must publish inside the first fixed 50ms window");
+
+        publisher.await.expect("publisher task");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn explicit_dispatcher_flush_coalesces_burst_queues_to_latest_state() {
+        let (root, state) = build_test_state("dispatcher-flush-burst-coalesced").await;
+        let thread = state
+            .create_project_dispatcher_thread("demo", CreateDispatcherThreadOptions::default())
+            .await
+            .expect("dispatcher thread should be created");
+
+        {
+            let mut threads = state.dispatcher_threads.write().await;
+            let current = threads.get_mut(&thread.id).expect("dispatcher state");
+            current.summary = Some("first queued state".to_string());
+        }
+        state.queue_dispatcher_flush(&thread.id).await;
+
+        {
+            let mut threads = state.dispatcher_threads.write().await;
+            let current = threads.get_mut(&thread.id).expect("dispatcher state");
+            current.summary = Some("second queued state".to_string());
+        }
+        state.queue_dispatcher_flush(&thread.id).await;
+
+        {
+            let mut threads = state.dispatcher_threads.write().await;
+            let current = threads.get_mut(&thread.id).expect("dispatcher state");
+            current.status = SessionStatus::NeedsInput;
+            current.summary = Some("latest queued state".to_string());
+        }
+        state.queue_dispatcher_flush(&thread.id).await;
+
+        state
+            .flush_pending_dispatcher_snapshots()
+            .await
+            .expect("explicit flush should persist the latest state");
+
+        let persisted = read_json::<SessionRecord>(&state.dispatcher_snapshot_path(&thread.id))
+            .await
+            .expect("persisted dispatcher snapshot");
+        assert_eq!(persisted.status, SessionStatus::NeedsInput);
+        assert_eq!(persisted.summary.as_deref(), Some("latest queued state"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn explicit_dispatcher_flush_persists_without_waiting_for_watchdog_debounce() {
+        let (root, state) = build_test_state("dispatcher-flush-explicit-final").await;
+        let thread = state
+            .create_project_dispatcher_thread("demo", CreateDispatcherThreadOptions::default())
+            .await
+            .expect("dispatcher thread should be created");
+        let snapshot_path = state.dispatcher_snapshot_path(&thread.id);
+
+        {
+            let mut threads = state.dispatcher_threads.write().await;
+            let current = threads.get_mut(&thread.id).expect("dispatcher state");
+            current.summary = Some("final explicit flush state".to_string());
+        }
+        state.queue_dispatcher_flush(&thread.id).await;
+
+        let persisted_before_flush = read_json::<SessionRecord>(&snapshot_path)
+            .await
+            .expect("initial dispatcher snapshot");
+        assert_ne!(
+            persisted_before_flush.summary.as_deref(),
+            Some("final explicit flush state")
+        );
+
+        state
+            .flush_pending_dispatcher_snapshots()
+            .await
+            .expect("explicit flush should persist immediately");
+
+        let persisted_after_flush = read_json::<SessionRecord>(&snapshot_path)
+            .await
+            .expect("updated dispatcher snapshot");
+        assert_eq!(
+            persisted_after_flush.summary.as_deref(),
+            Some("final explicit flush state")
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn explicit_dispatcher_flush_survives_restart_and_reads_back_latest_state() {
+        let (root, state) = build_test_state("dispatcher-flush-restart-readback").await;
+        let thread = state
+            .create_project_dispatcher_thread("demo", CreateDispatcherThreadOptions::default())
+            .await
+            .expect("dispatcher thread should be created");
+
+        {
+            let mut threads = state.dispatcher_threads.write().await;
+            let current = threads.get_mut(&thread.id).expect("dispatcher state");
+            current.status = SessionStatus::NeedsInput;
+            current.summary = Some("restart durable state".to_string());
+        }
+        state.queue_dispatcher_flush(&thread.id).await;
+        state
+            .flush_pending_dispatcher_snapshots()
+            .await
+            .expect("explicit flush should persist before restart");
+        drop(state);
+
+        let reloaded_state = reopen_test_state(&root).await;
+        let reloaded_thread = reloaded_state
+            .get_dispatcher_thread(&thread.id)
+            .await
+            .expect("dispatcher thread should reload from disk");
+        assert_eq!(reloaded_thread.status, SessionStatus::NeedsInput);
+        assert_eq!(
+            reloaded_thread.summary.as_deref(),
+            Some("restart durable state")
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn explicit_dispatcher_flush_requeues_failed_snapshots_until_storage_recovers() {
+        let (root, state) = build_test_state("dispatcher-flush-retry").await;
+        let thread = state
+            .create_project_dispatcher_thread("demo", CreateDispatcherThreadOptions::default())
+            .await
+            .expect("dispatcher thread should be created");
+        let store_dir = state.dispatcher_store_dir();
+        let blocked_store = root.join("dispatchers-blocked");
+
+        tokio::fs::rename(&store_dir, &blocked_store)
+            .await
+            .expect("dispatcher store should be movable");
+        tokio::fs::write(&store_dir, b"blocked store")
+            .await
+            .expect("dispatcher store path should be blockable");
+
+        {
+            let mut threads = state.dispatcher_threads.write().await;
+            let current = threads.get_mut(&thread.id).expect("dispatcher state");
+            current.summary = Some("persist after retry".to_string());
+        }
+        state.queue_dispatcher_flush(&thread.id).await;
+
+        let flush_error = state
+            .flush_pending_dispatcher_snapshots()
+            .await
+            .expect_err("explicit flush should report storage failures");
+        assert!(flush_error
+            .to_string()
+            .contains("Failed to persist 1 queued dispatcher snapshot"));
+        assert!(state
+            .pending_dispatcher_flushes
+            .lock()
+            .await
+            .contains(&thread.id));
+
+        tokio::fs::remove_file(&store_dir)
+            .await
+            .expect("blocking file should be removable");
+        tokio::fs::rename(&blocked_store, &store_dir)
+            .await
+            .expect("dispatcher store should be restorable");
+
+        state
+            .flush_pending_dispatcher_snapshots()
+            .await
+            .expect("explicit flush should retry persisted snapshots after recovery");
+
+        let persisted = read_json::<SessionRecord>(&state.dispatcher_snapshot_path(&thread.id))
+            .await
+            .expect("persisted dispatcher snapshot");
+        assert_eq!(persisted.summary.as_deref(), Some("persist after retry"));
+        assert!(!state
+            .pending_dispatcher_flushes
+            .lock()
+            .await
+            .contains(&thread.id));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn queued_snapshot_clones_current_state_after_write_guard() {
+        let (root, state) = build_test_state("dispatcher-snapshot-race").await;
+        let thread = state
+            .create_project_dispatcher_thread("demo", CreateDispatcherThreadOptions::default())
+            .await
+            .expect("dispatcher thread should be created");
+        {
+            let mut threads = state.dispatcher_threads.write().await;
+            let current = threads.get_mut(&thread.id).expect("dispatcher state");
+            current.status = SessionStatus::Working;
+            current.summary = Some("stale streaming state".to_string());
+        }
+
+        let write_guard = state.dispatcher_snapshot_guard(&thread.id).await;
+        let held_write = write_guard.lock().await;
+        let queued_state = Arc::clone(&state);
+        let queued_thread_id = thread.id.clone();
+        let queued_write = tokio::spawn(async move {
+            queued_state
+                .persist_current_dispatcher_snapshot(&queued_thread_id)
+                .await
+        });
+        tokio::task::yield_now().await;
+
+        {
+            let mut threads = state.dispatcher_threads.write().await;
+            let current = threads.get_mut(&thread.id).expect("dispatcher state");
+            current.status = SessionStatus::NeedsInput;
+            current.summary = Some("final durable state".to_string());
+        }
+        drop(held_write);
+        queued_write
+            .await
+            .expect("queued writer task")
+            .expect("queued snapshot should persist");
+
+        let persisted = read_json::<SessionRecord>(&state.dispatcher_snapshot_path(&thread.id))
+            .await
+            .expect("persisted dispatcher snapshot");
+        assert_eq!(persisted.status, SessionStatus::NeedsInput);
+        assert_eq!(persisted.summary.as_deref(), Some("final durable state"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn deleted_dispatcher_threads_are_not_repersisted_by_stale_snapshot_writes() {
+        let (root, state) = build_test_state("dispatcher-delete-stale-persist-race").await;
+        let thread = state
+            .create_project_dispatcher_thread("demo", CreateDispatcherThreadOptions::default())
+            .await
+            .expect("dispatcher thread should be created");
+        let snapshot_path = state.dispatcher_snapshot_path(&thread.id);
+        let stale_snapshot = state
+            .get_dispatcher_thread(&thread.id)
+            .await
+            .expect("dispatcher thread should exist");
+
+        let write_guard = state.dispatcher_snapshot_guard(&thread.id).await;
+        let held_write = write_guard.lock().await;
+        let persist_state = Arc::clone(&state);
+        let persist_thread = stale_snapshot.clone();
+        let persist_task = tokio::spawn(async move {
+            persist_state
+                .persist_dispatcher_thread(&persist_thread)
+                .await
+        });
+        tokio::task::yield_now().await;
+
+        state
+            .delete_dispatcher_thread(&thread.id)
+            .await
+            .expect("dispatcher thread should be deleted");
+        timeout(Duration::from_secs(1), async {
+            loop {
+                if !snapshot_path.exists() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("dispatcher snapshot should be removed after delete");
+
+        drop(held_write);
+        persist_task
+            .await
+            .expect("stale persist task")
+            .expect("stale persist should succeed without rewriting");
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(state.get_dispatcher_thread(&thread.id).await.is_none());
+        assert!(!snapshot_path.exists());
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn deleted_dispatcher_threads_are_not_resurrected_by_queued_snapshot_flushes() {
+        let (root, state) = build_test_state("dispatcher-delete-queued-flush-race").await;
+        let thread = state
+            .create_project_dispatcher_thread("demo", CreateDispatcherThreadOptions::default())
+            .await
+            .expect("dispatcher thread should be created");
+        let snapshot_path = state.dispatcher_snapshot_path(&thread.id);
+
+        let write_guard = state.dispatcher_snapshot_guard(&thread.id).await;
+        let held_write = write_guard.lock().await;
+        state.queue_dispatcher_flush(&thread.id).await;
+        tokio::time::sleep(Duration::from_millis(175)).await;
+
+        state
+            .delete_dispatcher_thread(&thread.id)
+            .await
+            .expect("dispatcher thread should be deleted");
+        timeout(Duration::from_secs(1), async {
+            loop {
+                if !snapshot_path.exists() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("dispatcher snapshot should be removed after delete");
+
+        drop(held_write);
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        assert!(state.get_dispatcher_thread(&thread.id).await.is_none());
+        assert!(!snapshot_path.exists());
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn explicit_dispatcher_flush_teardown_skips_deleted_queued_threads() {
+        let (root, state) = build_test_state("dispatcher-flush-teardown").await;
+        let live_thread = state
+            .create_project_dispatcher_thread("demo", CreateDispatcherThreadOptions::default())
+            .await
+            .expect("live dispatcher thread should be created");
+        let deleted_thread = state
+            .create_project_dispatcher_thread(
+                "demo",
+                CreateDispatcherThreadOptions {
+                    force_new: true,
+                    ..CreateDispatcherThreadOptions::default()
+                },
+            )
+            .await
+            .expect("deleted dispatcher thread should be created");
+        let live_snapshot_path = state.dispatcher_snapshot_path(&live_thread.id);
+        let deleted_snapshot_path = state.dispatcher_snapshot_path(&deleted_thread.id);
+
+        {
+            let mut threads = state.dispatcher_threads.write().await;
+            let current = threads
+                .get_mut(&live_thread.id)
+                .expect("live dispatcher state");
+            current.summary = Some("live teardown state".to_string());
+        }
+        state.queue_dispatcher_flush(&live_thread.id).await;
+        state.queue_dispatcher_flush(&deleted_thread.id).await;
+        state
+            .delete_dispatcher_thread(&deleted_thread.id)
+            .await
+            .expect("dispatcher thread should be deleted");
+        timeout(Duration::from_secs(1), async {
+            loop {
+                if !deleted_snapshot_path.exists() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("deleted dispatcher snapshot should be removed before teardown flush");
+
+        state
+            .flush_pending_dispatcher_snapshots()
+            .await
+            .expect("explicit teardown flush should skip deleted threads");
+
+        let live_persisted = timeout(Duration::from_secs(1), async {
+            loop {
+                if let Some(snapshot) = read_json::<SessionRecord>(&live_snapshot_path).await {
+                    if snapshot.summary.as_deref() == Some("live teardown state") {
+                        break snapshot;
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("live dispatcher snapshot should converge after teardown flush");
+        assert_eq!(
+            live_persisted.summary.as_deref(),
+            Some("live teardown state")
+        );
+        assert!(state
+            .get_dispatcher_thread(&deleted_thread.id)
+            .await
+            .is_none());
+        assert!(!deleted_snapshot_path.exists());
+
+        let _ = fs::remove_dir_all(root);
     }
 
     #[tokio::test]

--- a/crates/conductor-server/src/state/acp_dispatcher.rs
+++ b/crates/conductor-server/src/state/acp_dispatcher.rs
@@ -1874,7 +1874,10 @@ impl AppState {
     }
 
     pub(crate) async fn persist_dispatcher_thread(&self, thread_id: &str) -> Result<()> {
-        self.persist_current_dispatcher_snapshot(thread_id).await?;
+        if let Err(err) = self.persist_current_dispatcher_snapshot(thread_id).await {
+            self.queue_dispatcher_flush(thread_id).await;
+            return Err(err);
+        }
         self.invalidate_dispatcher_caches(thread_id).await;
         Ok(())
     }
@@ -4942,6 +4945,84 @@ mod tests {
             .await
             .expect("persisted dispatcher snapshot");
         assert_eq!(persisted.summary.as_deref(), Some("persist after retry"));
+        assert!(!state
+            .pending_dispatcher_flushes
+            .lock()
+            .await
+            .contains(&thread.id));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn failed_direct_dispatcher_persist_queues_retry_and_recovers_latest_in_memory_state() {
+        let (root, state) = build_test_state("dispatcher-direct-persist-retry").await;
+        let thread = state
+            .create_project_dispatcher_thread("demo", CreateDispatcherThreadOptions::default())
+            .await
+            .expect("dispatcher thread should be created");
+        let store_dir = state.dispatcher_store_dir();
+        let blocked_store = root.join("dispatchers-blocked");
+
+        tokio::fs::rename(&store_dir, &blocked_store)
+            .await
+            .expect("dispatcher store should be movable");
+        tokio::fs::write(&store_dir, b"blocked store")
+            .await
+            .expect("dispatcher store path should be blockable");
+
+        {
+            let mut threads = state.dispatcher_threads.write().await;
+            let current = threads.get_mut(&thread.id).expect("dispatcher state");
+            current.summary = Some("failed direct persist state".to_string());
+        }
+
+        let persist_error = state
+            .persist_dispatcher_thread(&thread.id)
+            .await
+            .expect_err("direct persist should return the original storage failure");
+        assert!(
+            state
+                .pending_dispatcher_flushes
+                .lock()
+                .await
+                .contains(&thread.id),
+            "failed direct persist should queue a watchdog retry"
+        );
+        assert!(
+            !persist_error
+                .to_string()
+                .contains("queued dispatcher snapshot"),
+            "direct persist should return the original storage error"
+        );
+
+        {
+            let mut threads = state.dispatcher_threads.write().await;
+            let current = threads.get_mut(&thread.id).expect("dispatcher state");
+            current.status = SessionStatus::NeedsInput;
+            current.summary = Some("recovered in-memory state".to_string());
+        }
+
+        tokio::fs::remove_file(&store_dir)
+            .await
+            .expect("blocking file should be removable");
+        tokio::fs::rename(&blocked_store, &store_dir)
+            .await
+            .expect("dispatcher store should be restorable");
+
+        state
+            .flush_pending_dispatcher_snapshots()
+            .await
+            .expect("queued retry should persist after storage recovers");
+
+        let persisted = read_json::<SessionRecord>(&state.dispatcher_snapshot_path(&thread.id))
+            .await
+            .expect("persisted dispatcher snapshot");
+        assert_eq!(persisted.status, SessionStatus::NeedsInput);
+        assert_eq!(
+            persisted.summary.as_deref(),
+            Some("recovered in-memory state")
+        );
         assert!(!state
             .pending_dispatcher_flushes
             .lock()

--- a/crates/conductor-server/src/state/acp_dispatcher.rs
+++ b/crates/conductor-server/src/state/acp_dispatcher.rs
@@ -4323,6 +4323,7 @@ mod tests {
     use std::collections::{BTreeMap, HashMap};
     use std::fs;
     use std::path::Path;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
     use tokio::process::Command;
@@ -4941,6 +4942,117 @@ mod tests {
             .lock()
             .await
             .contains(&thread.id));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn shutdown_dispatcher_flush_stays_bounded_while_runtime_keeps_requeueing() {
+        let (root, state) = build_test_state("dispatcher-flush-shutdown-bounded").await;
+        let thread = state
+            .create_project_dispatcher_thread("demo", CreateDispatcherThreadOptions::default())
+            .await
+            .expect("dispatcher thread should be created");
+        let snapshot_path = state.dispatcher_snapshot_path(&thread.id);
+
+        {
+            let mut threads = state.dispatcher_threads.write().await;
+            let current = threads.get_mut(&thread.id).expect("dispatcher state");
+            current.summary = Some("pre-shutdown snapshot".to_string());
+        }
+        state.queue_dispatcher_flush(&thread.id).await;
+        state
+            .flush_pending_dispatcher_snapshots()
+            .await
+            .expect("baseline snapshot should persist");
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let iterations = Arc::new(AtomicUsize::new(0));
+        let producer_state = Arc::clone(&state);
+        let producer_thread_id = thread.id.clone();
+        let producer_stop = Arc::clone(&stop);
+        let producer_iterations = Arc::clone(&iterations);
+        let producer = tokio::spawn(async move {
+            while !producer_stop.load(Ordering::Relaxed) {
+                let next = producer_iterations.fetch_add(1, Ordering::Relaxed) + 1;
+                {
+                    let mut threads = producer_state.dispatcher_threads.write().await;
+                    let current = threads
+                        .get_mut(&producer_thread_id)
+                        .expect("dispatcher state should stay live");
+                    current.summary = Some(format!("shutdown update {next}"));
+                }
+                producer_state
+                    .queue_dispatcher_flush(&producer_thread_id)
+                    .await;
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        });
+
+        timeout(Duration::from_millis(250), async {
+            loop {
+                if iterations.load(Ordering::Relaxed) >= 3 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("producer should requeue a few shutdown updates");
+
+        let write_guard = state.dispatcher_snapshot_guard(&thread.id).await;
+        let held_write = write_guard.lock().await;
+        let iterations_before_flush = iterations.load(Ordering::Relaxed);
+        let shutdown_state = Arc::clone(&state);
+        let shutdown_flush = tokio::spawn(async move {
+            shutdown_state
+                .flush_pending_dispatcher_snapshots_bounded(4, Duration::from_millis(80))
+                .await
+        });
+
+        timeout(Duration::from_millis(250), async {
+            loop {
+                if iterations.load(Ordering::Relaxed) >= iterations_before_flush + 3 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("producer should keep requeueing while shutdown drain is in flight");
+        drop(held_write);
+
+        let shutdown_flush_result = timeout(Duration::from_millis(500), shutdown_flush)
+            .await
+            .expect("bounded shutdown flush should return instead of hanging")
+            .expect("shutdown flush task should complete");
+        if let Err(err) = shutdown_flush_result {
+            assert!(
+                err.to_string()
+                    .contains("Dispatcher shutdown flush stopped after"),
+                "expected a bounded shutdown flush status, got {err:?}"
+            );
+        }
+
+        stop.store(true, Ordering::Relaxed);
+        producer.await.expect("producer task should stop cleanly");
+
+        let persisted = read_json::<SessionRecord>(&snapshot_path)
+            .await
+            .expect("shutdown flush should leave behind the latest available snapshot");
+        let persisted_summary = persisted
+            .summary
+            .expect("persisted dispatcher snapshot should include a summary");
+        assert_ne!(persisted_summary, "pre-shutdown snapshot");
+        assert!(
+            persisted_summary.starts_with("shutdown update "),
+            "expected a best-effort shutdown update, got {persisted_summary:?}"
+        );
+
+        state
+            .flush_pending_dispatcher_snapshots()
+            .await
+            .expect("final explicit flush should settle once the producer stops");
 
         let _ = fs::remove_dir_all(root);
     }

--- a/crates/conductor-server/src/state/mod.rs
+++ b/crates/conductor-server/src/state/mod.rs
@@ -736,23 +736,11 @@ impl AppState {
 
     #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) async fn flush_pending_dispatcher_snapshots(&self) -> Result<()> {
-        let mut retries_remaining = 2usize;
-
-        loop {
-            match self.flush_pending_dispatcher_snapshots_once().await {
-                Ok(0) => return Ok(()),
-                Ok(_) => {
-                    retries_remaining = 2;
-                }
-                Err(err) => {
-                    if retries_remaining == 0 {
-                        return Err(err);
-                    }
-                    retries_remaining -= 1;
-                    tokio::task::yield_now().await;
-                }
-            }
-        }
+        self.flush_pending_dispatcher_snapshots_bounded(
+            DISPATCHER_SHUTDOWN_FLUSH_ROUND_BUDGET,
+            DISPATCHER_SHUTDOWN_FLUSH_TIME_BUDGET,
+        )
+        .await
     }
 
     pub(crate) async fn flush_pending_dispatcher_snapshots_for_shutdown(&self) -> Result<()> {
@@ -774,15 +762,23 @@ impl AppState {
         let mut rounds = 0usize;
         let mut exhausted_budget = false;
 
-        while rounds < round_budget && Instant::now() < deadline {
+        while rounds < round_budget {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                exhausted_budget = true;
+                break;
+            }
+
             rounds += 1;
 
-            match self.flush_pending_dispatcher_snapshots_once().await {
-                Ok(0) => return Ok(()),
-                Ok(_) => {
+            match tokio::time::timeout(remaining, self.flush_pending_dispatcher_snapshots_once())
+                .await
+            {
+                Ok(Ok(0)) => return Ok(()),
+                Ok(Ok(_)) => {
                     retries_remaining = 2;
                 }
-                Err(err) => {
+                Ok(Err(err)) => {
                     if retries_remaining == 0 {
                         tracing::warn!(
                             rounds,
@@ -801,9 +797,19 @@ impl AppState {
                         "dispatcher shutdown flush will retry queued snapshot persistence"
                     );
                 }
+                Err(_) => {
+                    exhausted_budget = true;
+                    tracing::warn!(
+                        rounds,
+                        round_budget,
+                        time_budget_ms = time_budget.as_millis(),
+                        "dispatcher shutdown flush timed out before queues settled"
+                    );
+                    break;
+                }
             }
 
-            if rounds >= round_budget || Instant::now() >= deadline {
+            if rounds >= round_budget {
                 exhausted_budget = true;
                 break;
             }
@@ -811,8 +817,25 @@ impl AppState {
             tokio::task::yield_now().await;
         }
 
-        rounds += 1;
-        let final_result = self.flush_pending_dispatcher_snapshots_once().await;
+        let final_result = match deadline.saturating_duration_since(Instant::now()) {
+            remaining if remaining.is_zero() => Err(anyhow!(
+                "timed out before a final best-effort flush could start"
+            )),
+            remaining => {
+                rounds += 1;
+                match tokio::time::timeout(
+                    remaining,
+                    self.flush_pending_dispatcher_snapshots_once(),
+                )
+                .await
+                {
+                    Ok(result) => result,
+                    Err(_) => Err(anyhow!(
+                        "timed out during the final best-effort flush after waiting {remaining:?}"
+                    )),
+                }
+            }
+        };
         let pending_after_final = self.pending_dispatcher_flushes.lock().await.len();
 
         match final_result {

--- a/crates/conductor-server/src/state/mod.rs
+++ b/crates/conductor-server/src/state/mod.rs
@@ -57,7 +57,7 @@ pub use types::{
 };
 pub use workspace::{expand_path, resolve_workspace_path};
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use board_collaboration::BoardCollaborationStore;
 use chrono::{DateTime, Utc};
 use conductor_core::config::{
@@ -116,6 +116,7 @@ struct FeedPayloadCacheEntry {
 
 const RUNTIME_STATUS_CACHE_TTL: Duration = Duration::from_millis(1500);
 const SESSION_FLUSH_DEBOUNCE_INTERVAL: Duration = Duration::from_millis(125);
+const DISPATCHER_FLUSH_DEBOUNCE_INTERVAL: Duration = Duration::from_millis(125);
 const TERMINAL_CAPTURE_BUFFER_CAPACITY: usize = 64 * 1024;
 const TERMINAL_CAPTURE_FLUSH_INTERVAL: Duration = Duration::from_millis(32);
 const TERMINAL_CAPTURE_FORCE_FLUSH_BYTES: usize = 64 * 1024;
@@ -180,7 +181,7 @@ pub struct AppState {
     pub output_updates: broadcast::Sender<(String, String)>,
     pub feed_updates: broadcast::Sender<String>,
     pub dispatcher_updates: broadcast::Sender<String>,
-    pub pending_dispatcher_updates: Arc<tokio::sync::Mutex<HashMap<String, u64>>>,
+    pub pending_dispatcher_updates: Arc<tokio::sync::Mutex<HashSet<String>>>,
     pub app_update_config: AppUpdateConfig,
     app_update: Mutex<app_update::AppUpdateRuntime>,
     pub started_at: DateTime<Utc>,
@@ -193,6 +194,10 @@ pub struct AppState {
     feed_payload_cache: Mutex<HashMap<String, FeedPayloadCacheEntry>>,
     pending_session_flushes: Mutex<HashSet<String>>,
     session_flush_notify: Arc<Notify>,
+    pending_dispatcher_flushes: Mutex<HashSet<String>>,
+    dispatcher_flush_notify: Arc<Notify>,
+    dispatcher_flush_round_guard: Mutex<()>,
+    dispatcher_snapshot_guards: Mutex<HashMap<String, Arc<Mutex<()>>>>,
     dispatcher_feed_payload_cache: Mutex<HashMap<String, FeedPayloadCacheEntry>>,
     dispatcher_runtimes: Mutex<HashMap<String, DispatcherRuntimeHandle>>,
     dispatcher_transition_guards: Mutex<HashMap<String, Arc<Mutex<()>>>>,
@@ -225,7 +230,7 @@ impl AppState {
             output_updates,
             feed_updates,
             dispatcher_updates,
-            pending_dispatcher_updates: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            pending_dispatcher_updates: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
             app_update: Mutex::new(app_update_state),
             app_update_config,
             started_at: Utc::now(),
@@ -237,6 +242,10 @@ impl AppState {
             feed_payload_cache: Mutex::new(HashMap::new()),
             pending_session_flushes: Mutex::new(HashSet::new()),
             session_flush_notify: Arc::new(Notify::new()),
+            pending_dispatcher_flushes: Mutex::new(HashSet::new()),
+            dispatcher_flush_notify: Arc::new(Notify::new()),
+            dispatcher_flush_round_guard: Mutex::new(()),
+            dispatcher_snapshot_guards: Mutex::new(HashMap::new()),
             dispatcher_feed_payload_cache: Mutex::new(HashMap::new()),
             dispatcher_runtimes: Mutex::new(HashMap::new()),
             dispatcher_transition_guards: Mutex::new(HashMap::new()),
@@ -252,6 +261,7 @@ impl AppState {
         state.load_dispatcher_bindings_from_disk().await;
         state.load_board_collaboration_from_disk().await;
         state.start_session_flush_watchdog();
+        state.start_dispatcher_flush_watchdog();
         state
     }
 
@@ -664,6 +674,84 @@ impl AppState {
         self.session_flush_notify.notify_one();
     }
 
+    pub(crate) async fn queue_dispatcher_flush(&self, thread_id: &str) {
+        self.pending_dispatcher_flushes
+            .lock()
+            .await
+            .insert(thread_id.to_string());
+        self.dispatcher_flush_notify.notify_one();
+    }
+
+    async fn drain_pending_dispatcher_flushes(&self) -> Vec<String> {
+        let mut pending = self.pending_dispatcher_flushes.lock().await;
+        if pending.is_empty() {
+            Vec::new()
+        } else {
+            pending.drain().collect::<Vec<_>>()
+        }
+    }
+
+    async fn requeue_dispatcher_flushes(&self, thread_ids: Vec<String>) {
+        if thread_ids.is_empty() {
+            return;
+        }
+        self.pending_dispatcher_flushes
+            .lock()
+            .await
+            .extend(thread_ids);
+        self.dispatcher_flush_notify.notify_one();
+    }
+
+    pub(crate) async fn flush_pending_dispatcher_snapshots_once(&self) -> Result<usize> {
+        let _flush_round_lock = self.dispatcher_flush_round_guard.lock().await;
+        let pending_ids = self.drain_pending_dispatcher_flushes().await;
+        if pending_ids.is_empty() {
+            return Ok(0);
+        }
+
+        let mut failed_ids = Vec::new();
+        let mut first_error = None;
+        for thread_id in &pending_ids {
+            if let Err(err) = self.persist_current_dispatcher_snapshot(thread_id).await {
+                if first_error.is_none() {
+                    first_error = Some(err);
+                }
+                failed_ids.push(thread_id.clone());
+            }
+        }
+
+        if failed_ids.is_empty() {
+            return Ok(pending_ids.len());
+        }
+
+        let failed_count = failed_ids.len();
+        let first_error = first_error.expect("failed dispatcher flush should capture an error");
+        self.requeue_dispatcher_flushes(failed_ids).await;
+        Err(anyhow!(
+            "Failed to persist {failed_count} queued dispatcher snapshot(s): {first_error}"
+        ))
+    }
+
+    pub(crate) async fn flush_pending_dispatcher_snapshots(&self) -> Result<()> {
+        let mut retries_remaining = 2usize;
+
+        loop {
+            match self.flush_pending_dispatcher_snapshots_once().await {
+                Ok(0) => return Ok(()),
+                Ok(_) => {
+                    retries_remaining = 2;
+                }
+                Err(err) => {
+                    if retries_remaining == 0 {
+                        return Err(err);
+                    }
+                    retries_remaining -= 1;
+                    tokio::task::yield_now().await;
+                }
+            }
+        }
+    }
+
     pub(crate) async fn queue_hot_path_session_update(
         &self,
         session_id: &str,
@@ -764,6 +852,38 @@ impl AppState {
                     }
 
                     app_state.publish_snapshot().await;
+                }
+            }
+        });
+    }
+
+    fn start_dispatcher_flush_watchdog(self: &Arc<Self>) {
+        let notify = Arc::clone(&self.dispatcher_flush_notify);
+        let state = Arc::downgrade(self);
+        tokio::spawn(async move {
+            loop {
+                notify.notified().await;
+
+                loop {
+                    tokio::time::sleep(DISPATCHER_FLUSH_DEBOUNCE_INTERVAL).await;
+
+                    let Some(app_state) = state.upgrade() else {
+                        return;
+                    };
+                    let flushed = match app_state.flush_pending_dispatcher_snapshots_once().await {
+                        Ok(flushed) => flushed,
+                        Err(err) => {
+                            tracing::debug!(
+                                error = %err,
+                                "Failed to persist queued dispatcher snapshot"
+                            );
+                            break;
+                        }
+                    };
+
+                    if flushed == 0 {
+                        break;
+                    }
                 }
             }
         });

--- a/crates/conductor-server/src/state/mod.rs
+++ b/crates/conductor-server/src/state/mod.rs
@@ -117,6 +117,8 @@ struct FeedPayloadCacheEntry {
 const RUNTIME_STATUS_CACHE_TTL: Duration = Duration::from_millis(1500);
 const SESSION_FLUSH_DEBOUNCE_INTERVAL: Duration = Duration::from_millis(125);
 const DISPATCHER_FLUSH_DEBOUNCE_INTERVAL: Duration = Duration::from_millis(125);
+const DISPATCHER_SHUTDOWN_FLUSH_ROUND_BUDGET: usize = 8;
+const DISPATCHER_SHUTDOWN_FLUSH_TIME_BUDGET: Duration = Duration::from_secs(2);
 const TERMINAL_CAPTURE_BUFFER_CAPACITY: usize = 64 * 1024;
 const TERMINAL_CAPTURE_FLUSH_INTERVAL: Duration = Duration::from_millis(32);
 const TERMINAL_CAPTURE_FORCE_FLUSH_BYTES: usize = 64 * 1024;
@@ -732,6 +734,7 @@ impl AppState {
         ))
     }
 
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) async fn flush_pending_dispatcher_snapshots(&self) -> Result<()> {
         let mut retries_remaining = 2usize;
 
@@ -750,6 +753,91 @@ impl AppState {
                 }
             }
         }
+    }
+
+    pub(crate) async fn flush_pending_dispatcher_snapshots_for_shutdown(&self) -> Result<()> {
+        self.flush_pending_dispatcher_snapshots_bounded(
+            DISPATCHER_SHUTDOWN_FLUSH_ROUND_BUDGET,
+            DISPATCHER_SHUTDOWN_FLUSH_TIME_BUDGET,
+        )
+        .await
+    }
+
+    pub(crate) async fn flush_pending_dispatcher_snapshots_bounded(
+        &self,
+        round_budget: usize,
+        time_budget: Duration,
+    ) -> Result<()> {
+        let round_budget = round_budget.max(1);
+        let deadline = Instant::now() + time_budget.max(Duration::from_millis(1));
+        let mut retries_remaining = 2usize;
+        let mut rounds = 0usize;
+        let mut exhausted_budget = false;
+
+        while rounds < round_budget && Instant::now() < deadline {
+            rounds += 1;
+
+            match self.flush_pending_dispatcher_snapshots_once().await {
+                Ok(0) => return Ok(()),
+                Ok(_) => {
+                    retries_remaining = 2;
+                }
+                Err(err) => {
+                    if retries_remaining == 0 {
+                        tracing::warn!(
+                            rounds,
+                            round_budget,
+                            error = %err,
+                            "dispatcher shutdown flush exhausted retry budget before queues settled"
+                        );
+                        break;
+                    }
+                    retries_remaining -= 1;
+                    tracing::debug!(
+                        rounds,
+                        round_budget,
+                        retries_remaining,
+                        error = %err,
+                        "dispatcher shutdown flush will retry queued snapshot persistence"
+                    );
+                }
+            }
+
+            if rounds >= round_budget || Instant::now() >= deadline {
+                exhausted_budget = true;
+                break;
+            }
+
+            tokio::task::yield_now().await;
+        }
+
+        rounds += 1;
+        let final_result = self.flush_pending_dispatcher_snapshots_once().await;
+        let pending_after_final = self.pending_dispatcher_flushes.lock().await.len();
+
+        match final_result {
+            Ok(0) if pending_after_final == 0 => Ok(()),
+            Ok(_) if pending_after_final == 0 => Ok(()),
+            Ok(_) => Err(anyhow!(
+                "Dispatcher shutdown flush stopped after {rounds} round(s) across a {time_budget:?} budget; {pending_after_final} queued snapshot(s) remain pending"
+            )),
+            Err(err) => Err(anyhow!(
+                "Dispatcher shutdown flush stopped after {rounds} round(s) across a {time_budget:?} budget; {pending_after_final} queued snapshot(s) remain pending after final best-effort flush: {err}"
+            )),
+        }
+        .map_err(|err| {
+            if exhausted_budget || pending_after_final > 0 {
+                tracing::warn!(
+                    rounds,
+                    round_budget,
+                    time_budget_ms = time_budget.as_millis(),
+                    pending_after_final,
+                    error = %err,
+                    "dispatcher shutdown flush exited before queued snapshots fully settled"
+                );
+            }
+            err
+        })
     }
 
     pub(crate) async fn queue_hot_path_session_update(

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "basic-ftp": "5.3.1",
     "fast-uri": "3.1.2",
     "ip-address": "10.5.0",
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "picomatch": "2.3.2",
     "postcss": "8.5.18",
     "sharp": "0.35.3",

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -197,22 +197,64 @@ a:hover {
   animation: pulse-ring 1.8s ease-out infinite;
 }
 
-/* Mobile responsiveness: prevent iOS auto-zoom on input focus */
-@media (max-width: 767px) {
-  input,
-  textarea,
-  select {
-    font-size: 16px !important;
-  }
-}
-
 /* Mobile responsiveness: touch-friendly scrolling */
 @media (pointer: coarse) {
   .overflow-x-auto,
   .overflow-y-auto,
   .overflow-auto {
     -webkit-overflow-scrolling: touch;
+  }
+
+  .overflow-x-auto {
+    overscroll-behavior-x: contain;
+  }
+
+  .overflow-y-auto {
+    overscroll-behavior-y: contain;
+  }
+
+  .overflow-auto {
     overscroll-behavior: contain;
+  }
+}
+
+/* Mobile overlays: reliable taps and scrollable, viewport-contained menus. */
+@media (max-width: 767px), (pointer: coarse) {
+  input:not([type="checkbox"]):not([type="radio"]):not([type="hidden"]),
+  textarea,
+  select {
+    font-size: 16px !important;
+  }
+
+  button[aria-haspopup="menu"],
+  button[aria-haspopup="listbox"],
+  .oc-mobile-touch-target {
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  .oc-mobile-menu-content [role="menuitem"],
+  .oc-mobile-menu-content [role="menuitemcheckbox"],
+  .oc-mobile-menu-content [role="menuitemradio"],
+  .oc-mobile-menu-content button,
+  .oc-mobile-menu-content a {
+    min-height: 44px;
+    touch-action: manipulation;
+  }
+
+  [role="dialog"] button,
+  [role="dialog"] [role="button"] {
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  [role="dialog"] input:not([type="checkbox"]):not([type="radio"]):not([type="hidden"]),
+  [role="dialog"] textarea {
+    min-height: 44px;
+  }
+
+  select {
+    min-height: 44px;
   }
 }
 
@@ -220,6 +262,16 @@ a:hover {
 html,
 body {
   overflow-x: hidden;
+}
+
+/* The dashboard uses explicit inner scroll owners. Keep the document itself
+   passive so iOS Safari cannot hand a boundary swipe to the body and leave the
+   visible workspace stuck between two scroll positions. Public/auth pages do
+   not mount AppShell and retain normal document scrolling. */
+html.conductor-app-shell-active,
+html.conductor-app-shell-active body {
+  height: 100%;
+  overflow-y: hidden;
 }
 
 .conductor-auth-form .cl-formButtonPrimary {

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -48,6 +48,7 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
+  viewportFit: "cover",
 };
 
 function Shell({ children }: { children: React.ReactNode }) {

--- a/packages/web/src/components/board/WorkspaceKanban.tsx
+++ b/packages/web/src/components/board/WorkspaceKanban.tsx
@@ -37,9 +37,20 @@ import {
 } from "lucide-react";
 import { AgentTileIcon } from "@/components/AgentTileIcon";
 import {
+  BOARD_CONTENT_CLASS_NAME,
+  BOARD_HEADER_CLASS_NAME,
+  BOARD_KANBAN_COLUMN_BODY_CLASS_NAME,
+  BOARD_KANBAN_COLUMN_CLASS_NAME,
+  BOARD_KANBAN_RAIL_CLASS_NAME,
+  BOARD_KANBAN_RAIL_TOUCH_STYLE,
+  BOARD_KANBAN_SHELL_CLASS_NAME,
+  BOARD_SCROLL_SURFACE_CLASS_NAME,
+} from "@/components/board/boardMobileLayout";
+import {
   KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME,
   KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME,
 } from "@/components/layout/keyboardSafeViewport";
+import { MobileDropdownMenuContent } from "@/components/ui/MobileDropdownMenu";
 import { usePreferences } from "@/hooks/usePreferences";
 import { getDisplaySessionId } from "@/lib/bridgeSessionIds";
 import { withBridgeQuery } from "@/lib/bridgeQuery";
@@ -316,7 +327,7 @@ const PRIORITY_OPTIONS = [
   { value: "low", label: "Low" },
 ] as const;
 const MENU_PANEL_CLASS =
-  "z-[120] rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] p-2 shadow-[0_18px_50px_rgba(0,0,0,0.35)]";
+  "rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] p-2 shadow-[0_18px_50px_rgba(0,0,0,0.35)]";
 const MENU_ITEM_CLASS =
   "flex min-h-[40px] cursor-default items-center gap-2 rounded-[4px] px-3 py-2 text-[14px] leading-[21px] text-[var(--vk-text-normal)] outline-none hover:bg-[var(--vk-bg-hover)] focus:bg-[var(--vk-bg-hover)]";
 const BOARD_LAYOUT_STORAGE_KEY = "conductor:board-layout";
@@ -666,7 +677,7 @@ function ContextAttachmentChip({
       type="button"
       onClick={onOpen}
       disabled={opening}
-      className="inline-flex max-w-full items-center gap-1 rounded-[3px] bg-[color:#292929] px-2 py-1 text-[11px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] hover:text-[var(--vk-text-normal)] disabled:opacity-60"
+      className="inline-flex min-h-11 max-w-full items-center gap-1 rounded-[3px] bg-[color:#292929] px-2 py-1 text-[11px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] hover:text-[var(--vk-text-normal)] disabled:opacity-60 xl:min-h-0"
       title={attachment}
       aria-label={`Open ${attachment}`}
     >
@@ -834,12 +845,11 @@ function AgentSelectMenu({
         </button>
       </DropdownMenu.Trigger>
 
-      <DropdownMenu.Portal>
-        <DropdownMenu.Content
-          align="start"
-          sideOffset={6}
-          className={`${MENU_PANEL_CLASS} min-w-[220px] max-w-[calc(100vw-2rem)] max-h-[min(360px,50vh)] overflow-y-auto sm:min-w-[280px]`}
-        >
+      <MobileDropdownMenuContent
+        align="start"
+        sideOffset={6}
+        className={`${MENU_PANEL_CLASS} w-[calc(100vw-2rem)] min-w-0 sm:w-auto sm:min-w-[280px]`}
+      >
           <p className="px-3 pb-1 text-[12px] font-semibold uppercase tracking-[0.08em] text-[var(--vk-text-muted)]">
             Agents
           </p>
@@ -866,8 +876,7 @@ function AgentSelectMenu({
               </DropdownMenu.Item>
             );
           })}
-        </DropdownMenu.Content>
-      </DropdownMenu.Portal>
+      </MobileDropdownMenuContent>
     </DropdownMenu.Root>
   );
 }
@@ -1479,7 +1488,7 @@ function BoardTaskCard({
         <button
           type="button"
           onClick={() => onOpenEditor(task, role)}
-          className="inline-flex h-9 w-9 items-center justify-center rounded-[3px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] hover:text-[var(--vk-text-normal)] sm:h-6 sm:w-6"
+          className="inline-flex h-11 w-11 items-center justify-center rounded-[3px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] hover:text-[var(--vk-text-normal)] xl:h-6 xl:w-6"
           aria-label="Edit task"
           title="Edit task"
         >
@@ -1517,7 +1526,7 @@ function BoardTaskCard({
                 href={issueUrl}
                 target="_blank"
                 rel="noreferrer"
-                className="inline-flex h-5 items-center gap-1 rounded-[3px] border border-[var(--vk-border)] px-2 text-[11px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)]"
+                className="inline-flex min-h-11 items-center gap-1 rounded-[3px] border border-[var(--vk-border)] px-2 text-[11px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] xl:min-h-5"
               >
                 <span>Issue #{task.issueId}</span>
                 <ExternalLink className="h-3 w-3" />
@@ -1564,7 +1573,7 @@ function BoardTaskCard({
               <button
                 type="button"
                 onClick={() => void onOpenSessionView(primaryLinkedSession.id, getPrimaryTabForSession(primaryLinkedSession))}
-                className="flex w-full items-center justify-between gap-2 rounded-[3px] border border-[rgba(255,255,255,0.05)] bg-[rgba(255,255,255,0.03)] px-2 py-1.5 text-left hover:bg-[var(--vk-bg-hover)]"
+                className="flex min-h-11 w-full items-center justify-between gap-2 rounded-[3px] border border-[rgba(255,255,255,0.05)] bg-[rgba(255,255,255,0.03)] px-2 py-1.5 text-left hover:bg-[var(--vk-bg-hover)] xl:min-h-0"
                 title={primaryLinkedSession.id}
               >
                 <div className="flex min-w-0 items-center gap-2">
@@ -1605,7 +1614,7 @@ function BoardTaskCard({
                   key={session.id}
                   type="button"
                   onClick={() => void onOpenSessionView(session.id, getPrimaryTabForSession(session))}
-                  className="flex w-full items-center justify-between gap-2 rounded-[3px] px-2 py-1.5 text-left hover:bg-[var(--vk-bg-hover)]"
+                  className="flex min-h-11 w-full items-center justify-between gap-2 rounded-[3px] px-2 py-1.5 text-left hover:bg-[var(--vk-bg-hover)] xl:min-h-0"
                   title={session.id}
                 >
                   <div className="flex min-w-0 items-center gap-2">
@@ -1638,7 +1647,7 @@ function BoardTaskCard({
               <button
                 type="button"
                 onClick={() => void onOpenSessionView(unresolvedPrimaryLink, "terminal")}
-                className="flex w-full items-center justify-between gap-2 rounded-[3px] px-2 py-1.5 text-left hover:bg-[var(--vk-bg-hover)]"
+                className="flex min-h-11 w-full items-center justify-between gap-2 rounded-[3px] px-2 py-1.5 text-left hover:bg-[var(--vk-bg-hover)] xl:min-h-0"
                 title={unresolvedPrimaryLink}
               >
                 <div className="min-w-0">
@@ -1751,7 +1760,7 @@ function BoardListRow({
           onOpenEditor(task, role);
         }
       }}
-      className="group flex items-start gap-2 border-b border-[var(--vk-border)] py-2.5 pl-2 pr-3 text-sm text-[var(--vk-text-normal)] transition-colors hover:bg-[var(--vk-bg-hover)] last:border-b-0 sm:items-center sm:py-2 sm:pl-1"
+      className="group flex min-h-11 items-start gap-2 border-b border-[var(--vk-border)] py-2.5 pl-2 pr-3 text-sm text-[var(--vk-text-normal)] transition-colors hover:bg-[var(--vk-bg-hover)] last:border-b-0 sm:items-center sm:py-2 sm:pl-1"
     >
       <span className="shrink-0 pt-px sm:hidden">
         <span
@@ -1785,7 +1794,7 @@ function BoardListRow({
                   onOpenSessionView(primaryLinkedSession.id, getPrimaryTabForSession(primaryLinkedSession));
                 }
               }}
-              className="inline-flex items-center gap-1 rounded-full bg-[color:color-mix(in_srgb,var(--status-working)_18%,transparent)] px-2 py-0.5 text-[10px] font-medium text-[var(--status-working)]"
+              className="inline-flex min-h-11 items-center gap-1 rounded-full bg-[color:color-mix(in_srgb,var(--status-working)_18%,transparent)] px-2 py-0.5 text-[10px] font-medium text-[var(--status-working)] xl:min-h-0"
             >
               <span className="relative flex h-2 w-2">
                 <span className="absolute inline-flex h-full w-full animate-pulse rounded-full bg-[var(--status-working)] opacity-75" />
@@ -1852,7 +1861,7 @@ function BoardListRow({
             target="_blank"
             rel="noreferrer"
             onClick={(event) => event.stopPropagation()}
-            className="text-[11px] text-[var(--vk-text-muted)] hover:text-[var(--vk-text-normal)]"
+            className="inline-flex min-h-11 min-w-11 items-center justify-center text-[11px] text-[var(--vk-text-muted)] hover:text-[var(--vk-text-normal)] xl:min-h-0 xl:min-w-0"
           >
             #{task.issueId}
           </a>
@@ -1864,7 +1873,7 @@ function BoardListRow({
               event.stopPropagation();
               onOpenSessionView(primaryLinkedSession.id, getPrimaryTabForSession(primaryLinkedSession));
             }}
-            className="text-[11px] text-[var(--vk-text-muted)] hover:text-[var(--vk-text-normal)]"
+            className="inline-flex min-h-11 min-w-11 items-center justify-center text-[11px] text-[var(--vk-text-muted)] hover:text-[var(--vk-text-normal)] xl:min-h-0 xl:min-w-0"
           >
             {formatLinkedSessionLabel(primaryLinkedSession)}
           </button>
@@ -3227,11 +3236,11 @@ export function WorkspaceKanban({
   }
 
   return (
-    <section className="flex h-full min-h-0 flex-col overflow-hidden sm:overflow-hidden">
-      <header className="border-b border-[var(--vk-border)] px-3 py-3 sm:px-4 sm:py-4">
-        <div className="mb-3 flex flex-wrap items-center justify-between gap-3 sm:mb-4">
+    <section className={BOARD_SCROLL_SURFACE_CLASS_NAME}>
+      <header className={BOARD_HEADER_CLASS_NAME}>
+        <div className="mb-2 flex flex-wrap items-center justify-between gap-2 xl:mb-4 xl:gap-3">
           <div className="min-w-0">
-            <h1 className="truncate text-[20px] font-medium leading-[28px] text-[var(--vk-text-normal)] sm:text-[24px] sm:leading-[32px]">
+            <h1 className="truncate text-[18px] font-medium leading-[26px] text-[var(--vk-text-normal)] xl:text-[24px] xl:leading-[32px]">
               {projectLabel?.trim() || projectId}
             </h1>
           </div>
@@ -3244,14 +3253,15 @@ export function WorkspaceKanban({
 
         {boardLayout === "list" ? (
           <div className="flex flex-wrap items-center justify-between gap-2 sm:gap-3">
-            <div className="flex min-w-0 items-center gap-2 sm:gap-3">
+            <div className="flex w-full min-w-0 items-center gap-2 xl:w-auto xl:gap-3">
               <button
                 type="button"
                 onClick={() => openComposer("intake")}
-                className="inline-flex h-[31px] items-center gap-1 rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-active)] px-3 text-[13px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)]"
+                className="inline-flex h-11 w-11 shrink-0 items-center justify-center gap-1 rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-active)] px-3 text-[13px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] xl:h-[31px] xl:w-auto"
+                aria-label="New Issue"
               >
                 <Plus className="h-3.5 w-3.5" />
-                <span className="hidden sm:inline">New Issue</span>
+                <span className="hidden xl:inline">New Issue</span>
               </button>
               {collapsibleBoardListGroupKeys.length > 0 ? (
                 <button
@@ -3263,7 +3273,7 @@ export function WorkspaceKanban({
                         : collapsibleBoardListGroupKeys,
                     })
                   }
-                  className="hidden h-[31px] w-[31px] items-center justify-center rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] hover:text-[var(--vk-text-normal)] sm:inline-flex"
+                  className="hidden h-11 w-11 items-center justify-center rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] hover:text-[var(--vk-text-normal)] sm:inline-flex xl:h-[31px] xl:w-[31px]"
                   aria-label={allBoardListGroupsCollapsed ? "Expand groups" : "Collapse groups"}
                   title={allBoardListGroupsCollapsed ? "Expand groups" : "Collapse groups"}
                 >
@@ -3275,13 +3285,13 @@ export function WorkspaceKanban({
                 </button>
               ) : null}
 
-              <label className="relative w-48 sm:w-64 md:w-80">
+              <label className="relative min-w-0 flex-1 xl:w-80 xl:flex-none">
                 <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[var(--vk-text-muted)]" />
                 <input
                   value={search}
                   onChange={(event) => setSearch(event.target.value)}
                   placeholder="Search issues..."
-                  className="h-[31px] w-full rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] pl-7 pr-3 text-[13px] text-[var(--vk-text-normal)] outline-none placeholder:text-[var(--vk-text-muted)]"
+                  className="h-11 w-full rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] pl-7 pr-3 text-[13px] text-[var(--vk-text-normal)] outline-none placeholder:text-[var(--vk-text-muted)] xl:h-[31px]"
                 />
               </label>
             </div>
@@ -3291,7 +3301,7 @@ export function WorkspaceKanban({
                 <button
                   type="button"
                   className={cn(
-                    "p-1.5 transition-colors",
+                    "inline-flex h-11 w-11 items-center justify-center transition-colors xl:h-7 xl:w-7",
                     boardLayout === "list"
                       ? "bg-[var(--vk-bg-hover)] text-[var(--vk-text-normal)]"
                       : "text-[var(--vk-text-muted)] hover:text-[var(--vk-text-normal)]"
@@ -3304,7 +3314,7 @@ export function WorkspaceKanban({
                 <button
                   type="button"
                   className={cn(
-                    "p-1.5 transition-colors",
+                    "inline-flex h-11 w-11 items-center justify-center transition-colors xl:h-7 xl:w-7",
                     "text-[var(--vk-text-muted)] hover:text-[var(--vk-text-normal)]"
                   )}
                   onClick={() => setBoardLayout("kanban")}
@@ -3352,12 +3362,11 @@ export function WorkspaceKanban({
                     ) : null}
                   </button>
                 </DropdownMenu.Trigger>
-                <DropdownMenu.Portal>
-                  <DropdownMenu.Content
-                    align="end"
-                    sideOffset={6}
-                    className={`${MENU_PANEL_CLASS} w-[min(420px,calc(100vw-2rem))]`}
-                  >
+                <MobileDropdownMenuContent
+                  align="end"
+                  sideOffset={6}
+                  className={`${MENU_PANEL_CLASS} w-[min(420px,calc(100vw-2rem))]`}
+                >
                     <div className="space-y-3 p-1">
                       <div className="flex items-center justify-between px-2 pt-1">
                         <span className="text-[12px] font-semibold text-[var(--vk-text-normal)]">
@@ -3485,7 +3494,7 @@ export function WorkspaceKanban({
                             <span className="text-[11px] uppercase tracking-[0.08em] text-[var(--vk-text-muted)]">
                               Assignee
                             </span>
-                            <div className="max-h-40 space-y-0.5 overflow-y-auto">
+                            <div className="space-y-0.5">
                               <button
                                 type="button"
                                 onClick={() =>
@@ -3537,8 +3546,7 @@ export function WorkspaceKanban({
                         </div>
                       </div>
                     </div>
-                  </DropdownMenu.Content>
-                </DropdownMenu.Portal>
+                </MobileDropdownMenuContent>
               </DropdownMenu.Root>
 
               <DropdownMenu.Root>
@@ -3551,12 +3559,11 @@ export function WorkspaceKanban({
                     <span className="hidden sm:inline">Sort</span>
                   </button>
                 </DropdownMenu.Trigger>
-                <DropdownMenu.Portal>
-                  <DropdownMenu.Content
-                    align="end"
-                    sideOffset={6}
-                    className={`${MENU_PANEL_CLASS} min-w-[180px]`}
-                  >
+                <MobileDropdownMenuContent
+                  align="end"
+                  sideOffset={6}
+                  className={`${MENU_PANEL_CLASS} min-w-[180px]`}
+                >
                     {(
                       [
                         ["status", "Status"],
@@ -3596,8 +3603,7 @@ export function WorkspaceKanban({
                         </button>
                       );
                     })}
-                  </DropdownMenu.Content>
-                </DropdownMenu.Portal>
+                </MobileDropdownMenuContent>
               </DropdownMenu.Root>
 
               <DropdownMenu.Root>
@@ -3610,12 +3616,11 @@ export function WorkspaceKanban({
                     <span className="hidden sm:inline">Group</span>
                   </button>
                 </DropdownMenu.Trigger>
-                <DropdownMenu.Portal>
-                  <DropdownMenu.Content
-                    align="end"
-                    sideOffset={6}
-                    className={`${MENU_PANEL_CLASS} min-w-[180px]`}
-                  >
+                <MobileDropdownMenuContent
+                  align="end"
+                  sideOffset={6}
+                  className={`${MENU_PANEL_CLASS} min-w-[180px]`}
+                >
                     {(
                       [
                         ["status", "Status"],
@@ -3644,14 +3649,13 @@ export function WorkspaceKanban({
                         </button>
                       );
                     })}
-                  </DropdownMenu.Content>
-                </DropdownMenu.Portal>
+                </MobileDropdownMenuContent>
               </DropdownMenu.Root>
             </div>
           </div>
         ) : (
           <div className="flex flex-wrap items-center gap-2">
-            <div className="inline-flex rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] p-px">
+            <div className="inline-flex min-w-0 flex-1 rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] p-px xl:flex-none">
               {(
                 [
                   ["active", "Active"],
@@ -3665,7 +3669,7 @@ export function WorkspaceKanban({
                   type="button"
                   onClick={() => setViewFilter(value)}
                   className={cn(
-                    "px-3 py-[5px] text-[13px]",
+                    "min-h-11 min-w-0 flex-1 px-1.5 py-1 text-[12px] xl:min-h-0 xl:flex-none xl:px-3 xl:py-[5px] xl:text-[13px]",
                     viewFilter === value
                       ? "rounded-[2px] bg-[var(--vk-bg-hover)] text-[var(--vk-text-normal)]"
                       : "text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)]"
@@ -3679,7 +3683,7 @@ export function WorkspaceKanban({
             <button
               type="button"
               onClick={() => setBoardLayout("list")}
-              className="inline-flex h-[31px] items-center gap-2 rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] px-3 text-[13px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)]"
+              className="inline-flex h-11 w-11 shrink-0 items-center justify-center gap-2 rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] px-3 text-[13px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] xl:h-[31px] xl:w-auto"
               aria-label="Switch to list view"
               title="Switch to list view"
             >
@@ -3687,21 +3691,21 @@ export function WorkspaceKanban({
               <span className="hidden sm:inline">List view</span>
             </button>
 
-            <div className="ml-auto flex w-full min-w-0 flex-wrap items-center gap-2 sm:w-auto sm:min-w-[220px] sm:flex-nowrap sm:flex-none">
-              <label className="flex h-[31px] min-w-0 flex-1 items-center rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] px-2 sm:min-w-[200px] sm:w-[240px] sm:flex-none">
+            <div className="ml-auto flex w-full min-w-0 flex-nowrap items-center gap-2 xl:w-auto xl:min-w-[220px] xl:flex-none">
+              <label className="flex h-11 min-w-0 flex-1 items-center rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] px-2 xl:h-[31px] xl:min-w-[200px] xl:w-[240px] xl:flex-none">
                 <Search className="h-3.5 w-3.5 text-[var(--vk-text-muted)]" />
                 <input
                   value={search}
                   onChange={(event) => setSearch(event.target.value)}
                   placeholder="Search issues..."
-                  className="ml-2 w-full bg-transparent text-[14px] text-[var(--vk-text-normal)] outline-none placeholder:text-[var(--vk-text-muted)]"
+                  className="ml-2 h-full w-full bg-transparent text-[14px] text-[var(--vk-text-normal)] outline-none placeholder:text-[var(--vk-text-muted)]"
                 />
               </label>
 
               <button
                 type="button"
                 onClick={() => openComposer("intake")}
-                className="inline-flex h-[31px] w-full items-center justify-center gap-1 rounded-[3px] bg-[var(--vk-orange)] px-3 text-[14px] text-white hover:bg-[var(--accent-hover)] sm:w-auto"
+                className="inline-flex h-11 w-auto shrink-0 items-center justify-center gap-1 rounded-[3px] bg-[var(--vk-orange)] px-3 text-[14px] text-white hover:bg-[var(--accent-hover)] xl:h-[31px]"
               >
                 <span>New Issue</span>
                 <Plus className="h-3.5 w-3.5" />
@@ -3716,7 +3720,7 @@ export function WorkspaceKanban({
               <button
                 type="button"
                 onClick={() => setProjectSyncOpen(true)}
-                className="inline-flex h-[38px] items-center gap-2 rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] px-3 text-[13px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] sm:h-[31px]"
+                className="inline-flex h-11 items-center gap-2 rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] px-3 text-[13px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] xl:h-[31px]"
               >
                 <span className="hidden sm:inline">GitHub Project</span>
                 <span className="sm:hidden">GitHub</span>
@@ -3732,7 +3736,7 @@ export function WorkspaceKanban({
                   value={selectedGitHubProjectId}
                   onChange={handleGitHubProjectSelectChange}
                   disabled={projectSyncLoading || projectSyncSaving}
-                  className="h-9 min-w-0 flex-1 rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] px-2 text-[14px] text-[var(--vk-text-normal)] outline-none focus:border-[var(--vk-orange)] sm:min-w-[220px] sm:max-w-md sm:flex-none"
+                  className="h-11 min-w-0 flex-1 rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] px-2 text-[14px] text-[var(--vk-text-normal)] outline-none focus:border-[var(--vk-orange)] xl:h-9 xl:min-w-[220px] xl:max-w-md xl:flex-none"
                 >
                   <option value="">
                     {projectSyncLoading
@@ -3758,7 +3762,7 @@ export function WorkspaceKanban({
                     void handleSaveGitHubProjectLink(null);
                     setProjectSyncOpen(false);
                   }}
-                  className="inline-flex h-9 items-center rounded-[3px] border border-[var(--vk-border)] px-3 text-[13px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-50"
+                  className="inline-flex h-11 items-center rounded-[3px] border border-[var(--vk-border)] px-3 text-[13px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-50 xl:h-9"
                 >
                   Disconnect
                 </button>
@@ -3767,7 +3771,7 @@ export function WorkspaceKanban({
                   type="button"
                   disabled={!board?.githubProject?.id || projectSyncSaving}
                   onClick={() => void handleGitHubProjectSync("pull")}
-                  className="inline-flex h-9 items-center gap-2 rounded-[3px] border border-[var(--vk-border)] px-3 text-[13px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-50"
+                  className="inline-flex h-11 items-center gap-2 rounded-[3px] border border-[var(--vk-border)] px-3 text-[13px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-50 xl:h-9"
                 >
                   {projectSyncSaving ? (
                     <Loader2 className="h-4 w-4 animate-spin" />
@@ -3781,7 +3785,7 @@ export function WorkspaceKanban({
                   type="button"
                   disabled={!board?.githubProject?.id || projectSyncSaving}
                   onClick={() => void handleGitHubProjectSync("push")}
-                  className="inline-flex h-9 items-center rounded-[3px] bg-[var(--vk-bg-active)] px-3 text-[13px] text-[var(--vk-text-strong)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-50"
+                  className="inline-flex h-11 items-center rounded-[3px] bg-[var(--vk-bg-active)] px-3 text-[13px] text-[var(--vk-text-strong)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-50 xl:h-9"
                 >
                   Push
                 </button>
@@ -3791,7 +3795,7 @@ export function WorkspaceKanban({
                     href={board.githubProject.url}
                     target="_blank"
                     rel="noreferrer"
-                    className="inline-flex h-9 items-center gap-1 rounded-[3px] border border-[var(--vk-border)] px-3 text-[13px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)]"
+                    className="inline-flex h-11 items-center gap-1 rounded-[3px] border border-[var(--vk-border)] px-3 text-[13px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] xl:h-9"
                   >
                     <span>Open</span>
                     <ExternalLink className="h-3.5 w-3.5" />
@@ -3802,7 +3806,7 @@ export function WorkspaceKanban({
                   <button
                     type="button"
                     onClick={() => setProjectSyncOpen(false)}
-                    className="inline-flex h-9 items-center rounded-[3px] px-2 text-[13px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] hover:text-[var(--vk-text-normal)]"
+                    className="inline-flex h-11 items-center rounded-[3px] px-2 text-[13px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] hover:text-[var(--vk-text-normal)] xl:h-9"
                   >
                     Cancel
                   </button>
@@ -3891,7 +3895,12 @@ export function WorkspaceKanban({
 
       </header>
 
-      <div className="min-h-0 min-w-0 flex-1 overflow-y-auto overscroll-contain p-3 touch-pan-y sm:p-4 sm:touch-auto">
+      <div
+        className={cn(
+          BOARD_CONTENT_CLASS_NAME,
+          boardLayout === "kanban" && "xl:overflow-hidden"
+        )}
+      >
         {loading ? (
           <div className="flex h-full items-center justify-center text-[var(--vk-text-muted)]">
             <Loader2 className="h-4 w-4 animate-spin" />
@@ -3903,9 +3912,12 @@ export function WorkspaceKanban({
           </div>
         ) : (
           boardLayout === "kanban" ? (
-            <div className="flex h-full min-h-0 flex-col gap-4">
-              <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain touch-pan-y sm:touch-auto">
-                <div className="flex min-w-0 flex-row items-stretch gap-3 overflow-x-auto overscroll-x-contain pb-3 [-webkit-overflow-scrolling:touch] px-0.5 sm:h-full sm:gap-0 sm:overflow-x-auto sm:px-0 sm:pb-3">
+            <div className={BOARD_KANBAN_SHELL_CLASS_NAME}>
+              <div className="min-w-0 xl:min-h-0 xl:flex-1">
+                <div
+                  className={BOARD_KANBAN_RAIL_CLASS_NAME}
+                  style={BOARD_KANBAN_RAIL_TOUCH_STYLE}
+                >
                   {visibleColumns.map((column) => {
                     const fullColumn = allColumns.find(
                       (candidate) => candidate.role === column.role
@@ -3927,8 +3939,8 @@ export function WorkspaceKanban({
                       <article
                         key={column.role}
                         className={cn(
-                          "flex max-h-[min(560px,65dvh)] min-h-0 w-[min(85vw,320px)] shrink-0 flex-col border border-[var(--vk-border)] bg-[var(--vk-bg-main)] shadow-none sm:max-h-none sm:h-full sm:min-h-[560px] sm:w-[320px] sm:border-l-0 first:sm:border-l",
-                          draggingTask && "snap-start"
+                          BOARD_KANBAN_COLUMN_CLASS_NAME,
+                          draggingTask && "ring-1 ring-[var(--vk-border)]"
                         )}
                       >
                         <header className="flex items-center gap-2 border-b border-[var(--vk-border)] px-3 py-3">
@@ -3950,7 +3962,7 @@ export function WorkspaceKanban({
                           <button
                             type="button"
                             onClick={() => openComposer(column.role)}
-                            className="inline-flex h-9 w-9 items-center justify-center rounded-[7px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] sm:h-7 sm:w-7"
+                            className="inline-flex h-11 w-11 items-center justify-center rounded-[7px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] xl:h-7 xl:w-7"
                             aria-label={`Add task to ${column.heading}`}
                           >
                             <Plus className="h-3.5 w-3.5" />
@@ -3959,7 +3971,7 @@ export function WorkspaceKanban({
 
                         <div
                           className={cn(
-                            "flex-1 min-h-0 overflow-y-auto overscroll-contain px-3 pb-3 pt-2",
+                            BOARD_KANBAN_COLUMN_BODY_CLASS_NAME,
                             draggingTask?.role === column.role &&
                               "bg-[rgba(255,255,255,0.02)]"
                           )}
@@ -4068,7 +4080,7 @@ export function WorkspaceKanban({
               <button
                 type="button"
                 onClick={() => openComposer("intake")}
-                className="mt-4 inline-flex h-[31px] items-center gap-1 rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-active)] px-3 text-[13px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)]"
+                className="mt-4 inline-flex h-11 items-center gap-1 rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-active)] px-3 text-[13px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] xl:h-[31px]"
               >
                 <Plus className="h-3.5 w-3.5" />
                 <span>New Issue</span>
@@ -4123,7 +4135,7 @@ export function WorkspaceKanban({
                         <button
                           type="button"
                           onClick={() => openComposer(composerRole)}
-                          className="ml-auto inline-flex h-7 w-7 items-center justify-center rounded-[6px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)]"
+                          className="ml-auto inline-flex h-11 w-11 items-center justify-center rounded-[6px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] xl:h-7 xl:w-7"
                           aria-label={`Add task to ${group.label}`}
                         >
                           <Plus className="h-3.5 w-3.5" />

--- a/packages/web/src/components/board/boardMobileLayout.test.ts
+++ b/packages/web/src/components/board/boardMobileLayout.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  BOARD_CONTENT_CLASS_NAME,
+  BOARD_HEADER_CLASS_NAME,
+  BOARD_KANBAN_COLUMN_BODY_CLASS_NAME,
+  BOARD_KANBAN_COLUMN_CLASS_NAME,
+  BOARD_KANBAN_RAIL_CLASS_NAME,
+  BOARD_KANBAN_RAIL_TOUCH_STYLE,
+  BOARD_KANBAN_SHELL_CLASS_NAME,
+  BOARD_SCROLL_SURFACE_CLASS_NAME,
+} from "./boardMobileLayout";
+
+test("mobile board surface is the sole vertical momentum scroller", () => {
+  assert.match(BOARD_SCROLL_SURFACE_CLASS_NAME, /overflow-y-auto/);
+  assert.match(BOARD_SCROLL_SURFACE_CLASS_NAME, /overflow-x-hidden/);
+  assert.match(BOARD_SCROLL_SURFACE_CLASS_NAME, /overscroll-y-contain/);
+  assert.match(BOARD_SCROLL_SURFACE_CLASS_NAME, /-webkit-overflow-scrolling:touch/);
+  assert.match(BOARD_SCROLL_SURFACE_CLASS_NAME, /xl:overflow-hidden/);
+  assert.doesNotMatch(BOARD_SCROLL_SURFACE_CLASS_NAME, /sm:overflow-hidden/);
+
+  assert.match(BOARD_HEADER_CLASS_NAME, /shrink-0/);
+  assert.match(BOARD_CONTENT_CLASS_NAME, /flex-none/);
+  assert.match(BOARD_CONTENT_CLASS_NAME, /overflow-visible/);
+  assert.match(BOARD_CONTENT_CLASS_NAME, /xl:flex-1/);
+  assert.match(BOARD_CONTENT_CLASS_NAME, /xl:overflow-y-auto/);
+  assert.doesNotMatch(BOARD_CONTENT_CLASS_NAME, /sm:overflow-y-auto/);
+});
+
+test("mobile Kanban rail permits native horizontal and vertical gestures", () => {
+  assert.match(BOARD_KANBAN_RAIL_CLASS_NAME, /overflow-x-auto/);
+  assert.match(BOARD_KANBAN_RAIL_CLASS_NAME, /overflow-y-auto/);
+  assert.equal(BOARD_KANBAN_RAIL_TOUCH_STYLE.touchAction, "pan-x pan-y");
+  assert.equal(BOARD_KANBAN_RAIL_TOUCH_STYLE.overscrollBehaviorX, "contain");
+  assert.equal(BOARD_KANBAN_RAIL_TOUCH_STYLE.overscrollBehaviorY, "auto");
+  assert.equal(BOARD_KANBAN_RAIL_TOUCH_STYLE.WebkitOverflowScrolling, "touch");
+  assert.match(BOARD_KANBAN_RAIL_CLASS_NAME, /snap-proximity/);
+  assert.match(BOARD_KANBAN_RAIL_CLASS_NAME, /scroll-px-0\.5/);
+  assert.match(BOARD_KANBAN_COLUMN_CLASS_NAME, /snap-start/);
+  assert.match(BOARD_KANBAN_SHELL_CLASS_NAME, /xl:h-full/);
+});
+
+test("mobile columns use natural height while desktop columns own task scrolling", () => {
+  assert.match(BOARD_KANBAN_COLUMN_CLASS_NAME, /h-auto/);
+  assert.doesNotMatch(BOARD_KANBAN_COLUMN_CLASS_NAME, /max-h-/);
+  assert.match(BOARD_KANBAN_COLUMN_CLASS_NAME, /xl:h-full/);
+  assert.match(BOARD_KANBAN_COLUMN_BODY_CLASS_NAME, /flex-none/);
+  assert.match(BOARD_KANBAN_COLUMN_BODY_CLASS_NAME, /overflow-visible/);
+  assert.match(BOARD_KANBAN_COLUMN_BODY_CLASS_NAME, /xl:flex-1/);
+  assert.match(BOARD_KANBAN_COLUMN_BODY_CLASS_NAME, /xl:overflow-y-auto/);
+  assert.doesNotMatch(BOARD_KANBAN_COLUMN_BODY_CLASS_NAME, /sm:overflow-y-auto/);
+});
+
+test("WorkspaceKanban consumes the mobile layout contracts without legacy nested pan-y scrollers", () => {
+  const source = readFileSync(new URL("./WorkspaceKanban.tsx", import.meta.url), "utf8");
+
+  for (const contract of [
+    "BOARD_SCROLL_SURFACE_CLASS_NAME",
+    "BOARD_HEADER_CLASS_NAME",
+    "BOARD_CONTENT_CLASS_NAME",
+    "BOARD_KANBAN_SHELL_CLASS_NAME",
+    "BOARD_KANBAN_RAIL_CLASS_NAME",
+    "BOARD_KANBAN_RAIL_TOUCH_STYLE",
+    "BOARD_KANBAN_COLUMN_CLASS_NAME",
+    "BOARD_KANBAN_COLUMN_BODY_CLASS_NAME",
+  ]) {
+    assert.match(source, new RegExp(contract));
+  }
+
+  assert.doesNotMatch(source, /flex-1 overflow-y-auto overscroll-contain touch-pan-y sm:touch-auto/);
+  assert.doesNotMatch(source, /max-h-\[min\(560px,65dvh\)\]/);
+});
+
+test("mobile Kanban controls keep search and the primary action on one touch-friendly row", () => {
+  const source = readFileSync(new URL("./WorkspaceKanban.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /flex w-full min-w-0 flex-nowrap items-center gap-2/);
+  assert.match(source, /h-11 w-auto shrink-0 items-center justify-center gap-1/);
+  assert.doesNotMatch(source, /h-11 w-full items-center justify-center gap-1/);
+});
+
+test("mobile list controls expose a full-width 44px primary row", () => {
+  const source = readFileSync(new URL("./WorkspaceKanban.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /flex w-full min-w-0 items-center gap-2 xl:w-auto/);
+  assert.match(source, /h-11 w-11 shrink-0 items-center justify-center gap-1/);
+  assert.match(source, /relative min-w-0 flex-1 xl:w-80 xl:flex-none/);
+  assert.match(source, /h-11 w-full rounded-\[3px\].*xl:h-\[31px\]/);
+});
+
+test("board card and empty-state actions stay touch-sized through the single-pane breakpoint", () => {
+  const source = readFileSync(new URL("./WorkspaceKanban.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /h-11 w-11 items-center justify-center rounded-\[3px\].*xl:h-6 xl:w-6/);
+  assert.match(source, /min-h-11 max-w-full items-center gap-1.*xl:min-h-0/);
+  assert.match(source, /mt-4 inline-flex h-11 items-center gap-1.*xl:h-\[31px\]/);
+  assert.match(source, /ml-auto inline-flex h-11 w-11 items-center justify-center.*xl:h-7 xl:w-7/);
+  assert.doesNotMatch(source, /sm:h-6 sm:w-6/);
+});

--- a/packages/web/src/components/board/boardMobileLayout.ts
+++ b/packages/web/src/components/board/boardMobileLayout.ts
@@ -1,0 +1,38 @@
+import type { CSSProperties } from "react";
+
+/**
+ * Mobile board scrolling deliberately has one vertical owner. The whole board
+ * surface scrolls so its controls can leave the viewport; the Kanban rail only
+ * owns horizontal movement. Desktop keeps the fixed toolbar and independently
+ * scrolling columns.
+ */
+export const BOARD_SCROLL_SURFACE_CLASS_NAME =
+  "flex h-full min-h-0 min-w-0 flex-col overflow-x-hidden overflow-y-auto overscroll-y-contain touch-auto [-webkit-overflow-scrolling:touch] xl:overflow-hidden";
+
+export const BOARD_HEADER_CLASS_NAME =
+  "shrink-0 border-b border-[var(--vk-border)] px-3 py-2.5 xl:px-4 xl:py-4";
+
+export const BOARD_CONTENT_CLASS_NAME =
+  "min-h-[240px] min-w-0 flex-none overflow-visible p-3 sm:p-4 xl:min-h-0 xl:flex-1 xl:overflow-y-auto xl:overscroll-contain";
+
+export const BOARD_KANBAN_SHELL_CLASS_NAME =
+  "flex min-h-0 flex-col gap-3 xl:h-full xl:gap-4";
+
+export const BOARD_KANBAN_RAIL_CLASS_NAME =
+  "flex min-w-0 snap-x snap-proximity scroll-px-0.5 flex-row items-stretch gap-3 overflow-x-auto overflow-y-auto px-0.5 pb-3 xl:h-full xl:snap-none xl:gap-0 xl:px-0";
+
+// Inline axis-specific values intentionally win over globals.css's coarse-pointer
+// Y-axis containment. The rail contains horizontal bounce while vertical gestures
+// at its zero-range Y boundary chain to the board page.
+export const BOARD_KANBAN_RAIL_TOUCH_STYLE = {
+  WebkitOverflowScrolling: "touch",
+  touchAction: "pan-x pan-y",
+  overscrollBehaviorX: "contain",
+  overscrollBehaviorY: "auto",
+} satisfies CSSProperties;
+
+export const BOARD_KANBAN_COLUMN_CLASS_NAME =
+  "flex h-auto min-h-[280px] w-[min(85vw,320px)] shrink-0 snap-start flex-col border border-[var(--vk-border)] bg-[var(--vk-bg-main)] shadow-none xl:h-full xl:min-h-0 xl:w-[320px] xl:border-l-0 first:xl:border-l";
+
+export const BOARD_KANBAN_COLUMN_BODY_CLASS_NAME =
+  "min-h-0 flex-none overflow-visible px-3 pb-3 pt-2 xl:flex-1 xl:overflow-y-auto xl:overscroll-contain";

--- a/packages/web/src/components/bridge/BridgeStatusPill.tsx
+++ b/packages/web/src/components/bridge/BridgeStatusPill.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { ArrowUpRight, ChevronDown, Download, Laptop, Loader2, RefreshCw, Wrench } from "lucide-react";
 import { BridgeLocalRepairNotice } from "@/components/bridge/BridgeLocalRepairNotice";
+import { MobileDropdownMenuContent } from "@/components/ui/MobileDropdownMenu";
 import {
   isBridgeAutoUpdateInFlight,
   readRecentBridgePairing,
@@ -404,12 +405,10 @@ function BridgeStatusDropdown({ className }: { className?: string }) {
           />
         </button>
       </DropdownMenu.Trigger>
-      <DropdownMenu.Portal>
-        <DropdownMenu.Content
-          align="end"
-          sideOffset={8}
-          className="z-[90] w-[320px] rounded-[18px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] p-2 text-[var(--vk-text-normal)] shadow-[0_22px_48px_rgba(0,0,0,0.34)]"
-        >
+      <MobileDropdownMenuContent
+        align="end"
+        className="w-[min(320px,calc(100vw-1rem))] rounded-[18px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] p-2 text-[var(--vk-text-normal)] shadow-[0_22px_48px_rgba(0,0,0,0.34)]"
+      >
           <div className="rounded-[14px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-3 py-3">
             <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[var(--vk-text-muted)]">
               Conductor Bridge
@@ -447,7 +446,7 @@ function BridgeStatusDropdown({ className }: { className?: string }) {
             ) : null}
           </div>
 
-          <div className="mt-2 max-h-[280px] overflow-y-auto">
+          <div className="mt-2">
             {devices.length > 0 ? (
               devices.map((device) => {
                 const updateInFlight = isBridgeAutoUpdateInFlight(autoUpdate, device.device_id);
@@ -595,8 +594,7 @@ function BridgeStatusDropdown({ className }: { className?: string }) {
               <Laptop className="h-4 w-4 text-[var(--vk-text-muted)]" />
             </Link>
           </DropdownMenu.Item>
-        </DropdownMenu.Content>
-      </DropdownMenu.Portal>
+      </MobileDropdownMenuContent>
     </DropdownMenu.Root>
   );
 }

--- a/packages/web/src/components/dispatcher/DispatcherPane.tsx
+++ b/packages/web/src/components/dispatcher/DispatcherPane.tsx
@@ -10,6 +10,11 @@ import {
 } from "@/components/dispatcher/DispatcherPreferenceChips";
 import { DispatcherSessionPane } from "@/components/dispatcher/DispatcherSessionPane";
 import { Button } from "@/components/ui/Button";
+import { MobileDropdownMenuContent } from "@/components/ui/MobileDropdownMenu";
+import {
+  KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME,
+  KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME,
+} from "@/components/layout/keyboardSafeViewport";
 import {
   buildModelSelection,
   resolveModelSelectionValue,
@@ -118,14 +123,14 @@ function DeleteDispatcherThreadDialog({
 
   return createPortal(
     <div
-      className="fixed inset-0 z-[80] flex items-center justify-center bg-black/60 px-4"
+      className={`fixed ${KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME} z-[140] flex items-start justify-center overflow-y-auto bg-black/60 px-3 py-3 sm:items-center`}
       onClick={() => {
         if (deleting) return;
         onCancel();
       }}
     >
       <div
-        className="surface-card w-full max-w-md rounded-[var(--radius-lg)] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_28px_90px_rgba(0,0,0,0.55)]"
+        className={`surface-card flex ${KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME} w-full max-w-md flex-col overflow-hidden rounded-[var(--radius-lg)] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_28px_90px_rgba(0,0,0,0.55)]`}
         onClick={(event) => event.stopPropagation()}
         role="dialog"
         aria-modal="true"
@@ -143,7 +148,7 @@ function DeleteDispatcherThreadDialog({
           </p>
         </div>
 
-        <div className="space-y-3 px-4 py-4">
+        <div className="min-h-0 flex-1 space-y-3 overflow-y-auto px-4 py-4">
           <p className="text-[13px] leading-5 text-[var(--vk-text-normal)]">
             This removes the dispatcher conversation and its saved thread state. Repository files on disk are not changed.
           </p>
@@ -165,10 +170,10 @@ function DeleteDispatcherThreadDialog({
         </div>
 
         <div className="flex items-center justify-end gap-2 border-t border-[var(--vk-border)] px-4 py-3">
-          <Button type="button" variant="ghost" onClick={onCancel} disabled={deleting}>
+          <Button type="button" variant="ghost" onClick={onCancel} disabled={deleting} className="oc-mobile-touch-target">
             Cancel
           </Button>
-          <Button type="button" variant="danger" onClick={() => void onConfirm()} disabled={deleting}>
+          <Button type="button" variant="danger" onClick={() => void onConfirm()} disabled={deleting} className="oc-mobile-touch-target">
             {deleting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
             Delete Thread
           </Button>
@@ -546,17 +551,14 @@ export function DispatcherPane({
               <ListTodo className="h-3.5 w-3.5" />
             </button>
           </DropdownMenu.Trigger>
-          <DropdownMenu.Portal>
-            <DropdownMenu.Content
-              align="end"
-              collisionPadding={8}
-              sideOffset={8}
-              className="z-50 w-[calc(100vw-1rem)] max-w-[26rem] overflow-hidden rounded-[12px] border border-[rgba(255,255,255,0.08)] bg-[#1c1a19] p-2 shadow-[0_18px_50px_rgba(0,0,0,0.45)]"
-            >
+          <MobileDropdownMenuContent
+            align="end"
+            className="w-[calc(100vw-1rem)] max-w-[26rem] rounded-[12px] border border-[rgba(255,255,255,0.08)] bg-[#1c1a19] p-2 shadow-[0_18px_50px_rgba(0,0,0,0.45)]"
+          >
               <div className="px-3 pb-2 pt-1 text-[11px] font-semibold uppercase tracking-[0.08em] text-[rgba(255,255,255,0.58)]">
                 Threads
               </div>
-              <div className="max-h-[70vh] space-y-1 overflow-y-auto pr-1">
+              <div className="space-y-1 pr-1">
                 {threads.map((candidate) => {
                   const selected = candidate.id === thread.id;
                   const deleting = deletingThreadId === candidate.id;
@@ -611,8 +613,7 @@ export function DispatcherPane({
                   );
                 })}
               </div>
-            </DropdownMenu.Content>
-          </DropdownMenu.Portal>
+          </MobileDropdownMenuContent>
         </DropdownMenu.Root>
       ) : null}
       {onStartNewConversation ? (

--- a/packages/web/src/components/dispatcher/DispatcherPreferenceChips.tsx
+++ b/packages/web/src/components/dispatcher/DispatcherPreferenceChips.tsx
@@ -5,6 +5,7 @@ import type { ModelAccessPreferences } from "@conductor-oss/core/types";
 import type { ReactNode } from "react";
 import { Brain, Check, ChevronDown } from "lucide-react";
 import { AgentTileIcon } from "@/components/AgentTileIcon";
+import { MobileDropdownMenuContent } from "@/components/ui/MobileDropdownMenu";
 import { cn } from "@/lib/cn";
 import {
   getSelectableAgentModels,
@@ -77,19 +78,16 @@ function PreferenceChip({
           <ChevronDown className="h-3.5 w-3.5 shrink-0 text-[rgba(255,255,255,0.55)] sm:h-2.5 sm:w-2.5" />
         </button>
       </DropdownMenu.Trigger>
-      <DropdownMenu.Portal>
-        <DropdownMenu.Content
-          align="start"
-          collisionPadding={8}
-          sideOffset={6}
-          className={cn(
-            "z-50 max-h-[70vh] w-[calc(100vw-1rem)] max-w-[22rem] overflow-y-auto rounded-[12px] border border-[rgba(255,255,255,0.08)] bg-[#1c1a19] p-2 shadow-[0_18px_50px_rgba(0,0,0,0.45)] sm:max-h-[22rem] sm:w-auto sm:min-w-[200px] sm:max-w-[26rem] sm:rounded-[10px] sm:p-1.5",
-            contentClassName,
-          )}
-        >
+      <MobileDropdownMenuContent
+        align="start"
+        sideOffset={6}
+        className={cn(
+          "w-[calc(100vw-1rem)] max-w-[22rem] rounded-[12px] border border-[rgba(255,255,255,0.08)] bg-[#1c1a19] p-2 shadow-[0_18px_50px_rgba(0,0,0,0.45)] sm:w-auto sm:min-w-[200px] sm:max-w-[26rem] sm:rounded-[10px] sm:p-1.5",
+          contentClassName,
+        )}
+      >
           {children}
-        </DropdownMenu.Content>
-      </DropdownMenu.Portal>
+      </MobileDropdownMenuContent>
     </DropdownMenu.Root>
   );
 }

--- a/packages/web/src/components/dispatcher/DispatcherSessionPane.tsx
+++ b/packages/web/src/components/dispatcher/DispatcherSessionPane.tsx
@@ -34,6 +34,7 @@ import {
   X,
 } from "lucide-react";
 import { AgentTileIcon } from "@/components/AgentTileIcon";
+import { MobileDropdownMenuContent } from "@/components/ui/MobileDropdownMenu";
 import {
   DISPATCHER_CHAT_FEED_SCROLL_CLASS_NAME,
   DISPATCHER_CHAT_FRAME_CLASS_NAME,
@@ -1034,12 +1035,10 @@ function ProjectAgentSelect({
           {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <ChevronDown className="h-4 w-4 shrink-0" />}
         </button>
       </DropdownMenu.Trigger>
-      <DropdownMenu.Portal>
-        <DropdownMenu.Content
-          align="start"
-          sideOffset={8}
-          className="z-50 min-w-[250px] max-w-[calc(100vw-2rem)] rounded-[10px] border border-[rgba(255,255,255,0.08)] bg-[#1c1a19] p-2 shadow-[0_18px_50px_rgba(0,0,0,0.45)]"
-        >
+      <MobileDropdownMenuContent
+        align="start"
+        className="w-[calc(100vw-1rem)] min-w-0 max-w-[250px] rounded-[10px] border border-[rgba(255,255,255,0.08)] bg-[#1c1a19] p-2 shadow-[0_18px_50px_rgba(0,0,0,0.45)] sm:w-auto sm:min-w-[250px]"
+      >
           <p className="px-3 pb-1 text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--vk-text-muted)]">
             Coding agent
           </p>
@@ -1076,8 +1075,7 @@ function ProjectAgentSelect({
               </DropdownMenu.Item>
             );
           })}
-        </DropdownMenu.Content>
-      </DropdownMenu.Portal>
+      </MobileDropdownMenuContent>
     </DropdownMenu.Root>
   );
 }

--- a/packages/web/src/components/dispatcher/ProjectDispatcherPanel.tsx
+++ b/packages/web/src/components/dispatcher/ProjectDispatcherPanel.tsx
@@ -11,6 +11,10 @@ import {
   upsertDispatcherThread,
 } from "@/components/dispatcher/threadState";
 import { Button } from "@/components/ui/Button";
+import {
+  KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME,
+  KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME,
+} from "@/components/layout/keyboardSafeViewport";
 import { cn } from "@/lib/cn";
 import {
   buildModelSelection,
@@ -70,17 +74,22 @@ function CreateDispatcherConversationDialog({
   onImplementationModelSelectionChange,
 }: CreateDispatcherConversationDialogProps) {
   return (
-    <div className="fixed inset-0 z-[90] flex items-center justify-center bg-black/60 px-4">
-      <div className="w-full max-w-[720px] rounded-[14px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_28px_90px_rgba(0,0,0,0.55)]">
+    <div className={`fixed ${KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME} z-[90] flex items-start justify-center overflow-y-auto bg-black/60 px-3 py-3 sm:items-center`}>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="create-dispatcher-conversation-title"
+        className={`flex ${KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME} w-full max-w-[720px] flex-col overflow-hidden rounded-[14px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_28px_90px_rgba(0,0,0,0.55)]`}
+      >
         <div className="border-b border-[var(--vk-border)] px-5 py-4">
-          <h2 className="text-[18px] font-semibold text-[var(--vk-text-strong)]">
+          <h2 id="create-dispatcher-conversation-title" className="text-[18px] font-semibold text-[var(--vk-text-strong)]">
             Start new dispatcher conversation
           </h2>
           <p className="mt-1 text-[12px] leading-5 text-[var(--vk-text-muted)]">
             Choose the runtime agent for the conversation and the default agent for implementation handoffs.
           </p>
         </div>
-        <div className="space-y-4 px-5 py-5">
+        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto overscroll-contain px-4 py-4 [-webkit-overflow-scrolling:touch] sm:px-5 sm:py-5">
           <div className="rounded-[12px] border border-[var(--vk-border)] bg-[rgba(0,0,0,0.16)] p-3">
             <p className="mb-3 text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--vk-text-muted)]">
               Dispatcher runtime
@@ -120,10 +129,10 @@ function CreateDispatcherConversationDialog({
           ) : null}
         </div>
         <div className="flex items-center justify-end gap-2 border-t border-[var(--vk-border)] px-5 py-4">
-          <Button type="button" variant="ghost" onClick={onCancel} disabled={creating}>
+          <Button type="button" variant="ghost" onClick={onCancel} disabled={creating} className="oc-mobile-touch-target">
             Cancel
           </Button>
-          <Button type="button" onClick={onConfirm} disabled={creating}>
+          <Button type="button" onClick={onConfirm} disabled={creating} className="oc-mobile-touch-target">
             {creating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
             Start conversation
           </Button>

--- a/packages/web/src/components/layout/AppShell.tsx
+++ b/packages/web/src/components/layout/AppShell.tsx
@@ -4,15 +4,9 @@ import { useEffect, useState, type CSSProperties, type ReactNode } from "react";
 import { PanelLeftOpen, PanelRightClose } from "lucide-react";
 import { cn } from "@/lib/cn";
 import { AppUpdateNotice } from "@/components/layout/AppUpdateNotice";
+import { KeyboardSafeViewportMetricsProvider } from "@/components/layout/KeyboardSafeViewportMetricsProvider";
 import {
-  APP_SHELL_DOCUMENT_CLASS_NAME,
   KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VALUE,
-  KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VAR,
-  KEYBOARD_SAFE_VISUAL_VIEWPORT_HEIGHT_CSS_VAR,
-  KEYBOARD_SAFE_VISUAL_VIEWPORT_OFFSET_TOP_CSS_VAR,
-  resolveKeyboardSafeViewportMetrics,
-  resolveStableLayoutViewportHeight,
-  shouldResetStableLayoutViewportHeight,
 } from "@/components/layout/keyboardSafeViewport";
 
 interface AppShellProps {
@@ -82,145 +76,86 @@ export function AppShell({
     };
   }, [resizing, sidebarWidth]);
 
-  useEffect(() => {
-    const root = document.documentElement;
-    const initialVisualViewport = window.visualViewport;
-    const getLayoutViewportWidth = () => Math.max(0, window.innerWidth, root.clientWidth);
-    let stableLayoutViewportWidth = getLayoutViewportWidth();
-    let stableLayoutViewportHeight = resolveStableLayoutViewportHeight(
-      0,
-      window.innerHeight,
-      root.clientHeight,
-      initialVisualViewport?.height ?? Number.NaN,
-      initialVisualViewport?.offsetTop ?? Number.NaN,
-    );
-
-    const syncViewportMetrics = () => {
-      const visualViewport = window.visualViewport;
-      const layoutViewportWidth = getLayoutViewportWidth();
-      if (shouldResetStableLayoutViewportHeight(stableLayoutViewportWidth, layoutViewportWidth)) {
-        stableLayoutViewportHeight = 0;
-      }
-      stableLayoutViewportWidth = layoutViewportWidth;
-      stableLayoutViewportHeight = resolveStableLayoutViewportHeight(
-        stableLayoutViewportHeight,
-        window.innerHeight,
-        root.clientHeight,
-        visualViewport?.height ?? Number.NaN,
-        visualViewport?.offsetTop ?? Number.NaN,
-      );
-      const viewportMetrics = resolveKeyboardSafeViewportMetrics(
-        stableLayoutViewportHeight,
-        visualViewport?.height ?? Number.NaN,
-        visualViewport?.offsetTop ?? Number.NaN,
-      );
-      root.style.setProperty(KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VAR, `${viewportMetrics.bottom}px`);
-      root.style.setProperty(
-        KEYBOARD_SAFE_VISUAL_VIEWPORT_HEIGHT_CSS_VAR,
-        `${viewportMetrics.visibleHeight}px`,
-      );
-      root.style.setProperty(
-        KEYBOARD_SAFE_VISUAL_VIEWPORT_OFFSET_TOP_CSS_VAR,
-        `${viewportMetrics.offsetTop}px`,
-      );
-    };
-
-    root.classList.add(APP_SHELL_DOCUMENT_CLASS_NAME);
-    syncViewportMetrics();
-    const visualViewport = window.visualViewport;
-    visualViewport?.addEventListener("resize", syncViewportMetrics);
-    visualViewport?.addEventListener("scroll", syncViewportMetrics);
-    window.addEventListener("resize", syncViewportMetrics);
-
-    return () => {
-      visualViewport?.removeEventListener("resize", syncViewportMetrics);
-      visualViewport?.removeEventListener("scroll", syncViewportMetrics);
-      window.removeEventListener("resize", syncViewportMetrics);
-      root.classList.remove(APP_SHELL_DOCUMENT_CLASS_NAME);
-      root.style.removeProperty(KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VAR);
-      root.style.removeProperty(KEYBOARD_SAFE_VISUAL_VIEWPORT_HEIGHT_CSS_VAR);
-      root.style.removeProperty(KEYBOARD_SAFE_VISUAL_VIEWPORT_OFFSET_TOP_CSS_VAR);
-    };
-  }, []);
-
   const shellStyle = {
     "--workspace-sidebar-width": `${sidebarWidth}px`,
     "--oc-shell-height": KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VALUE,
   } as CSSProperties;
 
   return (
-    <div
-      style={shellStyle}
-      className="relative flex h-[var(--oc-shell-height)] min-h-[var(--oc-shell-height)] max-h-[var(--oc-shell-height)] w-full max-w-full overflow-hidden bg-[var(--vk-bg-main)] text-[var(--vk-text-normal)] [padding-top:env(safe-area-inset-top)] [padding-bottom:env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)] pr-[env(safe-area-inset-right)]"
-    >
-      {mobileSidebarOpen && (
-        <button
-          type="button"
-          className="absolute inset-0 z-20 bg-black/45 lg:hidden"
-          onClick={onToggleSidebar}
-          aria-label="Close workspace panel"
-        />
-      )}
-
-      <aside
-        className={cn(
-          "absolute inset-y-0 left-0 z-30 flex h-full w-full max-w-none flex-col border-r border-[var(--vk-border)] bg-[var(--vk-bg-panel)] transition-[transform,width] duration-200 sm:w-[min(90vw,var(--workspace-sidebar-width))] sm:max-w-[28rem]",
-          mobileSidebarOpen ? "translate-x-0" : "-translate-x-full",
-          desktopSidebarOpen
-            ? "lg:w-[var(--workspace-sidebar-width)]"
-            : "lg:w-0 lg:overflow-hidden lg:border-r-0",
-          "lg:relative lg:left-auto lg:translate-x-0",
-        )}
+    <KeyboardSafeViewportMetricsProvider lockDocumentScrolling>
+      <div
+        style={shellStyle}
+        className="relative flex h-[var(--oc-shell-height)] min-h-[var(--oc-shell-height)] max-h-[var(--oc-shell-height)] w-full max-w-full overflow-hidden bg-[var(--vk-bg-main)] text-[var(--vk-text-normal)] [padding-top:env(safe-area-inset-top)] [padding-bottom:env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)] pr-[env(safe-area-inset-right)]"
       >
-        {sidebar}
-      </aside>
+        {mobileSidebarOpen && (
+          <button
+            type="button"
+            className="absolute inset-0 z-20 bg-black/45 lg:hidden"
+            onClick={onToggleSidebar}
+            aria-label="Close workspace panel"
+          />
+        )}
 
-      {desktopSidebarOpen ? (
-        <div
-          className="absolute bottom-0 left-[var(--workspace-sidebar-width)] top-0 z-30 hidden w-2 -translate-x-1/2 cursor-col-resize lg:block"
-          onMouseDown={() => setResizing(true)}
-          aria-hidden="true"
+        <aside
+          className={cn(
+            "absolute inset-y-0 left-0 z-30 flex h-full w-full max-w-none flex-col border-r border-[var(--vk-border)] bg-[var(--vk-bg-panel)] transition-[transform,width] duration-200 sm:w-[min(90vw,var(--workspace-sidebar-width))] sm:max-w-[28rem]",
+            mobileSidebarOpen ? "translate-x-0" : "-translate-x-full",
+            desktopSidebarOpen
+              ? "lg:w-[var(--workspace-sidebar-width)]"
+              : "lg:w-0 lg:overflow-hidden lg:border-r-0",
+            "lg:relative lg:left-auto lg:translate-x-0",
+          )}
         >
-          <div className="mx-auto h-full w-px bg-transparent transition-colors hover:bg-[var(--vk-border)]" />
-        </div>
-      ) : null}
+          {sidebar}
+        </aside>
 
-      {desktopSidebarOpen && (
-        <button
-          type="button"
-          onClick={onToggleSidebar}
-          className="absolute left-[var(--workspace-sidebar-width)] top-2 z-40 hidden h-7 w-7 -translate-x-1/2 items-center justify-center rounded-[4px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] text-[var(--vk-text-muted)] shadow-[0_0_0_1px_rgba(0,0,0,0.25)] hover:bg-[var(--vk-bg-hover)] lg:inline-flex"
-          aria-label="Hide workspace panel"
-        >
-          <PanelRightClose className="h-5 w-5" />
-        </button>
-      )}
+        {desktopSidebarOpen ? (
+          <div
+            className="absolute bottom-0 left-[var(--workspace-sidebar-width)] top-0 z-30 hidden w-2 -translate-x-1/2 cursor-col-resize lg:block"
+            onMouseDown={() => setResizing(true)}
+            aria-hidden="true"
+          >
+            <div className="mx-auto h-full w-px bg-transparent transition-colors hover:bg-[var(--vk-border)]" />
+          </div>
+        ) : null}
 
-      <main className="relative flex min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden bg-[var(--vk-bg-main)]">
-        {!mobileSidebarOpen && !hideMobileSidebarToggle && (
+        {desktopSidebarOpen && (
           <button
             type="button"
             onClick={onToggleSidebar}
-            className="oc-mobile-touch-target absolute left-2 top-2 z-40 inline-flex h-11 w-11 items-center justify-center rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] text-[var(--vk-text-muted)] shadow-[0_10px_24px_rgba(0,0,0,0.28)] hover:bg-[var(--vk-bg-hover)] sm:h-8 sm:w-8 lg:hidden"
-            aria-label="Open workspace panel"
+            className="absolute left-[var(--workspace-sidebar-width)] top-2 z-40 hidden h-7 w-7 -translate-x-1/2 items-center justify-center rounded-[4px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] text-[var(--vk-text-muted)] shadow-[0_0_0_1px_rgba(0,0,0,0.25)] hover:bg-[var(--vk-bg-hover)] lg:inline-flex"
+            aria-label="Hide workspace panel"
           >
-            <PanelLeftOpen className="h-5 w-5" />
+            <PanelRightClose className="h-5 w-5" />
           </button>
         )}
-        {!desktopSidebarOpen && (
-          <button
-            type="button"
-            onClick={onToggleSidebar}
-            className="absolute left-2 top-2 z-40 hidden h-7 w-7 items-center justify-center rounded-[4px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] lg:inline-flex"
-            aria-label="Open workspace panel"
-          >
-            <PanelLeftOpen className="h-5 w-5" />
-          </button>
-        )}
-        {children}
-      </main>
 
-      <AppUpdateNotice />
-    </div>
+        <main className="relative flex min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden bg-[var(--vk-bg-main)]">
+          {!mobileSidebarOpen && !hideMobileSidebarToggle && (
+            <button
+              type="button"
+              onClick={onToggleSidebar}
+              className="oc-mobile-touch-target absolute left-2 top-2 z-40 inline-flex h-11 w-11 items-center justify-center rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] text-[var(--vk-text-muted)] shadow-[0_10px_24px_rgba(0,0,0,0.28)] hover:bg-[var(--vk-bg-hover)] sm:h-8 sm:w-8 lg:hidden"
+              aria-label="Open workspace panel"
+            >
+              <PanelLeftOpen className="h-5 w-5" />
+            </button>
+          )}
+          {!desktopSidebarOpen && (
+            <button
+              type="button"
+              onClick={onToggleSidebar}
+              className="absolute left-2 top-2 z-40 hidden h-7 w-7 items-center justify-center rounded-[4px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] lg:inline-flex"
+              aria-label="Open workspace panel"
+            >
+              <PanelLeftOpen className="h-5 w-5" />
+            </button>
+          )}
+          {children}
+        </main>
+
+        <AppUpdateNotice />
+      </div>
+    </KeyboardSafeViewportMetricsProvider>
   );
 }

--- a/packages/web/src/components/layout/AppShell.tsx
+++ b/packages/web/src/components/layout/AppShell.tsx
@@ -5,12 +5,14 @@ import { PanelLeftOpen, PanelRightClose } from "lucide-react";
 import { cn } from "@/lib/cn";
 import { AppUpdateNotice } from "@/components/layout/AppUpdateNotice";
 import {
+  APP_SHELL_DOCUMENT_CLASS_NAME,
   KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VALUE,
   KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VAR,
   KEYBOARD_SAFE_VISUAL_VIEWPORT_HEIGHT_CSS_VAR,
   KEYBOARD_SAFE_VISUAL_VIEWPORT_OFFSET_TOP_CSS_VAR,
   resolveKeyboardSafeViewportMetrics,
   resolveStableLayoutViewportHeight,
+  shouldResetStableLayoutViewportHeight,
 } from "@/components/layout/keyboardSafeViewport";
 
 interface AppShellProps {
@@ -83,6 +85,8 @@ export function AppShell({
   useEffect(() => {
     const root = document.documentElement;
     const initialVisualViewport = window.visualViewport;
+    const getLayoutViewportWidth = () => Math.max(0, window.innerWidth, root.clientWidth);
+    let stableLayoutViewportWidth = getLayoutViewportWidth();
     let stableLayoutViewportHeight = resolveStableLayoutViewportHeight(
       0,
       window.innerHeight,
@@ -93,6 +97,11 @@ export function AppShell({
 
     const syncViewportMetrics = () => {
       const visualViewport = window.visualViewport;
+      const layoutViewportWidth = getLayoutViewportWidth();
+      if (shouldResetStableLayoutViewportHeight(stableLayoutViewportWidth, layoutViewportWidth)) {
+        stableLayoutViewportHeight = 0;
+      }
+      stableLayoutViewportWidth = layoutViewportWidth;
       stableLayoutViewportHeight = resolveStableLayoutViewportHeight(
         stableLayoutViewportHeight,
         window.innerHeight,
@@ -116,6 +125,7 @@ export function AppShell({
       );
     };
 
+    root.classList.add(APP_SHELL_DOCUMENT_CLASS_NAME);
     syncViewportMetrics();
     const visualViewport = window.visualViewport;
     visualViewport?.addEventListener("resize", syncViewportMetrics);
@@ -126,6 +136,7 @@ export function AppShell({
       visualViewport?.removeEventListener("resize", syncViewportMetrics);
       visualViewport?.removeEventListener("scroll", syncViewportMetrics);
       window.removeEventListener("resize", syncViewportMetrics);
+      root.classList.remove(APP_SHELL_DOCUMENT_CLASS_NAME);
       root.style.removeProperty(KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VAR);
       root.style.removeProperty(KEYBOARD_SAFE_VISUAL_VIEWPORT_HEIGHT_CSS_VAR);
       root.style.removeProperty(KEYBOARD_SAFE_VISUAL_VIEWPORT_OFFSET_TOP_CSS_VAR);
@@ -190,7 +201,7 @@ export function AppShell({
           <button
             type="button"
             onClick={onToggleSidebar}
-            className="absolute left-2 top-2 z-40 inline-flex h-11 w-11 items-center justify-center rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] text-[var(--vk-text-muted)] shadow-[0_10px_24px_rgba(0,0,0,0.28)] hover:bg-[var(--vk-bg-hover)] sm:h-8 sm:w-8 lg:hidden"
+            className="oc-mobile-touch-target absolute left-2 top-2 z-40 inline-flex h-11 w-11 items-center justify-center rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] text-[var(--vk-text-muted)] shadow-[0_10px_24px_rgba(0,0,0,0.28)] hover:bg-[var(--vk-bg-hover)] sm:h-8 sm:w-8 lg:hidden"
             aria-label="Open workspace panel"
           >
             <PanelLeftOpen className="h-5 w-5" />

--- a/packages/web/src/components/layout/AppUpdateNotice.test.ts
+++ b/packages/web/src/components/layout/AppUpdateNotice.test.ts
@@ -37,4 +37,9 @@ test("mobile update notice collapses into a compact card instead of covering the
   assert.match(source, /compactNotice/);
   assert.match(source, /mobileExpanded/);
   assert.match(source, /Details/);
+  assert.match(source, /oc-mobile-touch-target inline-flex min-h-11 min-w-11/);
+  assert.match(source, /sm:min-h-7 sm:min-w-0 sm:px-2/);
+  assert.match(source, /Dismiss update notice/);
+  assert.match(source, /oc-mobile-touch-target inline-flex h-11 w-11/);
+  assert.match(source, /sm:h-7 sm:w-7/);
 });

--- a/packages/web/src/components/layout/AppUpdateNotice.tsx
+++ b/packages/web/src/components/layout/AppUpdateNotice.tsx
@@ -349,7 +349,7 @@ export function AppUpdateNotice() {
               <button
                 type="button"
                 onClick={() => setMobileExpanded((current) => !current)}
-                className="inline-flex min-h-[28px] items-center rounded-[7px] border border-[var(--vk-border)] px-2 text-[11px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] hover:text-[var(--vk-text-normal)]"
+                className="oc-mobile-touch-target inline-flex min-h-11 min-w-11 items-center justify-center rounded-[7px] border border-[var(--vk-border)] px-3 text-[11px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] hover:text-[var(--vk-text-normal)] sm:min-h-7 sm:min-w-0 sm:px-2"
               >
                 {showDetailedBody ? "Hide" : "Details"}
               </button>
@@ -357,7 +357,7 @@ export function AppUpdateNotice() {
             <button
               type="button"
               onClick={handleDismiss}
-              className="inline-flex h-7 w-7 items-center justify-center rounded-[7px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] hover:text-[var(--vk-text-normal)]"
+              className="oc-mobile-touch-target inline-flex h-11 w-11 items-center justify-center rounded-[7px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] hover:text-[var(--vk-text-normal)] sm:h-7 sm:w-7"
               aria-label="Dismiss update notice"
             >
               <X className="h-4 w-4" />

--- a/packages/web/src/components/layout/KeyboardSafeViewportMetricsProvider.tsx
+++ b/packages/web/src/components/layout/KeyboardSafeViewportMetricsProvider.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, type ReactNode } from "react";
+import {
+  APP_SHELL_DOCUMENT_CLASS_NAME,
+  KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VAR,
+  KEYBOARD_SAFE_VISUAL_VIEWPORT_HEIGHT_CSS_VAR,
+  KEYBOARD_SAFE_VISUAL_VIEWPORT_OFFSET_TOP_CSS_VAR,
+  resolveKeyboardSafeViewportMetrics,
+  resolveStableLayoutViewportHeight,
+  shouldResetStableLayoutViewportHeight,
+} from "@/components/layout/keyboardSafeViewport";
+
+type KeyboardSafeViewportMetricsProviderProps = {
+  children: ReactNode;
+  lockDocumentScrolling?: boolean;
+};
+
+export function KeyboardSafeViewportMetricsProvider({
+  children,
+  lockDocumentScrolling = false,
+}: KeyboardSafeViewportMetricsProviderProps) {
+  useEffect(() => {
+    const root = document.documentElement;
+    const initialVisualViewport = window.visualViewport;
+    const getLayoutViewportWidth = () => Math.max(0, window.innerWidth, root.clientWidth);
+    let stableLayoutViewportWidth = getLayoutViewportWidth();
+    let stableLayoutViewportHeight = resolveStableLayoutViewportHeight(
+      0,
+      window.innerHeight,
+      root.clientHeight,
+      initialVisualViewport?.height ?? Number.NaN,
+      initialVisualViewport?.offsetTop ?? Number.NaN,
+    );
+
+    const syncViewportMetrics = () => {
+      const visualViewport = window.visualViewport;
+      const layoutViewportWidth = getLayoutViewportWidth();
+      if (shouldResetStableLayoutViewportHeight(stableLayoutViewportWidth, layoutViewportWidth)) {
+        stableLayoutViewportHeight = 0;
+      }
+      stableLayoutViewportWidth = layoutViewportWidth;
+      stableLayoutViewportHeight = resolveStableLayoutViewportHeight(
+        stableLayoutViewportHeight,
+        window.innerHeight,
+        root.clientHeight,
+        visualViewport?.height ?? Number.NaN,
+        visualViewport?.offsetTop ?? Number.NaN,
+      );
+      const viewportMetrics = resolveKeyboardSafeViewportMetrics(
+        stableLayoutViewportHeight,
+        visualViewport?.height ?? Number.NaN,
+        visualViewport?.offsetTop ?? Number.NaN,
+      );
+      root.style.setProperty(KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VAR, `${viewportMetrics.bottom}px`);
+      root.style.setProperty(
+        KEYBOARD_SAFE_VISUAL_VIEWPORT_HEIGHT_CSS_VAR,
+        `${viewportMetrics.visibleHeight}px`,
+      );
+      root.style.setProperty(
+        KEYBOARD_SAFE_VISUAL_VIEWPORT_OFFSET_TOP_CSS_VAR,
+        `${viewportMetrics.offsetTop}px`,
+      );
+    };
+
+    if (lockDocumentScrolling) {
+      root.classList.add(APP_SHELL_DOCUMENT_CLASS_NAME);
+    }
+    syncViewportMetrics();
+    const visualViewport = window.visualViewport;
+    visualViewport?.addEventListener("resize", syncViewportMetrics);
+    visualViewport?.addEventListener("scroll", syncViewportMetrics);
+    window.addEventListener("resize", syncViewportMetrics);
+
+    return () => {
+      visualViewport?.removeEventListener("resize", syncViewportMetrics);
+      visualViewport?.removeEventListener("scroll", syncViewportMetrics);
+      window.removeEventListener("resize", syncViewportMetrics);
+      if (lockDocumentScrolling) {
+        root.classList.remove(APP_SHELL_DOCUMENT_CLASS_NAME);
+      }
+      root.style.removeProperty(KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VAR);
+      root.style.removeProperty(KEYBOARD_SAFE_VISUAL_VIEWPORT_HEIGHT_CSS_VAR);
+      root.style.removeProperty(KEYBOARD_SAFE_VISUAL_VIEWPORT_OFFSET_TOP_CSS_VAR);
+    };
+  }, [lockDocumentScrolling]);
+
+  return children;
+}

--- a/packages/web/src/components/layout/Sidebar.tsx
+++ b/packages/web/src/components/layout/Sidebar.tsx
@@ -330,7 +330,7 @@ export function Sidebar({
             <button
               type="button"
               onClick={onCreateWorkspace}
-              className="ml-auto inline-flex h-5 w-5 items-center justify-center rounded-[3px] text-[var(--vk-orange)] hover:bg-[var(--vk-bg-hover)] lg:hidden"
+              className="oc-mobile-touch-target ml-auto inline-flex h-11 w-11 items-center justify-center rounded-[3px] text-[var(--vk-orange)] hover:bg-[var(--vk-bg-hover)] sm:h-8 sm:w-8 lg:hidden"
               aria-label="New workspace"
             >
               <span className="text-[14px]">+</span>
@@ -341,11 +341,11 @@ export function Sidebar({
 
       <div
         className={cn(
-          "flex h-[38px] items-center px-2 pb-1.5",
+          "flex h-[46px] items-center px-2 pb-1.5 sm:h-[38px]",
           !showHeader && "pt-1.5"
         )}
       >
-        <label className="flex h-[38px] flex-1 items-center rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] px-2 sm:h-[30px]">
+        <label className="oc-mobile-touch-target flex h-11 flex-1 items-center rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] px-2 sm:h-[30px]">
           <Search className="h-3.5 w-3.5 text-[var(--vk-text-muted)]" />
           <input
             value={search}
@@ -455,7 +455,7 @@ export function Sidebar({
                       onClick={(event) => void handleArchive(event, session.id)}
                       disabled={isArchiving}
                       className={cn(
-                        "mt-0.5 inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-[6px] border border-[var(--vk-border)] text-[var(--vk-text-muted)] transition sm:h-7 sm:w-7",
+                        "oc-mobile-touch-target mt-0.5 inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-[6px] border border-[var(--vk-border)] text-[var(--vk-text-muted)] transition sm:h-7 sm:w-7",
                         "opacity-70 group-hover:opacity-100 focus-visible:opacity-100",
                         "hover:border-[var(--vk-border)] hover:bg-[var(--vk-bg-hover)] hover:text-[var(--vk-text-normal)]",
                         isArchiving && "cursor-wait opacity-100"

--- a/packages/web/src/components/layout/Sidebar.tsx
+++ b/packages/web/src/components/layout/Sidebar.tsx
@@ -324,7 +324,7 @@ export function Sidebar({
   return (
     <div className="flex h-full min-h-0 flex-col">
       {showHeader && (
-        <div className="flex h-[33px] items-center gap-1 px-2">
+        <div className="flex h-11 items-center gap-1 px-2 sm:h-[33px]">
           <p className="text-[16px] text-[var(--vk-text-normal)]">Workspaces</p>
           {onCreateWorkspace && (
             <button

--- a/packages/web/src/components/layout/TopBar.tsx
+++ b/packages/web/src/components/layout/TopBar.tsx
@@ -12,7 +12,7 @@ interface TopBarProps {
 
 export const TopBar = memo(function TopBar({ title, onOpenPreferences, rightContent }: TopBarProps) {
   return (
-    <header className="flex h-[33px] items-center border-b border-[var(--vk-border)] bg-[var(--vk-bg-panel)] pl-14 pr-2 text-[12px] text-[var(--vk-text-muted)] sm:pl-5 sm:pr-5 sm:text-[13px]">
+    <header className="oc-mobile-touch-target flex h-11 shrink-0 items-center border-b border-[var(--vk-border)] bg-[var(--vk-bg-panel)] pl-14 pr-2 text-[12px] text-[var(--vk-text-muted)] sm:h-[33px] sm:pl-5 sm:pr-5 sm:text-[13px]">
       <div className="min-w-0 flex-1 text-left sm:text-center">
         <span className="block truncate font-medium tracking-[0.01em] text-[var(--vk-text-muted)]">
           {title ?? "All Projects"}
@@ -28,7 +28,7 @@ export const TopBar = memo(function TopBar({ title, onOpenPreferences, rightCont
           href={CONDUCTOR_SUPPORT_DISCUSSIONS_URL}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-[4px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] hover:text-[var(--vk-text-normal)]"
+          className="oc-mobile-touch-target inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-[4px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] hover:text-[var(--vk-text-normal)] sm:h-8 sm:w-8"
           aria-label="Open Conductor support"
           title="Support"
         >
@@ -38,7 +38,7 @@ export const TopBar = memo(function TopBar({ title, onOpenPreferences, rightCont
           <button
             type="button"
             onClick={onOpenPreferences}
-            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-[4px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] hover:text-[var(--vk-text-normal)]"
+            className="oc-mobile-touch-target inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-[4px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] hover:text-[var(--vk-text-normal)] sm:h-8 sm:w-8"
             aria-label="Open preferences"
             title="Preferences"
           >

--- a/packages/web/src/components/layout/WorkspaceSidebarPanel.tsx
+++ b/packages/web/src/components/layout/WorkspaceSidebarPanel.tsx
@@ -7,6 +7,10 @@ import { cn } from "@/lib/cn";
 import { getAttentionLevel, type DashboardSession } from "@/lib/types";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { Button } from "@/components/ui/Button";
+import {
+  KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME,
+  KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME,
+} from "@/components/layout/keyboardSafeViewport";
 
 interface ProjectItem {
   id: string;
@@ -31,6 +35,7 @@ interface WorkspaceSidebarPanelProps {
   }) => void;
   onArchiveSession?: (sessionId: string) => Promise<void> | void;
   onCreateWorkspace: () => void;
+  onCloseMobile?: () => void;
 }
 
 export const WorkspaceSidebarPanel = memo(function WorkspaceSidebarPanel({
@@ -46,6 +51,7 @@ export const WorkspaceSidebarPanel = memo(function WorkspaceSidebarPanel({
   onSelectSession,
   onArchiveSession,
   onCreateWorkspace,
+  onCloseMobile,
 }: WorkspaceSidebarPanelProps) {
   const [unlinkingId, setUnlinkingId] = useState<string | null>(null);
   const [confirmUnlinkProjectId, setConfirmUnlinkProjectId] = useState<string | null>(null);
@@ -109,17 +115,27 @@ export const WorkspaceSidebarPanel = memo(function WorkspaceSidebarPanel({
   return (
     <>
       <div className="flex h-full min-h-0 w-full flex-col bg-[var(--vk-bg-panel)]">
-        <section className="border-b border-[var(--vk-border)] px-4 py-4">
+        <section className="relative border-b border-[var(--vk-border)] px-4 py-4">
           <div className="flex justify-center text-center">
             <p className="font-brand-header text-[22px] font-bold leading-none uppercase tracking-[0.32em] text-[var(--vk-text-strong)]">
               Conductor
             </p>
           </div>
+          {onCloseMobile ? (
+            <button
+              type="button"
+              onClick={onCloseMobile}
+              className="oc-mobile-touch-target absolute right-4 top-4 inline-flex h-11 w-11 items-center justify-center rounded-[4px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] hover:text-[var(--vk-text-normal)] lg:hidden"
+              aria-label="Close workspace panel"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          ) : null}
 
           <button
             type="button"
             onClick={onCreateWorkspace}
-            className="mt-3 inline-flex h-11 w-full items-center justify-center gap-1 rounded-[6px] border border-[var(--vk-border)] px-2 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] sm:h-8"
+            className="oc-mobile-touch-target mt-3 inline-flex h-11 w-full items-center justify-center gap-1 rounded-[6px] border border-[var(--vk-border)] px-2 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] sm:h-8"
             aria-label="Add workspace"
           >
             <Plus className="h-3.5 w-3.5" />
@@ -136,7 +152,7 @@ export const WorkspaceSidebarPanel = memo(function WorkspaceSidebarPanel({
               type="button"
               onClick={() => onSelectProject(null)}
               className={cn(
-                "mb-1.5 flex w-full items-center gap-3 rounded-[6px] px-3 py-2.5 text-left text-[14px] leading-[21px]",
+                "oc-mobile-touch-target mb-1.5 flex min-h-11 w-full items-center gap-3 rounded-[6px] px-3 py-2.5 text-left text-[14px] leading-[21px] sm:min-h-0",
                 selectedProjectId === null
                   ? "bg-[var(--vk-bg-hover)] text-[var(--vk-text-normal)]"
                   : "text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)]",
@@ -192,7 +208,7 @@ export const WorkspaceSidebarPanel = memo(function WorkspaceSidebarPanel({
                     type="button"
                     onClick={() => onSelectProject(project.id)}
                     className={cn(
-                      "flex min-w-0 flex-1 items-center gap-3 px-3 py-2.5 text-left text-[14px] leading-[21px]",
+                      "oc-mobile-touch-target flex min-h-11 min-w-0 flex-1 items-center gap-3 px-3 py-2.5 text-left text-[14px] leading-[21px] sm:min-h-0",
                       selected
                         ? "text-[var(--vk-text-normal)]"
                         : "text-[var(--vk-text-muted)]",
@@ -226,7 +242,7 @@ export const WorkspaceSidebarPanel = memo(function WorkspaceSidebarPanel({
                         setUnlinkError(null);
                         setConfirmUnlinkProjectId(project.id);
                       }}
-                      className="mr-2 inline-flex shrink-0 items-center justify-center rounded-[4px] p-1 text-[var(--vk-text-muted)] hover:bg-[var(--vk-red)]/10 hover:text-[var(--vk-red)] disabled:opacity-50"
+                      className="oc-mobile-touch-target mr-1 inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-[4px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-red)]/10 hover:text-[var(--vk-red)] disabled:opacity-50 sm:mr-2 sm:h-7 sm:w-7"
                       aria-label={`Unlink ${project.id}`}
                       title="Unlink project"
                     >
@@ -254,7 +270,7 @@ export const WorkspaceSidebarPanel = memo(function WorkspaceSidebarPanel({
       {confirmUnlinkProject && typeof document !== "undefined"
         ? createPortal(
           <div
-            className="fixed inset-0 z-[80] flex items-center justify-center bg-black/60 px-4"
+            className={`fixed ${KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME} z-[140] flex items-start justify-center overflow-y-auto bg-black/60 px-3 py-3 sm:items-center`}
             onClick={() => {
               if (unlinkingId) return;
               setConfirmUnlinkProjectId(null);
@@ -262,7 +278,7 @@ export const WorkspaceSidebarPanel = memo(function WorkspaceSidebarPanel({
             }}
           >
             <div
-              className="surface-card w-full max-w-md rounded-[var(--radius-lg)] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_28px_90px_rgba(0,0,0,0.55)]"
+              className={`surface-card flex ${KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME} w-full max-w-md flex-col overflow-hidden rounded-[var(--radius-lg)] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_28px_90px_rgba(0,0,0,0.55)]`}
               onClick={(event) => event.stopPropagation()}
               role="dialog"
               aria-modal="true"
@@ -277,7 +293,7 @@ export const WorkspaceSidebarPanel = memo(function WorkspaceSidebarPanel({
                 </p>
               </div>
 
-              <div className="space-y-3 px-4 py-4">
+              <div className="min-h-0 flex-1 space-y-3 overflow-y-auto px-4 py-4">
                 <p className="text-[13px] leading-5 text-[var(--vk-text-normal)]">
                   This only removes the project from Conductor. Repository files on disk are not deleted.
                 </p>
@@ -298,6 +314,7 @@ export const WorkspaceSidebarPanel = memo(function WorkspaceSidebarPanel({
                     setUnlinkError(null);
                   }}
                   disabled={unlinkingId !== null}
+                  className="oc-mobile-touch-target"
                 >
                   Cancel
                 </Button>
@@ -306,6 +323,7 @@ export const WorkspaceSidebarPanel = memo(function WorkspaceSidebarPanel({
                   variant="danger"
                   onClick={() => void handleConfirmUnlink()}
                   disabled={unlinkingId !== null}
+                  className="oc-mobile-touch-target"
                 >
                   {unlinkingId === confirmUnlinkProject.id ? "Unlinking..." : "Unlink Project"}
                 </Button>

--- a/packages/web/src/components/layout/keyboardSafeViewport.test.ts
+++ b/packages/web/src/components/layout/keyboardSafeViewport.test.ts
@@ -105,14 +105,13 @@ test("keyboard-safe viewport css helpers expose literal Tailwind-detectable cont
   );
 });
 
-test("AppShell writes and cleans up every shared keyboard-safe viewport css variable", () => {
-  const source = readFileSync(new URL("./AppShell.tsx", import.meta.url), "utf8");
+test("viewport metrics provider writes and cleans up every shared keyboard-safe viewport css variable", () => {
+  const source = readFileSync(new URL("./KeyboardSafeViewportMetricsProvider.tsx", import.meta.url), "utf8");
 
   assert.match(source, /resolveStableLayoutViewportHeight/);
   assert.match(source, /shouldResetStableLayoutViewportHeight/);
   assert.match(source, /resolveKeyboardSafeViewportMetrics/);
-  assert.match(source, /classList\.add\(APP_SHELL_DOCUMENT_CLASS_NAME\)/);
-  assert.match(source, /classList\.remove\(APP_SHELL_DOCUMENT_CLASS_NAME\)/);
+  assert.match(source, /lockDocumentScrolling/);
   for (const cssVarName of [
     "KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VAR",
     "KEYBOARD_SAFE_VISUAL_VIEWPORT_HEIGHT_CSS_VAR",
@@ -121,6 +120,18 @@ test("AppShell writes and cleans up every shared keyboard-safe viewport css vari
     assert.match(source, new RegExp(`setProperty\\(\\s*${cssVarName}`));
     assert.match(source, new RegExp(`removeProperty\\(${cssVarName}\\)`));
   }
+});
+
+test("AppShell and PublicPageShell both reuse the shared viewport metrics provider", () => {
+  const appShellSource = readFileSync(new URL("./AppShell.tsx", import.meta.url), "utf8");
+  const publicShellSource = readFileSync(new URL("../public/PublicPageShell.tsx", import.meta.url), "utf8");
+
+  assert.match(appShellSource, /KeyboardSafeViewportMetricsProvider/);
+  assert.match(appShellSource, /lockDocumentScrolling/);
+  assert.match(publicShellSource, /KeyboardSafeViewportMetricsProvider/);
+  assert.match(publicShellSource, /KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VALUE/);
+  assert.match(publicShellSource, /style=\{\{ height: KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VALUE \}\}/);
+  assert.doesNotMatch(publicShellSource, /className="h-\[100dvh\]/);
 });
 
 test("app shell locks only dashboard document scrolling and opts into safe-area viewport coverage", () => {

--- a/packages/web/src/components/layout/keyboardSafeViewport.test.ts
+++ b/packages/web/src/components/layout/keyboardSafeViewport.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
+  APP_SHELL_DOCUMENT_CLASS_NAME,
   KEYBOARD_SAFE_VIEWPORT_DIALOG_MAX_HEIGHT_CLASS_NAME,
   KEYBOARD_SAFE_VIEWPORT_FRAME_CLASS_NAME,
   KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VALUE,
@@ -15,6 +16,7 @@ import {
   resolveKeyboardSafeViewportHeight,
   resolveKeyboardSafeViewportMetrics,
   resolveStableLayoutViewportHeight,
+  shouldResetStableLayoutViewportHeight,
 } from "./keyboardSafeViewport";
 
 test("stable layout height survives keyboard-driven innerHeight shrinkage", () => {
@@ -25,6 +27,18 @@ test("stable layout height survives keyboard-driven innerHeight shrinkage", () =
     resolveStableLayoutViewportHeight(844, 600, 600, Number.NaN, Number.NaN),
     600,
   );
+});
+
+test("stable layout height follows a normal visual viewport contraction", () => {
+  assert.equal(resolveStableLayoutViewportHeight(844, 600, 600, 600, 0), 600);
+  assert.equal(resolveStableLayoutViewportHeight(844, 390, 390, 390, 0), 390);
+});
+
+test("layout width changes reset a keyboard-panned stable viewport", () => {
+  assert.equal(shouldResetStableLayoutViewportHeight(390, 844), true);
+  assert.equal(shouldResetStableLayoutViewportHeight(390.4, 390.3), false);
+  assert.equal(shouldResetStableLayoutViewportHeight(0, 390), false);
+  assert.equal(shouldResetStableLayoutViewportHeight(Number.NaN, 390), false);
 });
 
 test("keyboard-safe viewport metrics fill through the visual viewport bottom edge", () => {
@@ -95,7 +109,10 @@ test("AppShell writes and cleans up every shared keyboard-safe viewport css vari
   const source = readFileSync(new URL("./AppShell.tsx", import.meta.url), "utf8");
 
   assert.match(source, /resolveStableLayoutViewportHeight/);
+  assert.match(source, /shouldResetStableLayoutViewportHeight/);
   assert.match(source, /resolveKeyboardSafeViewportMetrics/);
+  assert.match(source, /classList\.add\(APP_SHELL_DOCUMENT_CLASS_NAME\)/);
+  assert.match(source, /classList\.remove\(APP_SHELL_DOCUMENT_CLASS_NAME\)/);
   for (const cssVarName of [
     "KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VAR",
     "KEYBOARD_SAFE_VISUAL_VIEWPORT_HEIGHT_CSS_VAR",
@@ -104,6 +121,16 @@ test("AppShell writes and cleans up every shared keyboard-safe viewport css vari
     assert.match(source, new RegExp(`setProperty\\(\\s*${cssVarName}`));
     assert.match(source, new RegExp(`removeProperty\\(${cssVarName}\\)`));
   }
+});
+
+test("app shell locks only dashboard document scrolling and opts into safe-area viewport coverage", () => {
+  const globalStyles = readFileSync(new URL("../../app/globals.css", import.meta.url), "utf8");
+  const layoutSource = readFileSync(new URL("../../app/layout.tsx", import.meta.url), "utf8");
+
+  assert.equal(APP_SHELL_DOCUMENT_CLASS_NAME, "conductor-app-shell-active");
+  assert.match(globalStyles, /html\.conductor-app-shell-active body/);
+  assert.match(globalStyles, /overflow-y:\s*hidden/);
+  assert.match(layoutSource, /viewportFit:\s*"cover"/);
 });
 
 test("dashboard dialogs use shared keyboard-safe frames for mobile forms", () => {

--- a/packages/web/src/components/layout/keyboardSafeViewport.ts
+++ b/packages/web/src/components/layout/keyboardSafeViewport.ts
@@ -1,6 +1,7 @@
 export const KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VAR = "--oc-safe-viewport-height";
 export const KEYBOARD_SAFE_VISUAL_VIEWPORT_HEIGHT_CSS_VAR = "--oc-visual-viewport-height";
 export const KEYBOARD_SAFE_VISUAL_VIEWPORT_OFFSET_TOP_CSS_VAR = "--oc-visual-viewport-offset-top";
+export const APP_SHELL_DOCUMENT_CLASS_NAME = "conductor-app-shell-active";
 
 export const KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VALUE = "var(--oc-safe-viewport-height,100dvh)";
 export const KEYBOARD_SAFE_VISUAL_VIEWPORT_HEIGHT_CSS_VALUE = "var(--oc-visual-viewport-height,100dvh)";
@@ -45,6 +46,16 @@ export function resolveStableLayoutViewportHeight(
   const safeOffsetTop = Number.isFinite(visualViewportOffsetTop)
     ? Math.max(0, visualViewportOffsetTop)
     : 0;
+
+  // With no obscured area above the visual viewport, follow the current
+  // layout size. Retaining the largest height forever makes the app stay
+  // portrait-height after rotation and prevents short-window resizing.
+  // A positive offset still uses the stable maximum below so a panned
+  // keyboard viewport keeps its original layout bottom as the reference.
+  if (safeOffsetTop === 0) {
+    return Math.round(currentLayoutHeight);
+  }
+
   const candidates = [previousHeight, currentLayoutHeight, visualViewportHeight + safeOffsetTop];
 
   return Math.round(
@@ -53,6 +64,22 @@ export function resolveStableLayoutViewportHeight(
       ...candidates.map((value) => (Number.isFinite(value) ? Math.max(0, value) : 0)),
     ),
   );
+}
+
+export function shouldResetStableLayoutViewportHeight(
+  previousLayoutWidth: number,
+  currentLayoutWidth: number,
+): boolean {
+  if (
+    !Number.isFinite(previousLayoutWidth)
+    || !Number.isFinite(currentLayoutWidth)
+    || previousLayoutWidth <= 0
+    || currentLayoutWidth <= 0
+  ) {
+    return false;
+  }
+
+  return Math.round(previousLayoutWidth) !== Math.round(currentLayoutWidth);
 }
 
 export function resolveKeyboardSafeViewportMetrics(

--- a/packages/web/src/components/layout/mobileShellLayout.test.ts
+++ b/packages/web/src/components/layout/mobileShellLayout.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+test("app shell owns a bounded safe-area viewport rather than document scrolling", () => {
+  const source = readFileSync(new URL("./AppShell.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /h-\[var\(--oc-shell-height\)\]/);
+  assert.match(source, /max-h-\[var\(--oc-shell-height\)\]/);
+  assert.match(source, /overflow-hidden/);
+  assert.match(source, /safe-area-inset-top/);
+  assert.match(source, /safe-area-inset-bottom/);
+});
+
+test("inactive mounted session workspaces cannot swallow mobile touch gestures", () => {
+  const dashboardSource = readFileSync(
+    new URL("../../features/dashboard/DashboardClient.tsx", import.meta.url),
+    "utf8",
+  );
+  const sessionSource = readFileSync(new URL("../sessions/SessionDetail.tsx", import.meta.url), "utf8");
+
+  assert.match(dashboardSource, /pointer-events-none absolute inset-0 overflow-hidden opacity-0 select-none/);
+  assert.match(sessionSource, /data-\[state=inactive\]:pointer-events-none/);
+  assert.match(sessionSource, /data-\[state=active\]:z-10/);
+  assert.match(sessionSource, /data-\[state=inactive\]:z-0/);
+});
+
+test("primary tabs retain 44px mobile targets and compact desktop sizing", () => {
+  const tabsSource = readFileSync(new URL("../ui/Tabs.tsx", import.meta.url), "utf8");
+  const sessionSource = readFileSync(new URL("../sessions/SessionDetail.tsx", import.meta.url), "utf8");
+
+  assert.match(tabsSource, /min-h-11/);
+  assert.match(tabsSource, /oc-mobile-touch-target/);
+  assert.match(tabsSource, /sm:min-h-\[34px\]/);
+  assert.match(sessionSource, /tabTriggerClass = "min-h-11/);
+  assert.doesNotMatch(sessionSource, /tabTriggerClass = "[^"]*sm:min-h-0/);
+});
+
+test("mobile workspace sidebar controls use finger-sized targets", () => {
+  const sidebarSource = readFileSync(new URL("./Sidebar.tsx", import.meta.url), "utf8");
+  const workspaceSidebarSource = readFileSync(
+    new URL("./WorkspaceSidebarPanel.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(sidebarSource, /<label className="oc-mobile-touch-target flex h-11/);
+  assert.match(sidebarSource, /inline-flex h-11 w-11[^\n]*sm:h-7 sm:w-7/);
+  assert.match(workspaceSidebarSource, /flex min-h-11 w-full/);
+  assert.match(workspaceSidebarSource, /inline-flex h-11 w-11/);
+  assert.match(workspaceSidebarSource, /aria-label="Close workspace panel"/);
+  assert.match(workspaceSidebarSource, /absolute right-4 top-4 inline-flex h-11 w-11/);
+});
+
+test("top bar contains its 44px mobile menu targets", () => {
+  const source = readFileSync(new URL("./TopBar.tsx", import.meta.url), "utf8");
+  const dashboardSource = readFileSync(
+    new URL("../../features/dashboard/DashboardClient.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(source, /<header className="oc-mobile-touch-target flex h-11 shrink-0/);
+  assert.match(source, /sm:h-\[33px\]/);
+  assert.match(source, /inline-flex h-11 w-11[^\n]*sm:h-8 sm:w-8/);
+  assert.match(dashboardSource, /className=\{`hidden items-center[^`]*sm:inline-flex \$\{scopeBadgeClassName\}`\}/);
+});

--- a/packages/web/src/components/notes/NotesGraph.tsx
+++ b/packages/web/src/components/notes/NotesGraph.tsx
@@ -466,7 +466,7 @@ export function NotesGraph({
           <button
             type="button"
             onClick={() => setSettingsOpen((current) => !current)}
-            className="inline-flex min-h-[32px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-2.5 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)]"
+            className="oc-mobile-touch-target inline-flex min-h-11 items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-2.5 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] sm:min-h-[32px]"
           >
             <Settings2 className="h-3.5 w-3.5" />
             Settings
@@ -474,7 +474,7 @@ export function NotesGraph({
           <button
             type="button"
             onClick={() => void fetchGraph()}
-            className="inline-flex min-h-[32px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-2.5 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)]"
+            className="oc-mobile-touch-target inline-flex min-h-11 items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-2.5 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] sm:min-h-[32px]"
           >
             <Network className="h-3.5 w-3.5" />
             Refresh
@@ -702,7 +702,7 @@ export function NotesGraph({
                     <button
                       type="button"
                       onClick={() => onNavigate(focusedNode.id)}
-                      className="inline-flex min-h-[32px] items-center gap-1.5 rounded-[8px] border border-[var(--vk-accent)] bg-[rgba(139,92,246,0.16)] px-3 text-[12px] text-[var(--vk-text-strong)] hover:bg-[rgba(139,92,246,0.22)]"
+                      className="oc-mobile-touch-target inline-flex min-h-11 items-center gap-1.5 rounded-[8px] border border-[var(--vk-accent)] bg-[rgba(139,92,246,0.16)] px-3 text-[12px] text-[var(--vk-text-strong)] hover:bg-[rgba(139,92,246,0.22)] sm:min-h-[32px]"
                     >
                       <ArrowUpRight className="h-3.5 w-3.5" />
                       Open note
@@ -713,7 +713,7 @@ export function NotesGraph({
                         setFocusedNodeId(focusedNode.id);
                         setLocalGraphEnabled(true);
                       }}
-                      className="inline-flex min-h-[32px] items-center gap-1.5 rounded-[8px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)]"
+                      className="oc-mobile-touch-target inline-flex min-h-11 items-center gap-1.5 rounded-[8px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] sm:min-h-[32px]"
                     >
                       <LocateFixed className="h-3.5 w-3.5" />
                       Use as local root
@@ -748,7 +748,7 @@ export function NotesGraph({
               title="Zoom out"
               aria-label="Zoom out"
               onClick={() => zoomAtPoint(transform.k * 0.88)}
-              className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-[color:rgba(148,163,184,0.16)] bg-black/35 text-[var(--vk-text-normal)] hover:bg-black/55"
+              className="oc-mobile-touch-target inline-flex h-11 w-11 items-center justify-center rounded-full border border-[color:rgba(148,163,184,0.16)] bg-black/35 text-[var(--vk-text-normal)] hover:bg-black/55 sm:h-9 sm:w-9"
             >
               <ZoomOut className="h-4 w-4" />
             </button>
@@ -757,7 +757,7 @@ export function NotesGraph({
               title="Zoom in"
               aria-label="Zoom in"
               onClick={() => zoomAtPoint(transform.k * 1.12)}
-              className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-[color:rgba(148,163,184,0.16)] bg-black/35 text-[var(--vk-text-normal)] hover:bg-black/55"
+              className="oc-mobile-touch-target inline-flex h-11 w-11 items-center justify-center rounded-full border border-[color:rgba(148,163,184,0.16)] bg-black/35 text-[var(--vk-text-normal)] hover:bg-black/55 sm:h-9 sm:w-9"
             >
               <ZoomIn className="h-4 w-4" />
             </button>
@@ -766,7 +766,7 @@ export function NotesGraph({
               title="Fit graph"
               aria-label="Fit graph"
               onClick={() => setTransform(getFittedTransform(layout.nodes, viewport.width, viewport.height))}
-              className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-[color:rgba(148,163,184,0.16)] bg-black/35 text-[var(--vk-text-normal)] hover:bg-black/55"
+              className="oc-mobile-touch-target inline-flex h-11 w-11 items-center justify-center rounded-full border border-[color:rgba(148,163,184,0.16)] bg-black/35 text-[var(--vk-text-normal)] hover:bg-black/55 sm:h-9 sm:w-9"
             >
               <LocateFixed className="h-4 w-4" />
             </button>

--- a/packages/web/src/components/notes/NotesToolbar.tsx
+++ b/packages/web/src/components/notes/NotesToolbar.tsx
@@ -13,6 +13,7 @@ import {
   Send,
   TriangleAlert,
 } from "lucide-react";
+import { MobileDropdownMenuContent } from "@/components/ui/MobileDropdownMenu";
 
 import type { ViewMode } from "./types";
 
@@ -38,9 +39,9 @@ interface NotesToolbarProps {
   onOpenShare?: () => void;
 }
 
-const BUTTON_CLASS_NAME = "inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-60";
+const BUTTON_CLASS_NAME = "oc-mobile-touch-target inline-flex min-h-11 items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-60 sm:min-h-[34px]";
 const SEGMENT_CLASS_NAME = "inline-flex rounded-[6px] border border-[var(--vk-border)] p-0.5 text-[12px]";
-const MENU_CONTENT_CLASS_NAME = "z-[120] min-w-[190px] rounded-[10px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] p-1 shadow-[0_20px_48px_rgba(0,0,0,0.35)]";
+const MENU_CONTENT_CLASS_NAME = "min-w-[190px] rounded-[10px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] p-1 shadow-[0_20px_48px_rgba(0,0,0,0.35)]";
 const MENU_ITEM_CLASS_NAME = "flex min-h-[36px] cursor-default items-center gap-2 rounded-[6px] px-3 text-[12px] text-[var(--vk-text-normal)] outline-none hover:bg-[var(--vk-bg-hover)] focus:bg-[var(--vk-bg-hover)] data-[disabled]:pointer-events-none data-[disabled]:opacity-45";
 
 function ViewModeSwitcher({
@@ -63,7 +64,7 @@ function ViewModeSwitcher({
           key={mode}
           type="button"
           onClick={() => onViewModeChange(mode)}
-          className={`rounded-[4px] px-3 py-1.5 ${
+          className={`oc-mobile-touch-target min-h-11 rounded-[4px] px-3 py-1.5 sm:min-h-0 ${
             viewMode === mode
               ? "bg-[var(--vk-bg-active)] text-[var(--vk-text-strong)]"
               : "text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)]"
@@ -117,7 +118,7 @@ export function NotesToolbar({
           <button
             type="button"
             onClick={onToggleGraph}
-            className={`inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border px-3 text-[12px] hover:bg-[var(--vk-bg-hover)] ${
+            className={`oc-mobile-touch-target inline-flex min-h-11 items-center gap-1.5 rounded-[6px] border px-3 text-[12px] hover:bg-[var(--vk-bg-hover)] sm:min-h-[34px] ${
               graphOpen
                 ? "border-[var(--vk-accent)] bg-[rgba(139,92,246,0.12)] text-[var(--vk-accent)]"
                 : "border-[var(--vk-border)] text-[var(--vk-text-normal)]"
@@ -134,8 +135,7 @@ export function NotesToolbar({
                 More
               </button>
             </DropdownMenu.Trigger>
-            <DropdownMenu.Portal>
-              <DropdownMenu.Content align="end" sideOffset={8} className={MENU_CONTENT_CLASS_NAME}>
+            <MobileDropdownMenuContent align="end" className={MENU_CONTENT_CLASS_NAME}>
                 <DropdownMenu.Item onSelect={onRefresh} className={MENU_ITEM_CLASS_NAME} disabled={indexLoading}>
                   {indexLoading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCcw className="h-3.5 w-3.5" />}
                   Refresh
@@ -158,8 +158,7 @@ export function NotesToolbar({
                   <Send className="h-3.5 w-3.5" />
                   Share note
                 </DropdownMenu.Item>
-              </DropdownMenu.Content>
-            </DropdownMenu.Portal>
+            </MobileDropdownMenuContent>
           </DropdownMenu.Root>
 
           {dirty ? (
@@ -198,7 +197,7 @@ export function NotesToolbar({
           <button
             type="button"
             onClick={onToggleGraph}
-            className={`inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border px-3 text-[12px] hover:bg-[var(--vk-bg-hover)] ${
+            className={`oc-mobile-touch-target inline-flex min-h-11 items-center gap-1.5 rounded-[6px] border px-3 text-[12px] hover:bg-[var(--vk-bg-hover)] sm:min-h-[34px] ${
               graphOpen
                 ? "border-[var(--vk-accent)] bg-[rgba(139,92,246,0.12)] text-[var(--vk-accent)]"
                 : "border-[var(--vk-border)] text-[var(--vk-text-normal)]"

--- a/packages/web/src/components/notes/ProjectNotesWorkspace.tsx
+++ b/packages/web/src/components/notes/ProjectNotesWorkspace.tsx
@@ -662,14 +662,14 @@ export function ProjectNotesWorkspace({
               value={newNotePath}
               onChange={(e) => setNewNotePath(e.target.value)}
               placeholder="New note path, e.g. architecture/overview.md"
-              className="min-h-[34px] min-w-0 rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-3 text-[12px] text-[var(--vk-text-normal)] outline-none placeholder:text-[var(--vk-text-muted)] sm:min-w-[260px]"
+              className="oc-mobile-touch-target min-h-11 min-w-0 rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-3 text-[12px] text-[var(--vk-text-normal)] outline-none placeholder:text-[var(--vk-text-muted)] sm:min-h-[34px] sm:min-w-[260px]"
               onKeyDown={(e) => { if (e.key === "Enter") void handleCreateNote(); }}
             />
             <button
               type="button"
               onClick={() => void handleCreateNote()}
               disabled={creatingNote || newNotePath.trim().length === 0 || !supportedLocalNotes}
-              className="inline-flex min-h-[34px] items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-60"
+              className="oc-mobile-touch-target inline-flex min-h-11 items-center gap-1.5 rounded-[6px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)] disabled:opacity-60 sm:min-h-[34px]"
             >
               {creatingNote ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <BookText className="h-3.5 w-3.5" />}
               New note

--- a/packages/web/src/components/notes/QuickSwitcher.tsx
+++ b/packages/web/src/components/notes/QuickSwitcher.tsx
@@ -3,6 +3,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { Search, FileText } from "lucide-react";
+import {
+  KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME,
+  KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME,
+} from "@/components/layout/keyboardSafeViewport";
 import { fuzzyMatch } from "./utils";
 
 interface QuickSwitcherProps {
@@ -95,8 +99,12 @@ export function QuickSwitcher({
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
-        <Dialog.Content className="fixed left-1/2 top-[20%] z-50 w-full max-w-lg -translate-x-1/2 rounded-[12px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_20px_48px_rgba(0,0,0,0.3)]">
+        <Dialog.Overlay className={`fixed ${KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME} z-[140] bg-black/50`} />
+        <Dialog.Content className={`fixed inset-x-3 top-[calc(var(--oc-visual-viewport-offset-top,0px)+0.75rem)] z-[141] flex ${KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME} flex-col overflow-hidden rounded-[12px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_20px_48px_rgba(0,0,0,0.3)] sm:left-1/2 sm:right-auto sm:top-[calc(var(--oc-visual-viewport-offset-top,0px)+10vh)] sm:w-[min(32rem,calc(100vw-2rem))] sm:-translate-x-1/2`}>
+          <Dialog.Title className="sr-only">Switch note</Dialog.Title>
+          <Dialog.Description className="sr-only">
+            Search for a note and open it in the notes workspace.
+          </Dialog.Description>
           {/* Search input */}
           <div className="flex items-center gap-3 border-b border-[var(--vk-border)] px-4 py-3">
             <Search className="h-4 w-4 shrink-0 text-[var(--vk-text-muted)]" />
@@ -114,7 +122,7 @@ export function QuickSwitcher({
           </div>
 
           {/* Results */}
-          <div ref={listRef} className="max-h-[320px] overflow-auto py-1">
+          <div ref={listRef} className="min-h-0 flex-1 overflow-y-auto overscroll-contain py-1 [-webkit-overflow-scrolling:touch]">
             {results.length === 0 ? (
               <div className="px-4 py-6 text-center text-[13px] text-[var(--vk-text-muted)]">
                 No notes found
@@ -127,7 +135,7 @@ export function QuickSwitcher({
                   data-index={idx}
                   onClick={() => handleSelect(file.path)}
                   onMouseEnter={() => setSelectedIndex(idx)}
-                  className={`flex w-full items-center gap-2.5 px-4 py-2 text-left text-[13px] ${
+                  className={`flex min-h-11 w-full touch-manipulation items-center gap-2.5 px-4 py-2 text-left text-[13px] ${
                     idx === selectedIndex
                       ? "bg-[var(--vk-bg-active)] text-[var(--vk-text-strong)]"
                       : "text-[var(--vk-text-normal)] hover:bg-[var(--vk-bg-hover)]"

--- a/packages/web/src/components/notes/notesMobileLayout.test.ts
+++ b/packages/web/src/components/notes/notesMobileLayout.test.ts
@@ -11,6 +11,7 @@ test("project notes workspace keeps a compact mobile mode with dedicated file an
   assert.match(source, /compactViewport/);
   assert.match(source, /<Dialog\.Root open=\{mobileSidebarOpen\}/);
   assert.match(source, /<Dialog\.Root open=\{mobileShareOpen\}/);
+  assert.match(source, /oc-mobile-touch-target min-h-11 min-w-0/);
 });
 
 test("notes toolbar exposes a compact actions menu for mobile", () => {
@@ -21,6 +22,8 @@ test("notes toolbar exposes a compact actions menu for mobile", () => {
   assert.match(source, /Files/);
   assert.match(source, /More/);
   assert.match(source, /Share note/);
+  assert.match(source, /BUTTON_CLASS_NAME = "oc-mobile-touch-target[^\n]*min-h-11/);
+  assert.ok((source.match(/oc-mobile-touch-target/g) ?? []).length >= 4);
 });
 
 test("notes graph exposes obsidian-style search, groups, local graph, and force controls", () => {
@@ -34,4 +37,5 @@ test("notes graph exposes obsidian-style search, groups, local graph, and force 
   assert.match(source, /Node size/);
   assert.match(source, /showArrows/);
   assert.match(source, /Zoom in/);
+  assert.ok((source.match(/oc-mobile-touch-target/g) ?? []).length >= 7);
 });

--- a/packages/web/src/components/public/PublicPageShell.tsx
+++ b/packages/web/src/components/public/PublicPageShell.tsx
@@ -2,6 +2,8 @@
 
 import Image from "next/image";
 import type { ReactNode } from "react";
+import { KeyboardSafeViewportMetricsProvider } from "@/components/layout/KeyboardSafeViewportMetricsProvider";
+import { KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VALUE } from "@/components/layout/keyboardSafeViewport";
 import { cn } from "@/lib/cn";
 
 type PublicPageShellProps = {
@@ -11,29 +13,34 @@ type PublicPageShellProps = {
 
 export function PublicPageShell({ children, className }: PublicPageShellProps) {
   return (
-    <main className="h-[100dvh] overflow-x-hidden overflow-y-auto bg-[var(--bg-canvas)] text-[var(--text-strong)]">
-      <div className="mx-auto flex min-h-full w-full max-w-6xl flex-col px-6 py-8 sm:px-8 sm:py-10">
-        <header className="flex items-center gap-3 border-b border-[var(--border-soft)] pb-6">
-          <img
-            src="/icon.svg"
-            alt="Conductor icon"
-            width={40}
-            height={40}
-            className="h-10 w-10 rounded-[10px] border border-[var(--border-soft)] bg-[var(--bg-panel)] p-1.5"
-          />
-          <Image
-            src="/brand/conductor-wordmark-dark.png"
-            alt="Conductor"
-            width={320}
-            height={62}
-            priority
-            className="h-auto w-[168px] sm:w-[220px]"
-          />
-        </header>
+    <KeyboardSafeViewportMetricsProvider>
+      <main
+        className="overflow-x-hidden overflow-y-auto bg-[var(--bg-canvas)] text-[var(--text-strong)]"
+        style={{ height: KEYBOARD_SAFE_VIEWPORT_HEIGHT_CSS_VALUE }}
+      >
+        <div className="mx-auto flex min-h-full w-full max-w-6xl flex-col px-6 py-8 sm:px-8 sm:py-10">
+          <header className="flex items-center gap-3 border-b border-[var(--border-soft)] pb-6">
+            <img
+              src="/icon.svg"
+              alt="Conductor icon"
+              width={40}
+              height={40}
+              className="h-10 w-10 rounded-[10px] border border-[var(--border-soft)] bg-[var(--bg-panel)] p-1.5"
+            />
+            <Image
+              src="/brand/conductor-wordmark-dark.png"
+              alt="Conductor"
+              width={320}
+              height={62}
+              priority
+              className="h-auto w-[168px] sm:w-[220px]"
+            />
+          </header>
 
-        <div className={cn("flex-1 py-10 sm:py-12", className)}>{children}</div>
-      </div>
-    </main>
+          <div className={cn("flex-1 py-10 sm:py-12", className)}>{children}</div>
+        </div>
+      </main>
+    </KeyboardSafeViewportMetricsProvider>
   );
 }
 

--- a/packages/web/src/components/sessions/SessionDetail.tsx
+++ b/packages/web/src/components/sessions/SessionDetail.tsx
@@ -293,7 +293,7 @@ export function SessionDetail({
   const immersiveTerminalActive = active && immersiveMobileMode && activeTab === "terminal";
   const previewTabActive = active && activeTab === "preview";
   const reviewTabActive = active && activeTab === "diff";
-  const tabTriggerClass = "min-h-[38px] gap-1.5 px-2.5 text-[12px] sm:min-h-0 sm:px-3";
+  const tabTriggerClass = "min-h-11 gap-1.5 px-2.5 text-[12px] sm:min-h-[34px] sm:px-3";
   const compactDisplaySessionId = getDisplaySessionId(sessionId).slice(0, 7);
 
   const sessionTabs = (

--- a/packages/web/src/components/sessions/SessionProjectOpenMenu.tsx
+++ b/packages/web/src/components/sessions/SessionProjectOpenMenu.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { Check, ChevronDown, ExternalLink, Loader2, Settings2 } from "lucide-react";
+import { MobileDropdownMenuContent } from "@/components/ui/MobileDropdownMenu";
 import { withBridgeQuery } from "@/lib/bridgeQuery";
 import { usePreferences } from "@/hooks/usePreferences";
 import { cn } from "@/lib/cn";
@@ -96,7 +97,7 @@ export function SessionProjectOpenMenu({
     }
   }
 
-  const menuClass = "z-50 min-w-[240px] rounded-[8px] border border-[rgba(255,255,255,0.08)] bg-[#1c1a19] p-2 shadow-[0_18px_50px_rgba(0,0,0,0.45)]";
+  const menuClass = "w-[calc(100vw-1rem)] min-w-0 rounded-[8px] border border-[rgba(255,255,255,0.08)] bg-[#1c1a19] p-2 shadow-[0_18px_50px_rgba(0,0,0,0.45)] sm:w-auto sm:min-w-[240px]";
   const menuItemClass = "flex min-h-[44px] cursor-default items-center gap-3 rounded-[6px] px-3 py-2 text-[14px] text-[#f3efea] outline-none transition hover:bg-[rgba(255,255,255,0.06)] focus:bg-[rgba(255,255,255,0.06)]";
 
   return (
@@ -121,8 +122,7 @@ export function SessionProjectOpenMenu({
           <ChevronDown className="h-3.5 w-3.5 text-current" />
         </button>
       </DropdownMenu.Trigger>
-      <DropdownMenu.Portal>
-        <DropdownMenu.Content align="end" sideOffset={8} className={menuClass}>
+      <MobileDropdownMenuContent align="end" className={menuClass}>
           {IDE_OPTIONS.map((option) => (
             <DropdownMenu.Item
               key={option.id}
@@ -136,8 +136,7 @@ export function SessionProjectOpenMenu({
               ) : null}
             </DropdownMenu.Item>
           ))}
-        </DropdownMenu.Content>
-      </DropdownMenu.Portal>
+      </MobileDropdownMenuContent>
     </DropdownMenu.Root>
   );
 }

--- a/packages/web/src/components/sessions/sessionMobileScroll.test.ts
+++ b/packages/web/src/components/sessions/sessionMobileScroll.test.ts
@@ -74,6 +74,26 @@ test("preview screen restores app surface scroll ownership", () => {
   assert.match(source, /lg:grid/);
 });
 
+test("skills screen keeps one app-level mobile scroller", () => {
+  const source = readFileSync(new URL("./SessionSkills.tsx", import.meta.url), "utf8");
+
+  assert.match(source, /APP_SURFACE_SCROLL_CLASS_NAME/);
+  assert.match(source, /lg:overflow-y-auto/);
+  assert.doesNotMatch(source, /className={`[^`]*\soverflow-y-auto\s[^`]*\$\{MOBILE_MOMENTUM_SCROLL_CLASS_NAME\}/);
+});
+
+test("workspace overview lets the page, not the recent-session card, scroll on mobile", () => {
+  const source = readFileSync(
+    new URL("../../features/dashboard/components/WorkspaceOverview.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(source, /APP_SURFACE_SCROLL_CLASS_NAME/);
+  assert.match(source, /lg:overflow-y-auto/);
+  assert.doesNotMatch(source, /gap-2 overflow-y-auto \$\{MOBILE_MOMENTUM_SCROLL_CLASS_NAME\}/);
+  assert.match(source, /lg:h-full lg:min-h-0 lg:flex-1/);
+});
+
 test("session detail keeps active tabs above hidden live surfaces", () => {
   const source = readFileSync(new URL("./SessionDetail.tsx", import.meta.url), "utf8");
 

--- a/packages/web/src/components/ui/Button.tsx
+++ b/packages/web/src/components/ui/Button.tsx
@@ -35,7 +35,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       <Comp
         ref={ref}
         className={cn(
-          "inline-flex items-center justify-center rounded-[var(--radius-sm)] border font-medium",
+          "oc-mobile-touch-target inline-flex items-center justify-center rounded-[var(--radius-sm)] border font-medium",
           "transition-colors duration-150",
           "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--vk-orange)]",
           "disabled:pointer-events-none disabled:opacity-45",

--- a/packages/web/src/components/ui/MobileDropdownMenu.test.ts
+++ b/packages/web/src/components/ui/MobileDropdownMenu.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { extname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+  MOBILE_DROPDOWN_COLLISION_PADDING,
+  MOBILE_DROPDOWN_CONTENT_CLASS_NAME,
+  MOBILE_DROPDOWN_LAYER_CLASS_NAME,
+  MOBILE_DROPDOWN_MAX_HEIGHT,
+  MOBILE_DROPDOWN_MAX_WIDTH,
+} from "./MobileDropdownMenu";
+
+test("mobile dropdown surfaces stay above dialogs and inside the visual viewport", () => {
+  assert.equal(MOBILE_DROPDOWN_LAYER_CLASS_NAME, "z-[160]");
+  assert.ok(MOBILE_DROPDOWN_COLLISION_PADDING >= 12);
+  assert.match(MOBILE_DROPDOWN_CONTENT_CLASS_NAME, /overflow-y-auto/);
+  assert.match(MOBILE_DROPDOWN_CONTENT_CLASS_NAME, /overscroll-contain/);
+  assert.match(MOBILE_DROPDOWN_CONTENT_CLASS_NAME, /touch-pan-y/);
+  assert.match(MOBILE_DROPDOWN_MAX_HEIGHT, /--radix-dropdown-menu-content-available-height/);
+  assert.match(MOBILE_DROPDOWN_MAX_HEIGHT, /--oc-visual-viewport-height/);
+  assert.match(MOBILE_DROPDOWN_MAX_HEIGHT, /safe-area-inset-top/);
+  assert.match(MOBILE_DROPDOWN_MAX_HEIGHT, /safe-area-inset-bottom/);
+  assert.match(MOBILE_DROPDOWN_MAX_WIDTH, /--radix-dropdown-menu-content-available-width/);
+  assert.match(MOBILE_DROPDOWN_MAX_WIDTH, /safe-area-inset-left/);
+  assert.match(MOBILE_DROPDOWN_MAX_WIDTH, /safe-area-inset-right/);
+});
+
+test("mobile coarse pointers receive full-size menu and native select targets", () => {
+  const source = readFileSync(new URL("../../app/globals.css", import.meta.url), "utf8");
+
+  assert.match(
+    source,
+    /@media \(max-width: 767px\), \(pointer: coarse\) \{[\s\S]*?input:not\([\s\S]*?textarea,[\s\S]*?select \{[^}]*font-size:\s*16px !important/s,
+  );
+  assert.match(source, /button\[aria-haspopup="menu"\]/);
+  assert.match(source, /\.oc-mobile-menu-content \[role="menuitem"\]/);
+  assert.match(source, /min-height:\s*44px/);
+  assert.match(source, /select\s*\{[^}]*min-height:\s*44px/s);
+});
+
+test("coarse-pointer overflow containment stays on each scroller's owned axis", () => {
+  const source = readFileSync(new URL("../../app/globals.css", import.meta.url), "utf8");
+
+  assert.match(source, /\.overflow-x-auto\s*\{[^}]*overscroll-behavior-x:\s*contain/s);
+  assert.match(source, /\.overflow-y-auto\s*\{[^}]*overscroll-behavior-y:\s*contain/s);
+  assert.match(source, /\.overflow-auto\s*\{[^}]*overscroll-behavior:\s*contain/s);
+  assert.doesNotMatch(source, /\.overflow-x-auto\s*\{[^}]*overscroll-behavior:\s*contain/s);
+  assert.doesNotMatch(source, /\.overflow-y-auto\s*\{[^}]*overscroll-behavior:\s*contain/s);
+});
+
+function collectSourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return collectSourceFiles(path);
+    return [".ts", ".tsx"].includes(extname(entry.name)) ? [path] : [];
+  });
+}
+
+test("every application dropdown uses the shared portaled mobile content contract", () => {
+  const sourceRoot = fileURLToPath(new URL("../..", import.meta.url));
+  const directRadixContentUsers = collectSourceFiles(sourceRoot).filter((path) => {
+    if (path.endsWith("MobileDropdownMenu.tsx")) return false;
+    const source = readFileSync(path, "utf8");
+    return /<DropdownMenu\.(?:Portal|Content)\b/.test(source);
+  });
+
+  assert.deepEqual(directRadixContentUsers, []);
+});
+
+test("critical mobile dialogs and launch toggles use visual viewport and touch contracts", () => {
+  const dispatcherDialogSource = readFileSync(
+    new URL("../dispatcher/ProjectDispatcherPanel.tsx", import.meta.url),
+    "utf8",
+  );
+  const quickSwitcherSource = readFileSync(
+    new URL("../notes/QuickSwitcher.tsx", import.meta.url),
+    "utf8",
+  );
+  const dashboardSource = readFileSync(
+    new URL("../../features/dashboard/DashboardClient.tsx", import.meta.url),
+    "utf8",
+  );
+  const dashboardDialogsSource = readFileSync(
+    new URL("../../features/dashboard/components/DashboardDialogs.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(dispatcherDialogSource, /KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME/);
+  assert.match(dispatcherDialogSource, /KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME/);
+  assert.match(dispatcherDialogSource, /overflow-y-auto overscroll-contain/);
+  assert.match(quickSwitcherSource, /KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME/);
+  assert.match(quickSwitcherSource, /KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME/);
+  assert.doesNotMatch(quickSwitcherSource, /top-\[20%\]/);
+  assert.doesNotMatch(dashboardSource, /avoidCollisions=\{false\}/);
+  assert.ok((dashboardSource.match(/oc-mobile-touch-target/g) ?? []).length >= 8);
+  assert.match(dashboardSource, /min-h-11 w-full resize-none bg-transparent pr-24/);
+  assert.match(dashboardSource, /oc-mobile-touch-target absolute right-11[^\n]*h-11 w-11/);
+  assert.match(dashboardSource, /oc-mobile-touch-target absolute right-0[^\n]*h-11 w-11/);
+  assert.match(
+    dashboardDialogsSource,
+    /z-\[90\][^`]*overflow-hidden[^`]*px-0 py-0[^`]*sm:overflow-y-auto/,
+  );
+  assert.doesNotMatch(
+    dashboardDialogsSource,
+    /z-\[90\][^`]*overflow-y-auto bg-black\/70 px-3 py-3/,
+  );
+});

--- a/packages/web/src/components/ui/MobileDropdownMenu.tsx
+++ b/packages/web/src/components/ui/MobileDropdownMenu.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import {
+  forwardRef,
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  type CSSProperties,
+} from "react";
+import { cn } from "@/lib/cn";
+
+/**
+ * Menus are portaled to document.body, so this layer must remain above every
+ * application dialog/sheet (currently capped at z-[141]). Keeping the layer in
+ * one place prevents a menu from opening invisibly behind its owning surface.
+ */
+export const MOBILE_DROPDOWN_LAYER_CLASS_NAME = "z-[160]";
+export const MOBILE_DROPDOWN_COLLISION_PADDING = 16;
+
+export const MOBILE_DROPDOWN_CONTENT_CLASS_NAME = [
+  "oc-mobile-menu-content",
+  MOBILE_DROPDOWN_LAYER_CLASS_NAME,
+  "overflow-y-auto overscroll-contain touch-pan-y [-webkit-overflow-scrolling:touch]",
+  "outline-none",
+].join(" ");
+
+export const MOBILE_DROPDOWN_MAX_HEIGHT =
+  "min(var(--radix-dropdown-menu-content-available-height), max(0px, calc(var(--oc-visual-viewport-height, 100dvh) - max(1rem, env(safe-area-inset-top)) - max(1rem, env(safe-area-inset-bottom)))))";
+
+export const MOBILE_DROPDOWN_MAX_WIDTH =
+  "min(var(--radix-dropdown-menu-content-available-width), max(0px, calc(100vw - max(0.5rem, env(safe-area-inset-left)) - max(0.5rem, env(safe-area-inset-right)))))";
+
+type MobileDropdownMenuContentProps = ComponentPropsWithoutRef<typeof DropdownMenu.Content>;
+
+export const MobileDropdownMenuContent = forwardRef<
+  ComponentRef<typeof DropdownMenu.Content>,
+  MobileDropdownMenuContentProps
+>(function MobileDropdownMenuContent(
+  {
+    children,
+    className,
+    collisionPadding = MOBILE_DROPDOWN_COLLISION_PADDING,
+    sideOffset = 8,
+    hideWhenDetached = true,
+    style,
+    ...props
+  },
+  ref,
+) {
+  const viewportSafeStyle: CSSProperties = {
+    ...style,
+    maxHeight: MOBILE_DROPDOWN_MAX_HEIGHT,
+    maxWidth: MOBILE_DROPDOWN_MAX_WIDTH,
+  };
+
+  return (
+    <DropdownMenu.Portal>
+      <DropdownMenu.Content
+        ref={ref}
+        collisionPadding={collisionPadding}
+        sideOffset={sideOffset}
+        hideWhenDetached={hideWhenDetached}
+        className={cn(className, MOBILE_DROPDOWN_CONTENT_CLASS_NAME)}
+        style={viewportSafeStyle}
+        {...props}
+      >
+        {children}
+      </DropdownMenu.Content>
+    </DropdownMenu.Portal>
+  );
+});
+
+MobileDropdownMenuContent.displayName = "MobileDropdownMenuContent";

--- a/packages/web/src/components/ui/Tabs.tsx
+++ b/packages/web/src/components/ui/Tabs.tsx
@@ -28,7 +28,7 @@ export const TabsTrigger = forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex min-h-[34px] shrink-0 items-center gap-1.5 rounded-[3px] px-2.5 py-1.5 text-[12px] text-[var(--vk-text-muted)]",
+      "oc-mobile-touch-target inline-flex min-h-11 shrink-0 items-center gap-1.5 rounded-[3px] px-2.5 py-1.5 text-[12px] text-[var(--vk-text-muted)] sm:min-h-[34px]",
       "data-[state=active]:bg-[var(--vk-bg-active)] data-[state=active]:text-[var(--vk-text-normal)]",
       "hover:text-[var(--vk-text-normal)]",
       "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--vk-orange)]",

--- a/packages/web/src/features/bridge/BridgeConnectClient.tsx
+++ b/packages/web/src/features/bridge/BridgeConnectClient.tsx
@@ -22,6 +22,10 @@ import { PublicPageShell } from "@/components/public/PublicPageShell";
 import { SessionTerminal } from "@/components/sessions/SessionTerminal";
 import { Button } from "@/components/ui/Button";
 import {
+  KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME,
+  KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME,
+} from "@/components/layout/keyboardSafeViewport";
+import {
   isBridgeAutoUpdateInFlight,
   readRecentBridgePairing,
   runBridgeAutoUpdate,
@@ -1474,7 +1478,7 @@ export default function BridgeConnectClient({
       </PublicPageShell>
 
       {testConnectionOpen ? (
-        <div className="fixed inset-0 z-[85] flex items-start justify-center overflow-y-auto bg-black/70 px-3 py-3 sm:items-center sm:py-0">
+        <div className={`fixed ${KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME} z-[140] flex items-start justify-center overflow-y-auto bg-black/70 px-3 py-3 sm:items-center sm:py-0`}>
           <button
             type="button"
             className="absolute inset-0"
@@ -1487,7 +1491,7 @@ export default function BridgeConnectClient({
             role="dialog"
             aria-modal="true"
             aria-labelledby="bridge-test-title"
-            className="relative z-10 flex max-h-[92vh] w-full max-w-6xl flex-col overflow-hidden rounded-[24px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_28px_80px_rgba(0,0,0,0.4)]"
+            className={`relative z-10 flex ${KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME} w-full max-w-6xl flex-col overflow-hidden rounded-[24px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_28px_80px_rgba(0,0,0,0.4)]`}
           >
             <div className="flex flex-col gap-4 border-b border-[var(--vk-border)] px-5 py-5 sm:flex-row sm:items-start sm:justify-between">
               <div>

--- a/packages/web/src/features/dashboard/DashboardClient.tsx
+++ b/packages/web/src/features/dashboard/DashboardClient.tsx
@@ -73,6 +73,7 @@ import { TopBar } from "@/components/layout/TopBar";
 import { BridgeStatusPill } from "@/components/bridge/BridgeStatusPill";
 import { shouldUseCompactTerminalChrome } from "@/components/sessions/sessionTerminalUtils";
 import { AgentTileIcon } from "@/components/AgentTileIcon";
+import { MobileDropdownMenuContent } from "@/components/ui/MobileDropdownMenu";
 import { uploadProjectAttachments } from "@/components/sessions/attachmentUploads";
 import { DISPATCHER_DESKTOP_XL_MEDIA_QUERY } from "@/components/dispatcher/dispatcherMobileLayout";
 import { withBridgeQuery } from "@/lib/bridgeQuery";
@@ -2056,9 +2057,11 @@ export default function DashboardClient({
         onSelectSession={handleSelectSession}
         onArchiveSession={handleArchiveSession}
         onCreateWorkspace={openWorkspaceDialog}
+        onCloseMobile={closeSidebarOnMobile}
       />
     );
   }, [
+    closeSidebarOnMobile,
     dashboardSessions,
     configError,
     configLoading,
@@ -2212,7 +2215,7 @@ export default function DashboardClient({
           type="button"
           aria-pressed={workspaceView === "direct"}
           onClick={() => navigateDashboard({ projectId: selectedProject.id, workspaceView: "direct" }, "replace")}
-          className={`${compact ? "min-h-[30px] px-3 text-[12px]" : "min-h-[32px] px-3 text-[13px]"} flex-1 rounded-[4px] ${
+          className={`${compact ? "min-h-11 px-3 text-[12px] sm:min-h-[30px]" : "min-h-11 px-3 text-[13px] sm:min-h-[32px]"} oc-mobile-touch-target flex-1 touch-manipulation rounded-[4px] ${
             workspaceView === "direct"
               ? "bg-[var(--vk-bg-active)] text-[var(--vk-text-strong)]"
               : "text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)]"
@@ -2224,7 +2227,7 @@ export default function DashboardClient({
           type="button"
           aria-pressed={workspaceView === "board"}
           onClick={() => navigateDashboard({ projectId: selectedProject.id, workspaceView: "board" }, "replace")}
-          className={`${compact ? "min-h-[30px] px-3 text-[12px]" : "min-h-[32px] px-3 text-[13px]"} flex-1 rounded-[4px] ${
+          className={`${compact ? "min-h-11 px-3 text-[12px] sm:min-h-[30px]" : "min-h-11 px-3 text-[13px] sm:min-h-[32px]"} oc-mobile-touch-target flex-1 touch-manipulation rounded-[4px] ${
             workspaceView === "board"
               ? "bg-[var(--vk-bg-active)] text-[var(--vk-text-strong)]"
               : "text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)]"
@@ -2236,7 +2239,7 @@ export default function DashboardClient({
           type="button"
           aria-pressed={workspaceView === "notes"}
           onClick={() => navigateDashboard({ projectId: selectedProject.id, workspaceView: "notes" }, "replace")}
-          className={`${compact ? "min-h-[30px] px-3 text-[12px]" : "min-h-[32px] px-3 text-[13px]"} flex-1 rounded-[4px] ${
+          className={`${compact ? "min-h-11 px-3 text-[12px] sm:min-h-[30px]" : "min-h-11 px-3 text-[13px] sm:min-h-[32px]"} oc-mobile-touch-target flex-1 touch-manipulation rounded-[4px] ${
             workspaceView === "notes"
               ? "bg-[var(--vk-bg-active)] text-[var(--vk-text-strong)]"
               : "text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)]"
@@ -2263,7 +2266,7 @@ export default function DashboardClient({
           }}
           aria-pressed={workspaceView === "board" && boardMobilePane === "board"}
           className={`inline-flex flex-1 items-center justify-center rounded-[4px] font-medium transition-colors ${
-            compact ? "min-h-[30px] gap-1 px-2.5 text-[11px]" : "min-h-[34px] gap-1.5 px-3 text-[12px]"
+            compact ? "oc-mobile-touch-target min-h-11 gap-1 px-2.5 text-[11px] sm:min-h-[30px]" : "oc-mobile-touch-target min-h-11 gap-1.5 px-3 text-[12px] sm:min-h-[34px]"
           } ${
             workspaceView === "board" && boardMobilePane === "board"
               ? "bg-[var(--vk-bg-active)] text-[var(--vk-text-strong)]"
@@ -2281,7 +2284,7 @@ export default function DashboardClient({
           }}
           aria-pressed={workspaceView === "board" && boardMobilePane === "chat"}
           className={`inline-flex flex-1 items-center justify-center rounded-[4px] font-medium transition-colors ${
-            compact ? "min-h-[30px] gap-1 px-2.5 text-[11px]" : "min-h-[34px] gap-1.5 px-3 text-[12px]"
+            compact ? "oc-mobile-touch-target min-h-11 gap-1 px-2.5 text-[11px] sm:min-h-[30px]" : "oc-mobile-touch-target min-h-11 gap-1.5 px-3 text-[12px] sm:min-h-[34px]"
           } ${
             workspaceView === "board" && boardMobilePane === "chat"
               ? "bg-[var(--vk-bg-active)] text-[var(--vk-text-strong)]"
@@ -2559,7 +2562,7 @@ export default function DashboardClient({
             rightContent={(
               <>
                 <span
-                  className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium ${scopeBadgeClassName}`}
+                  className={`hidden items-center rounded-full border px-2 py-0.5 text-[11px] font-medium sm:inline-flex ${scopeBadgeClassName}`}
                   title={scopeBadgeTitle}
                 >
                   {scopeBadgeLabel}
@@ -2887,7 +2890,7 @@ const CreateWorkspacePanel = memo(function CreateWorkspacePanel({
     if (selectedReasoningValue) return selectedReasoningValue;
     return availableReasoningOptions[0]?.label ?? "Default";
   }, [availableReasoningOptions, selectedReasoningValue]);
-  const lightMenuClass = "z-50 min-w-[240px] max-w-[calc(100vw-32px)] rounded-[4px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] p-2 shadow-[0_18px_50px_rgba(0,0,0,0.35)] sm:max-w-none";
+  const lightMenuClass = "w-[calc(100vw-2rem)] min-w-0 rounded-[4px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] p-2 shadow-[0_18px_50px_rgba(0,0,0,0.35)] sm:w-auto sm:min-w-[240px] sm:max-w-none";
   const scrollMenuClass = `${lightMenuClass} max-h-[min(360px,50vh)] overflow-y-auto`;
   const lightMenuItemClass = "flex min-h-[44px] cursor-default items-center gap-2 rounded-[3px] px-3 py-2 text-[14px] leading-[21px] text-[var(--vk-text-normal)] outline-none hover:bg-[var(--vk-bg-hover)] focus:bg-[var(--vk-bg-hover)] sm:min-h-[36px]";
   const permissionOptions: Array<{ id: CreatePermissionMode; label: string; icon: LucideIcon }> = [
@@ -3066,12 +3069,11 @@ const CreateWorkspacePanel = memo(function CreateWorkspacePanel({
                   </button>
                 </DropdownMenu.Trigger>
 
-                <DropdownMenu.Portal>
-                  <DropdownMenu.Content
-                    align="start"
-                    sideOffset={6}
-                    className={scrollMenuClass}
-                  >
+                <MobileDropdownMenuContent
+                  align="start"
+                  sideOffset={6}
+                  className={scrollMenuClass}
+                >
                     <p className="px-3 pb-1 text-[14px] font-semibold leading-[21px] text-[var(--vk-text-muted)]">
                       Agents
                     </p>
@@ -3100,8 +3102,7 @@ const CreateWorkspacePanel = memo(function CreateWorkspacePanel({
                         </DropdownMenu.Item>
                       );
                     })}
-                  </DropdownMenu.Content>
-                </DropdownMenu.Portal>
+                </MobileDropdownMenuContent>
               </DropdownMenu.Root>
             </div>
 
@@ -3125,13 +3126,12 @@ const CreateWorkspacePanel = memo(function CreateWorkspacePanel({
                   <ChevronDown className="h-3 w-3 shrink-0 text-[var(--vk-text-muted)]" />
                 </button>
               </DropdownMenu.Trigger>
-              <DropdownMenu.Portal>
-                <DropdownMenu.Content
-                  align="end"
-                  side="bottom"
-                  sideOffset={6}
-                  className={scrollMenuClass}
-                >
+              <MobileDropdownMenuContent
+                align="end"
+                side="bottom"
+                sideOffset={6}
+                className={scrollMenuClass}
+              >
                   <p className="px-3 pb-1 text-[14px] font-semibold leading-[21px] text-[var(--vk-text-muted)]">
                     Tasks
                   </p>
@@ -3160,7 +3160,7 @@ const CreateWorkspacePanel = memo(function CreateWorkspacePanel({
                         <DropdownMenu.Item
                           key={taskValue}
                           onSelect={() => setIssueId(taskValue)}
-                          className={`${lightMenuItemClass} min-w-[320px] items-start`}
+                          className={`${lightMenuItemClass} w-full min-w-0 items-start sm:min-w-[320px]`}
                         >
                           <div className="min-w-0 flex-1">
                             <div className="truncate">
@@ -3182,8 +3182,7 @@ const CreateWorkspacePanel = memo(function CreateWorkspacePanel({
                       No existing tasks were found for this project.
                     </div>
                   )}
-                </DropdownMenu.Content>
-              </DropdownMenu.Portal>
+              </MobileDropdownMenuContent>
             </DropdownMenu.Root>
           </div>
 
@@ -3195,11 +3194,11 @@ const CreateWorkspacePanel = memo(function CreateWorkspacePanel({
                   onChange={(e) => setPrompt(e.target.value)}
                   placeholder="Optional launch prompt. Leave empty to open the native CLI."
                   rows={1}
-                  className="min-h-[24px] w-full resize-none bg-transparent pr-16 text-[16px] leading-[24px] text-[var(--vk-text-normal)] outline-none placeholder:text-[var(--vk-text-muted)]"
+                  className="min-h-11 w-full resize-none bg-transparent pr-24 text-[16px] leading-[24px] text-[var(--vk-text-normal)] outline-none placeholder:text-[var(--vk-text-muted)]"
                 />
                 <label
                   htmlFor={attachmentInputId}
-                  className={`absolute right-[18px] top-0 inline-flex h-[24px] w-[24px] items-center justify-center rounded-[4px] ${
+                  className={`oc-mobile-touch-target absolute right-11 top-0 inline-flex h-11 w-11 cursor-pointer items-center justify-center rounded-[4px] ${
                     launchPayloadProjectId
                       ? "text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)]"
                       : "cursor-not-allowed opacity-50"
@@ -3219,7 +3218,7 @@ const CreateWorkspacePanel = memo(function CreateWorkspacePanel({
                 <button
                   type="button"
                   aria-label="Preview"
-                  className="absolute right-0 top-0 inline-flex h-[24px] w-[24px] items-center justify-center rounded-[4px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)]"
+                  className="oc-mobile-touch-target absolute right-0 top-0 inline-flex h-11 w-11 items-center justify-center rounded-[4px] text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)]"
                 >
                   <Eye className="h-[14px] w-[14px]" />
                 </button>
@@ -3241,7 +3240,7 @@ const CreateWorkspacePanel = memo(function CreateWorkspacePanel({
                         type="button"
                         aria-label={`Remove attachment ${file.name}`}
                         onClick={() => removeAttachment(index)}
-                        className="inline-flex h-[14px] w-[14px] items-center justify-center rounded-full text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)]"
+                        className="oc-mobile-touch-target inline-flex h-11 w-11 items-center justify-center rounded-full text-[var(--vk-text-muted)] hover:bg-[var(--vk-bg-hover)] sm:h-6 sm:w-6"
                       >
                         <X className="h-3 w-3" />
                       </button>
@@ -3262,8 +3261,7 @@ const CreateWorkspacePanel = memo(function CreateWorkspacePanel({
                         <SlidersHorizontal className="h-[15px] w-[15px]" />
                       </button>
                     </DropdownMenu.Trigger>
-                    <DropdownMenu.Portal>
-                      <DropdownMenu.Content align="start" sideOffset={6} className={scrollMenuClass}>
+                    <MobileDropdownMenuContent align="start" sideOffset={6} className={scrollMenuClass}>
                         <p className="px-3 pb-1 text-[14px] font-semibold leading-[21px] text-[var(--vk-text-muted)]">Projects</p>
                         {projectOptions.map((project) => {
                           const displayName = getProjectDisplayName(project);
@@ -3274,7 +3272,7 @@ const CreateWorkspacePanel = memo(function CreateWorkspacePanel({
                             <DropdownMenu.Item
                               key={project.id}
                               onSelect={() => onSelectProject(project.id)}
-                              className={`${lightMenuItemClass} min-w-[280px] items-start`}
+                              className={`${lightMenuItemClass} w-full min-w-0 items-start sm:min-w-[280px]`}
                             >
                               <div className="min-w-0 flex-1">
                                 <div className="truncate">{displayName}</div>
@@ -3295,8 +3293,7 @@ const CreateWorkspacePanel = memo(function CreateWorkspacePanel({
                           <FolderOpen className="h-4 w-4" />
                           <span>Add Workspace</span>
                         </DropdownMenu.Item>
-                      </DropdownMenu.Content>
-                    </DropdownMenu.Portal>
+                    </MobileDropdownMenuContent>
                   </DropdownMenu.Root>
 
                   {availableReasoningOptions.length > 0 ? (
@@ -3311,8 +3308,7 @@ const CreateWorkspacePanel = memo(function CreateWorkspacePanel({
                           <ChevronDown className="h-[10px] w-[10px] text-[var(--vk-text-muted)]" />
                         </button>
                       </DropdownMenu.Trigger>
-                      <DropdownMenu.Portal>
-                        <DropdownMenu.Content align="start" sideOffset={6} className={lightMenuClass}>
+                      <MobileDropdownMenuContent align="start" sideOffset={6} className={lightMenuClass}>
                           <p className="px-3 pb-1 text-[14px] font-semibold leading-[21px] text-[var(--vk-text-muted)]">
                             Reasoning
                           </p>
@@ -3331,8 +3327,7 @@ const CreateWorkspacePanel = memo(function CreateWorkspacePanel({
                               </span>
                             </DropdownMenu.Item>
                           ))}
-                        </DropdownMenu.Content>
-                      </DropdownMenu.Portal>
+                      </MobileDropdownMenuContent>
                     </DropdownMenu.Root>
                   ) : null}
 
@@ -3346,8 +3341,7 @@ const CreateWorkspacePanel = memo(function CreateWorkspacePanel({
                         <ChevronDown className="h-[10px] w-[10px] text-[var(--vk-text-muted)]" />
                       </button>
                     </DropdownMenu.Trigger>
-                    <DropdownMenu.Portal>
-                      <DropdownMenu.Content align="start" sideOffset={6} className={lightMenuClass}>
+                    <MobileDropdownMenuContent align="start" sideOffset={6} className={lightMenuClass}>
                         <p className="px-3 pb-1 text-[14px] font-semibold leading-[21px] text-[var(--vk-text-muted)]">Model</p>
                         <DropdownMenu.Item
                           onSelect={() => setModelSelection(buildModelSelection(
@@ -3393,8 +3387,7 @@ const CreateWorkspacePanel = memo(function CreateWorkspacePanel({
                             </button>
                           </>
                         ) : null}
-                      </DropdownMenu.Content>
-                    </DropdownMenu.Portal>
+                    </MobileDropdownMenuContent>
                   </DropdownMenu.Root>
 
                   <DropdownMenu.Root>
@@ -3407,8 +3400,7 @@ const CreateWorkspacePanel = memo(function CreateWorkspacePanel({
                         <ChevronDown className="h-[10px] w-[10px] text-[var(--vk-text-muted)]" />
                       </button>
                     </DropdownMenu.Trigger>
-                    <DropdownMenu.Portal>
-                      <DropdownMenu.Content align="start" sideOffset={6} className={lightMenuClass}>
+                    <MobileDropdownMenuContent align="start" sideOffset={6} className={lightMenuClass}>
                         <p className="px-3 pb-1 text-[14px] font-semibold leading-[21px] text-[var(--vk-text-muted)]">Permissions</p>
                         {permissionOptions.map(({ id, label, icon: Icon }) => (
                           <DropdownMenu.Item
@@ -3423,14 +3415,13 @@ const CreateWorkspacePanel = memo(function CreateWorkspacePanel({
                             </span>
                           </DropdownMenu.Item>
                         ))}
-                      </DropdownMenu.Content>
-                    </DropdownMenu.Portal>
+                    </MobileDropdownMenuContent>
                   </DropdownMenu.Root>
 
 
 
                   {availableBridges.length > 0 ? (
-                    <label className="inline-flex h-[29px] max-w-[260px] items-center gap-[6px] rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] px-[9px] py-[5px] text-[14px] leading-[21px] text-[var(--vk-text-normal)]">
+                    <label className="oc-mobile-touch-target inline-flex min-h-11 max-w-[260px] items-center gap-[6px] rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] px-[9px] py-[5px] text-[14px] leading-[21px] text-[var(--vk-text-normal)] sm:min-h-[29px]">
                       <PlugZap className="h-[14px] w-[14px] text-[var(--vk-text-muted)]" />
                       <select
                         value={selectedBridgeId}
@@ -3446,7 +3437,7 @@ const CreateWorkspacePanel = memo(function CreateWorkspacePanel({
                       </select>
                     </label>
                   ) : (
-                    <div className="inline-flex h-[29px] items-center gap-[6px] rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] px-[9px] py-[5px] text-[14px] leading-[21px] text-[var(--vk-text-muted)]">
+                    <div className="oc-mobile-touch-target inline-flex min-h-11 items-center gap-[6px] rounded-[3px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] px-[9px] py-[5px] text-[14px] leading-[21px] text-[var(--vk-text-muted)] sm:min-h-[29px]">
                       <PlugZap className="h-[14px] w-[14px]" />
                       <span>
                         {selectedBridgeId && !selectedBridgeOnline
@@ -3468,14 +3459,12 @@ const CreateWorkspacePanel = memo(function CreateWorkspacePanel({
                         {currentProjectLabel}
                       </button>
                     </DropdownMenu.Trigger>
-                    <DropdownMenu.Portal>
-                      <DropdownMenu.Content
-                        align="start"
-                        side="bottom"
-                        sideOffset={6}
-                        avoidCollisions={false}
-                        className={scrollMenuClass}
-                      >
+                    <MobileDropdownMenuContent
+                      align="start"
+                      side="bottom"
+                      sideOffset={6}
+                      className={scrollMenuClass}
+                    >
                         <p className="px-3 pb-1 text-[14px] font-semibold leading-[21px] text-[var(--vk-text-muted)]">Branch</p>
                         {selectedProjectLabel ? (
                           <p className="px-3 pb-2 text-[12px] leading-[16px] text-[var(--text-faint)]">
@@ -3498,8 +3487,7 @@ const CreateWorkspacePanel = memo(function CreateWorkspacePanel({
                             </DropdownMenu.Item>
                           ))
                         )}
-                      </DropdownMenu.Content>
-                    </DropdownMenu.Portal>
+                    </MobileDropdownMenuContent>
                   </DropdownMenu.Root>
                 </div>
 
@@ -3508,7 +3496,7 @@ const CreateWorkspacePanel = memo(function CreateWorkspacePanel({
                     type="button"
                     onClick={handleLaunch}
                     disabled={isCreatingSession || !effectiveProjectId}
-                    className="inline-flex min-h-[29px] items-center justify-center rounded-[3px] bg-[var(--vk-bg-hover)] px-[8px] py-[6.5px] text-[16px] leading-[16px] text-[var(--vk-text-strong)] transition-colors hover:bg-[var(--vk-bg-active)] disabled:cursor-not-allowed disabled:opacity-50"
+                    className="oc-mobile-touch-target inline-flex min-h-11 touch-manipulation items-center justify-center rounded-[3px] bg-[var(--vk-bg-hover)] px-[8px] py-[6.5px] text-[16px] leading-[16px] text-[var(--vk-text-strong)] transition-colors hover:bg-[var(--vk-bg-active)] disabled:cursor-not-allowed disabled:opacity-50 sm:min-h-[29px]"
                   >
                     {isCreatingSession ? <Loader2 className="h-4 w-4 animate-spin" /> : "Launch"}
                   </button>
@@ -3531,7 +3519,7 @@ const CreateWorkspacePanel = memo(function CreateWorkspacePanel({
                     <button
                       type="button"
                       onClick={() => onOpenAgentSetup(selectedAgent)}
-                      className="inline-flex h-[29px] items-center justify-center rounded-[3px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-orange)] hover:bg-[var(--vk-bg-hover)]"
+                      className="oc-mobile-touch-target inline-flex h-11 items-center justify-center rounded-[3px] border border-[var(--vk-border)] px-3 text-[12px] text-[var(--vk-orange)] hover:bg-[var(--vk-bg-hover)] sm:h-[29px]"
                     >
                       {selectedAgentState.installed ? "Open setup" : "Open install"}
                     </button>

--- a/packages/web/src/features/dashboard/DashboardClient.tsx
+++ b/packages/web/src/features/dashboard/DashboardClient.tsx
@@ -72,6 +72,7 @@ import { AppShell } from "@/components/layout/AppShell";
 import { TopBar } from "@/components/layout/TopBar";
 import { BridgeStatusPill } from "@/components/bridge/BridgeStatusPill";
 import { shouldUseCompactTerminalChrome } from "@/components/sessions/sessionTerminalUtils";
+import { focusVisibleWorkspacePanelOpenerIfNeeded } from "@/features/dashboard/components/dialogFocusRestore";
 import { AgentTileIcon } from "@/components/AgentTileIcon";
 import { MobileDropdownMenuContent } from "@/components/ui/MobileDropdownMenu";
 import { uploadProjectAttachments } from "@/components/sessions/attachmentUploads";
@@ -1042,6 +1043,7 @@ export default function DashboardClient({
   const [dispatcherPanelResizing, setDispatcherPanelResizing] = useState(false);
   const launchpadSessionIdRef = useRef<string | null>(null);
   const previousBoardProjectIdRef = useRef<string | null>(selectedProjectId);
+  const previousNewWorkspaceOpenRef = useRef(newWorkspaceOpen);
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -1064,6 +1066,23 @@ export default function DashboardClient({
       mediaQuery?.removeEventListener?.("change", syncCompactTerminalChrome);
     };
   }, []);
+
+  useEffect(() => {
+    const wasNewWorkspaceOpen = previousNewWorkspaceOpenRef.current;
+    previousNewWorkspaceOpenRef.current = newWorkspaceOpen;
+
+    if (!wasNewWorkspaceOpen || newWorkspaceOpen || typeof window === "undefined") {
+      return;
+    }
+
+    const frame = window.requestAnimationFrame(() => {
+      focusVisibleWorkspacePanelOpenerIfNeeded();
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [newWorkspaceOpen]);
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -2593,7 +2612,6 @@ export default function DashboardClient({
         </div>
       </AppShell>
 
-      {newWorkspaceOpen ? (
       <NewWorkspaceDialog
         open={newWorkspaceOpen}
         onClose={handleCloseNewWorkspaceDialog}
@@ -2606,31 +2624,28 @@ export default function DashboardClient({
         runtimeModelCatalogs={runtimeModelCatalogs}
         bridgeId={effectiveBridgeId}
       />
-      ) : null}
 
-      {preferencesDialogOpen || onboardingRequired ? (
-        <SettingsDialog
-          open={preferencesDialogOpen}
-          mode={onboardingRequired ? "onboarding" : "settings"}
-          creating={preferencesSaving}
-          error={preferencesError}
-          current={resolvedPreferences}
-          projectCount={projects.length}
-          agentOptions={agentOptions}
-          agentStates={agentStatesByName}
-          runtimeModelCatalogs={runtimeModelCatalogs}
-          onRepositoriesChanged={refreshConfig}
-          onOnboardingComplete={({ needsProject }) => {
-            if (needsProject) {
-              setPendingWorkspaceSetup(true);
-            }
-          }}
-          onOpenAgentSetup={openAgentSetup}
-          onClose={handleClosePreferencesDialog}
-          onSave={handleSavePreferences}
-          bridgeId={effectiveBridgeId}
-        />
-      ) : null}
+      <SettingsDialog
+        open={preferencesDialogOpen}
+        mode={onboardingRequired ? "onboarding" : "settings"}
+        creating={preferencesSaving}
+        error={preferencesError}
+        current={resolvedPreferences}
+        projectCount={projects.length}
+        agentOptions={agentOptions}
+        agentStates={agentStatesByName}
+        runtimeModelCatalogs={runtimeModelCatalogs}
+        onRepositoriesChanged={refreshConfig}
+        onOnboardingComplete={({ needsProject }) => {
+          if (needsProject) {
+            setPendingWorkspaceSetup(true);
+          }
+        }}
+        onOpenAgentSetup={openAgentSetup}
+        onClose={handleClosePreferencesDialog}
+        onSave={handleSavePreferences}
+        bridgeId={effectiveBridgeId}
+      />
     </>
   );
 }

--- a/packages/web/src/features/dashboard/components/DashboardDialogs.tsx
+++ b/packages/web/src/features/dashboard/components/DashboardDialogs.tsx
@@ -1130,6 +1130,9 @@ export function NewWorkspaceDialog({
         <form
           onSubmit={handleSubmit}
           onClick={(event) => event.stopPropagation()}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="new-workspace-dialog-title"
           className={`flex ${KEYBOARD_SAFE_VIEWPORT_FRAME_CLASS_NAME} ${KEYBOARD_SAFE_VIEWPORT_DIALOG_MAX_HEIGHT_CLASS_NAME} w-full max-w-none flex-col overflow-hidden rounded-none border-x-0 border-b-0 border-t border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_24px_80px_rgba(0,0,0,0.55)] sm:h-auto sm:max-w-[860px] sm:rounded-[10px] sm:border`}
         >
           <header className="border-b border-[var(--vk-border)] bg-[color:color-mix(in_srgb,var(--vk-bg-panel)_92%,transparent)] px-4 py-3 backdrop-blur">
@@ -1139,7 +1142,7 @@ export function NewWorkspaceDialog({
             <div className="flex items-start gap-3">
               <div className="min-w-0 flex-1">
                 <div className="flex flex-wrap items-center gap-2">
-                  <h2 className="text-[18px] leading-[22px] text-[var(--vk-text-strong)]">Add Workspace</h2>
+                  <h2 id="new-workspace-dialog-title" className="text-[18px] leading-[22px] text-[var(--vk-text-strong)]">Add Workspace</h2>
                   <span className="inline-flex rounded-full border border-[var(--vk-border)] px-2 py-0.5 text-[11px] text-[var(--vk-text-muted)]">
                     {step === "source" ? "Step 1 of 3" : step === "details" ? "Step 2 of 3" : "Step 3 of 3"}
                   </span>
@@ -1978,9 +1981,12 @@ function FolderPickerDialog({
       <div
         className={`flex ${KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME} w-full max-w-[760px] flex-col overflow-hidden rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_24px_80px_rgba(0,0,0,0.55)]`}
         onClick={(event) => event.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="folder-picker-dialog-title"
       >
         <header className="border-b border-[var(--vk-border)] px-4 py-3">
-          <h3 className="text-[16px] text-[var(--vk-text-strong)]">{title}</h3>
+          <h3 id="folder-picker-dialog-title" className="text-[16px] text-[var(--vk-text-strong)]">{title}</h3>
           <p className="pt-1 text-[12px] text-[var(--vk-text-muted)]">{description}</p>
         </header>
 
@@ -2722,7 +2728,7 @@ function hydrateRepositoryDraft(value: RepositorySettingsPayload): RepositorySet
   return (
     <>
       <div
-        className={`fixed ${KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME} z-[90] flex items-start justify-center overflow-y-auto bg-black/70 px-3 py-3 sm:items-center sm:py-6`}
+        className={`fixed ${KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME} z-[90] flex items-start justify-center overflow-hidden bg-black/70 px-0 py-0 sm:items-center sm:overflow-y-auto sm:px-3 sm:py-6`}
         onClick={() => {
           if (isBusy || mode === "onboarding" || repositoryFolderPickerOpen || notesFolderPickerOpen || filesystemRootPickerOpen) return;
           onClose();
@@ -2732,10 +2738,13 @@ function hydrateRepositoryDraft(value: RepositorySettingsPayload): RepositorySet
         <div
           className={`flex ${KEYBOARD_SAFE_VIEWPORT_FRAME_CLASS_NAME} ${KEYBOARD_SAFE_VIEWPORT_DIALOG_MAX_HEIGHT_CLASS_NAME} w-full flex-col overflow-hidden border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_24px_80px_rgba(0,0,0,0.55)] sm:h-[min(90vh,820px)] sm:max-w-[1180px] sm:rounded-[6px] sm:border sm:flex-row`}
           onClick={(event) => event.stopPropagation()}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="settings-dialog-title"
         >
           <aside className="flex w-full shrink-0 flex-col border-b border-[var(--vk-border)] bg-[rgba(28,28,28,0.8)] sm:w-[224px] sm:border-b-0 sm:border-r">
             <header className="border-b border-[var(--vk-border)] px-4 py-3 sm:py-4">
-              <h2 className="text-[22px] leading-[24px] text-[var(--vk-text-strong)] sm:text-[27px] sm:leading-[27px]">
+              <h2 id="settings-dialog-title" className="text-[22px] leading-[24px] text-[var(--vk-text-strong)] sm:text-[27px] sm:leading-[27px]">
                 {isOnboarding ? "Setup" : "Settings"}
               </h2>
             </header>

--- a/packages/web/src/features/dashboard/components/DashboardDialogs.tsx
+++ b/packages/web/src/features/dashboard/components/DashboardDialogs.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as Dialog from "@radix-ui/react-dialog";
 import { GitBranchIcon, LockIcon, MarkGithubIcon, RepoIcon } from "@primer/octicons-react";
 import {
   getAgentModelCatalog,
@@ -10,7 +11,7 @@ import {
   type DashboardRole,
   type ModelAccessPreferences,
 } from "@conductor-oss/core/types";
-import { type FormEvent, memo, useCallback, useEffect, useMemo, useState } from "react";
+import { type FormEvent, memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { IconType } from "react-icons";
 import { SiNotion, SiObsidian } from "react-icons/si";
 import { VscVscode } from "react-icons/vsc";
@@ -73,6 +74,11 @@ import {
   resolveReasoningSelectionValue,
   type ModelSelectionState,
 } from "@/lib/agentModelSelection";
+import {
+  captureDialogOpener,
+  findVisibleWorkspacePanelOpener,
+  restoreDialogOpener,
+} from "./dialogFocusRestore";
 
 const DEFAULT_AGENT = "claude-code";
 
@@ -767,6 +773,7 @@ export function NewWorkspaceDialog({
   runtimeModelCatalogs: Record<string, RuntimeAgentModelCatalog>;
   bridgeId?: string | null;
 }) {
+  const openerRef = useRef<HTMLElement | null>(null);
   const [mode, setMode] = useState<"git" | "local">("git");
   const [step, setStep] = useState<"source" | "details" | "review">("source");
   const [projectId, setProjectId] = useState("");
@@ -1081,7 +1088,10 @@ export function NewWorkspaceDialog({
     setStep("review");
   };
 
-  if (!open) return null;
+  const handleDialogOpenChange = (nextOpen: boolean) => {
+    if (nextOpen || creating || folderPickerOpen) return;
+    onClose();
+  };
 
   const canSubmit = sourceReady && defaultBranch.trim().length > 0;
 
@@ -1119,22 +1129,42 @@ export function NewWorkspaceDialog({
 
   return (
     <>
-      <div
-        className={`fixed ${KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME} z-[80] flex items-start justify-center overflow-y-auto bg-black/65 px-0 py-0 sm:items-center sm:px-3 sm:py-3`}
-        onClick={() => {
-          if (creating || folderPickerOpen) return;
-          onClose();
-        }}
-        role="presentation"
-      >
-        <form
-          onSubmit={handleSubmit}
-          onClick={(event) => event.stopPropagation()}
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="new-workspace-dialog-title"
-          className={`flex ${KEYBOARD_SAFE_VIEWPORT_FRAME_CLASS_NAME} ${KEYBOARD_SAFE_VIEWPORT_DIALOG_MAX_HEIGHT_CLASS_NAME} w-full max-w-none flex-col overflow-hidden rounded-none border-x-0 border-b-0 border-t border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_24px_80px_rgba(0,0,0,0.55)] sm:h-auto sm:max-w-[860px] sm:rounded-[10px] sm:border`}
-        >
+      <Dialog.Root open={open} onOpenChange={handleDialogOpenChange}>
+        <Dialog.Portal>
+          <Dialog.Overlay className={`fixed ${KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME} z-[80] bg-black/65`} />
+          <Dialog.Content
+            asChild
+            onOpenAutoFocus={() => {
+              captureDialogOpener(openerRef);
+            }}
+            onCloseAutoFocus={(event) => {
+              if (restoreDialogOpener(openerRef, event)) return;
+              const workspacePanelOpener = findVisibleWorkspacePanelOpener();
+              if (!workspacePanelOpener) return;
+              event.preventDefault();
+              workspacePanelOpener.focus({ preventScroll: true });
+            }}
+            onEscapeKeyDown={(event) => {
+              if (creating || folderPickerOpen) {
+                event.preventDefault();
+              }
+            }}
+            onPointerDownOutside={(event) => {
+              if (creating || folderPickerOpen) {
+                event.preventDefault();
+              }
+            }}
+          >
+            <form
+              onSubmit={handleSubmit}
+              className={`fixed ${KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME} z-[81] flex items-start justify-center overflow-y-auto px-0 py-0 sm:items-center sm:px-3 sm:py-3`}
+            >
+              <Dialog.Description className="sr-only">
+                Add a repository or local folder and configure the workspace before Conductor creates it.
+              </Dialog.Description>
+              <div
+                className={`flex ${KEYBOARD_SAFE_VIEWPORT_FRAME_CLASS_NAME} ${KEYBOARD_SAFE_VIEWPORT_DIALOG_MAX_HEIGHT_CLASS_NAME} w-full max-w-none flex-col overflow-hidden rounded-none border-x-0 border-b-0 border-t border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_24px_80px_rgba(0,0,0,0.55)] sm:h-auto sm:max-w-[860px] sm:rounded-[10px] sm:border`}
+              >
           <header className="border-b border-[var(--vk-border)] bg-[color:color-mix(in_srgb,var(--vk-bg-panel)_92%,transparent)] px-4 py-3 backdrop-blur">
             <div className="mb-3 flex justify-center sm:hidden">
               <span className="h-1 w-10 rounded-full bg-[color:color-mix(in_srgb,var(--vk-text-muted)_36%,transparent)]" />
@@ -1142,7 +1172,9 @@ export function NewWorkspaceDialog({
             <div className="flex items-start gap-3">
               <div className="min-w-0 flex-1">
                 <div className="flex flex-wrap items-center gap-2">
-                  <h2 id="new-workspace-dialog-title" className="text-[18px] leading-[22px] text-[var(--vk-text-strong)]">Add Workspace</h2>
+                  <Dialog.Title asChild>
+                    <h2 id="new-workspace-dialog-title" className="text-[18px] leading-[22px] text-[var(--vk-text-strong)]">Add Workspace</h2>
+                  </Dialog.Title>
                   <span className="inline-flex rounded-full border border-[var(--vk-border)] px-2 py-0.5 text-[11px] text-[var(--vk-text-muted)]">
                     {step === "source" ? "Step 1 of 3" : step === "details" ? "Step 2 of 3" : "Step 3 of 3"}
                   </span>
@@ -1816,8 +1848,11 @@ export function NewWorkspaceDialog({
               </div>
             )}
           </footer>
-        </form>
-      </div>
+              </div>
+            </form>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
 
       <FolderPickerDialog
         open={folderPickerOpen}
@@ -1867,6 +1902,7 @@ function FolderPickerDialog({
   onClose: () => void;
   onSelect: (path: string | null) => void;
 }) {
+  const openerRef = useRef<HTMLElement | null>(null);
   const [currentPath, setCurrentPath] = useState("");
   const [manualPath, setManualPath] = useState(initialPath ?? "");
   const [entries, setEntries] = useState<DirectoryEntry[]>([]);
@@ -1967,27 +2003,36 @@ function FolderPickerDialog({
     }
   };
 
-  if (!open) return null;
-
   return (
-    <div
-      className={`fixed ${KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME} z-[95] flex items-start justify-center overflow-y-auto bg-black/70 px-3 py-3 sm:items-center sm:py-0`}
-      onClick={() => {
+    <Dialog.Root
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (nextOpen) return;
         onClose();
         onSelect(null);
       }}
-      role="presentation"
     >
-      <div
-        className={`flex ${KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME} w-full max-w-[760px] flex-col overflow-hidden rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_24px_80px_rgba(0,0,0,0.55)]`}
-        onClick={(event) => event.stopPropagation()}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="folder-picker-dialog-title"
-      >
+      <Dialog.Portal>
+        <Dialog.Overlay className={`fixed ${KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME} z-[95] bg-black/70`} />
+        <Dialog.Content
+          className={`fixed ${KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME} z-[96] flex items-start justify-center overflow-y-auto px-3 py-3 outline-none sm:items-center sm:py-0`}
+          onOpenAutoFocus={() => {
+            captureDialogOpener(openerRef);
+          }}
+          onCloseAutoFocus={(event) => {
+            restoreDialogOpener(openerRef, event);
+          }}
+        >
+          <div
+            className={`flex ${KEYBOARD_SAFE_VIEWPORT_INSET_FRAME_CLASS_NAME} w-full max-w-[760px] flex-col overflow-hidden rounded-[6px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_24px_80px_rgba(0,0,0,0.55)]`}
+          >
         <header className="border-b border-[var(--vk-border)] px-4 py-3">
-          <h3 id="folder-picker-dialog-title" className="text-[16px] text-[var(--vk-text-strong)]">{title}</h3>
-          <p className="pt-1 text-[12px] text-[var(--vk-text-muted)]">{description}</p>
+          <Dialog.Title asChild>
+            <h3 id="folder-picker-dialog-title" className="text-[16px] text-[var(--vk-text-strong)]">{title}</h3>
+          </Dialog.Title>
+          <Dialog.Description asChild>
+            <p className="pt-1 text-[12px] text-[var(--vk-text-muted)]">{description}</p>
+          </Dialog.Description>
         </header>
 
         <div className="flex min-h-0 flex-1 flex-col gap-3 px-4 py-3">
@@ -2108,8 +2153,10 @@ function FolderPickerDialog({
             Use this folder
           </button>
         </footer>
-      </div>
-    </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }
 
@@ -2176,6 +2223,7 @@ export function SettingsDialog({
   onSave: (next: PreferencesPayload, options?: { closeDialog?: boolean }) => Promise<boolean>;
   bridgeId?: string | null;
 }) {
+  const openerRef = useRef<HTMLElement | null>(null);
   const [activeTab, setActiveTab] = useState<SettingsTabId>("preferences");
   const [codingAgent, setCodingAgent] = useState(current.codingAgent);
   const [ide, setIde] = useState(current.ide);
@@ -2610,8 +2658,6 @@ function hydrateRepositoryDraft(value: RepositorySettingsPayload): RepositorySet
     } as ModelAccessPreferences));
   }
 
-  if (!open) return null;
-
   const canSubmitPreferences = codingAgent.trim().length > 0
     && ide.trim().length > 0
     && markdownEditor.trim().length > 0;
@@ -2725,28 +2771,69 @@ function hydrateRepositoryDraft(value: RepositorySettingsPayload): RepositorySet
     onOnboardingComplete?.({ needsProject: false });
   }
 
+  const handleDialogOpenChange = (nextOpen: boolean) => {
+    if (
+      nextOpen
+      || isBusy
+      || mode === "onboarding"
+      || repositoryFolderPickerOpen
+      || notesFolderPickerOpen
+      || filesystemRootPickerOpen
+    ) {
+      return;
+    }
+    onClose();
+  };
+
   return (
     <>
-      <div
-        className={`fixed ${KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME} z-[90] flex items-start justify-center overflow-hidden bg-black/70 px-0 py-0 sm:items-center sm:overflow-y-auto sm:px-3 sm:py-6`}
-        onClick={() => {
-          if (isBusy || mode === "onboarding" || repositoryFolderPickerOpen || notesFolderPickerOpen || filesystemRootPickerOpen) return;
-          onClose();
-        }}
-        role="presentation"
-      >
-        <div
-          className={`flex ${KEYBOARD_SAFE_VIEWPORT_FRAME_CLASS_NAME} ${KEYBOARD_SAFE_VIEWPORT_DIALOG_MAX_HEIGHT_CLASS_NAME} w-full flex-col overflow-hidden border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_24px_80px_rgba(0,0,0,0.55)] sm:h-[min(90vh,820px)] sm:max-w-[1180px] sm:rounded-[6px] sm:border sm:flex-row`}
-          onClick={(event) => event.stopPropagation()}
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="settings-dialog-title"
-        >
+      <Dialog.Root open={open} onOpenChange={handleDialogOpenChange}>
+        <Dialog.Portal>
+          <Dialog.Overlay className={`fixed ${KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME} z-[89] bg-black/70`} />
+          <Dialog.Content
+            className={`fixed ${KEYBOARD_SAFE_VIEWPORT_OVERLAY_CLASS_NAME} z-[90] flex items-start justify-center overflow-hidden px-0 py-0 outline-none sm:items-center sm:overflow-y-auto sm:px-3 sm:py-6`}
+            onOpenAutoFocus={() => {
+              captureDialogOpener(openerRef);
+            }}
+            onCloseAutoFocus={(event) => {
+              restoreDialogOpener(openerRef, event);
+            }}
+            onEscapeKeyDown={(event) => {
+              if (
+                isBusy
+                || mode === "onboarding"
+                || repositoryFolderPickerOpen
+                || notesFolderPickerOpen
+                || filesystemRootPickerOpen
+              ) {
+                event.preventDefault();
+              }
+            }}
+            onPointerDownOutside={(event) => {
+              if (
+                isBusy
+                || mode === "onboarding"
+                || repositoryFolderPickerOpen
+                || notesFolderPickerOpen
+                || filesystemRootPickerOpen
+              ) {
+                event.preventDefault();
+              }
+            }}
+          >
+            <Dialog.Description className="sr-only">
+              Review and update dashboard preferences, repository defaults, and organization settings.
+            </Dialog.Description>
+            <div
+              className={`flex ${KEYBOARD_SAFE_VIEWPORT_FRAME_CLASS_NAME} ${KEYBOARD_SAFE_VIEWPORT_DIALOG_MAX_HEIGHT_CLASS_NAME} w-full flex-col overflow-hidden border-[var(--vk-border)] bg-[var(--vk-bg-panel)] shadow-[0_24px_80px_rgba(0,0,0,0.55)] sm:h-[min(90vh,820px)] sm:max-w-[1180px] sm:rounded-[6px] sm:border sm:flex-row`}
+            >
           <aside className="flex w-full shrink-0 flex-col border-b border-[var(--vk-border)] bg-[rgba(28,28,28,0.8)] sm:w-[224px] sm:border-b-0 sm:border-r">
             <header className="border-b border-[var(--vk-border)] px-4 py-3 sm:py-4">
-              <h2 id="settings-dialog-title" className="text-[22px] leading-[24px] text-[var(--vk-text-strong)] sm:text-[27px] sm:leading-[27px]">
-                {isOnboarding ? "Setup" : "Settings"}
-              </h2>
+              <Dialog.Title asChild>
+                <h2 id="settings-dialog-title" className="text-[22px] leading-[24px] text-[var(--vk-text-strong)] sm:text-[27px] sm:leading-[27px]">
+                  {isOnboarding ? "Setup" : "Settings"}
+                </h2>
+              </Dialog.Title>
             </header>
             <nav className="-mx-0.5 flex gap-1 overflow-x-auto px-2 py-2 sm:mx-0 sm:block sm:space-y-1 sm:overflow-auto sm:px-2">
               {visibleTabs.map((tab) => {
@@ -3975,9 +4062,11 @@ function hydrateRepositoryDraft(value: RepositorySettingsPayload): RepositorySet
                 )}
               </div>
             </footer>
+            </div>
           </div>
-        </div>
-      </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
 
       <FolderPickerDialog
         open={repositoryFolderPickerOpen}

--- a/packages/web/src/features/dashboard/components/WorkspaceOverview.tsx
+++ b/packages/web/src/features/dashboard/components/WorkspaceOverview.tsx
@@ -110,7 +110,7 @@ export function WorkspaceOverview({
   if (showProjectRecovery || showProjectError || showProjectLoading) {
     return (
       <div className={`flex h-full min-h-0 w-full flex-col bg-[linear-gradient(180deg,rgba(255,255,255,0.03),rgba(255,255,255,0))] ${APP_SURFACE_SCROLL_CLASS_NAME}`}>
-        <div className="flex h-full min-h-0 w-full flex-1 items-center justify-center px-3 py-3 sm:px-4 sm:py-4">
+        <div className="flex min-h-full w-full items-center justify-center px-3 py-3 sm:px-4 sm:py-4">
           <Card className="w-full max-w-[680px] border-[var(--vk-border)] bg-[color:color-mix(in_srgb,var(--vk-bg-panel)_88%,transparent)]">
             <CardContent className="flex flex-col items-center px-6 py-10 text-center sm:px-10 sm:py-12">
               <span className="inline-flex h-12 w-12 items-center justify-center rounded-[12px] border border-[var(--vk-border)] bg-[var(--vk-bg-main)] text-[var(--vk-text-normal)]">
@@ -142,7 +142,7 @@ export function WorkspaceOverview({
   if (showWelcomeState) {
     return (
       <div className={`flex h-full min-h-0 w-full flex-col bg-[linear-gradient(180deg,rgba(255,255,255,0.03),rgba(255,255,255,0))] ${APP_SURFACE_SCROLL_CLASS_NAME}`}>
-        <div className="mx-auto flex h-full min-h-0 w-full max-w-[1200px] flex-1 flex-col px-3 py-3 sm:px-4 sm:py-4">
+        <div className="mx-auto flex min-h-full w-full max-w-[1200px] flex-col px-3 py-3 sm:px-4 sm:py-4">
           <div className="mb-4 flex justify-end">
             <Button variant="outline" size="md" onClick={onCreateWorkspace}>
               Add workspace
@@ -184,7 +184,7 @@ export function WorkspaceOverview({
 
   return (
     <div className={`flex h-full min-h-0 w-full flex-col bg-[linear-gradient(180deg,rgba(255,255,255,0.03),rgba(255,255,255,0))] ${APP_SURFACE_SCROLL_CLASS_NAME}`}>
-      <div className="flex h-full min-h-0 w-full flex-1 flex-col gap-4 px-3 py-3 sm:px-4">
+      <div className="flex w-full flex-col gap-4 px-3 py-3 sm:px-4 lg:h-full lg:min-h-0 lg:flex-1">
         <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
           <div className="max-w-3xl">
             <p className="text-[11px] uppercase tracking-[0.12em] text-[var(--vk-text-muted)]">
@@ -225,8 +225,8 @@ export function WorkspaceOverview({
           ))}
         </div>
 
-        <div className="flex min-h-0 w-full flex-1">
-          <Card className="flex min-h-0 w-full flex-1 flex-col">
+        <div className="flex w-full lg:min-h-0 lg:flex-1">
+          <Card className="flex w-full flex-col lg:min-h-0 lg:flex-1">
             <CardHeader className="justify-between">
               <div>
                 <p className="text-[14px] font-semibold text-[var(--vk-text-strong)]">Recent sessions</p>
@@ -236,7 +236,7 @@ export function WorkspaceOverview({
               </div>
               <Badge variant="outline">{visibleSessions.length}</Badge>
             </CardHeader>
-            <CardContent className={`flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto ${MOBILE_MOMENTUM_SCROLL_CLASS_NAME}`}>
+            <CardContent className={`flex flex-col gap-2 lg:min-h-0 lg:flex-1 lg:overflow-y-auto ${MOBILE_MOMENTUM_SCROLL_CLASS_NAME}`}>
               {recentSessions.length === 0 ? (
                 <div className="flex h-full min-h-[180px] items-center justify-center rounded-[6px] border border-dashed border-[var(--vk-border)] bg-[var(--vk-bg-main)] px-4 text-center text-[13px] text-[var(--vk-text-muted)]">
                   No sessions yet. Create or open a workspace to start work.

--- a/packages/web/src/features/dashboard/components/dialogFocusRestore.test.ts
+++ b/packages/web/src/features/dashboard/components/dialogFocusRestore.test.ts
@@ -1,0 +1,315 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  captureDialogAutoFocusTarget,
+  focusVisibleWorkspacePanelOpenerIfNeeded,
+  findVisibleWorkspacePanelOpener,
+  restoreDialogAutoFocusTarget,
+} from "./dialogFocusRestore";
+
+test("captureDialogAutoFocusTarget stores the active opener when it can be focused", () => {
+  const opener = {
+    focus() {},
+    isConnected: true,
+  } as unknown as HTMLElement;
+
+  assert.equal(captureDialogAutoFocusTarget(opener), opener);
+  assert.equal(captureDialogAutoFocusTarget(null), null);
+  assert.equal(captureDialogAutoFocusTarget({} as Element), null);
+});
+
+test("restoreDialogAutoFocusTarget prevents default Radix restoration and focuses the stored opener", () => {
+  const calls: FocusOptions[] = [];
+  const opener = {
+    focus(options?: FocusOptions) {
+      calls.push(options ?? {});
+    },
+    isConnected: true,
+  } as unknown as HTMLElement;
+  let prevented = false;
+
+  const restored = restoreDialogAutoFocusTarget(opener, {
+    preventDefault() {
+      prevented = true;
+    },
+  });
+
+  assert.equal(restored, true);
+  assert.equal(prevented, true);
+  assert.deepEqual(calls, [{ preventScroll: true }]);
+});
+
+test("restoreDialogAutoFocusTarget skips stale or disabled openers", () => {
+  for (const opener of [
+    {
+      focus() {
+        throw new Error("should not focus disconnected opener");
+      },
+      isConnected: false,
+    } as unknown as HTMLElement,
+    {
+      focus() {
+        throw new Error("should not focus disabled opener");
+      },
+      isConnected: true,
+      disabled: true,
+    } as unknown as HTMLElement,
+  ]) {
+    let prevented = false;
+    const restored = restoreDialogAutoFocusTarget(opener, {
+      preventDefault() {
+        prevented = true;
+      },
+    });
+
+    assert.equal(restored, false);
+    assert.equal(prevented, false);
+  }
+});
+
+test("findVisibleWorkspacePanelOpener skips hidden or stale matches and returns the visible enabled button", () => {
+  const visibleOpener = {
+    focus() {},
+    isConnected: true,
+    getClientRects() {
+      return { length: 1 } as DOMRectList;
+    },
+  } as unknown as HTMLButtonElement;
+  const originalDocument = globalThis.document;
+  const matches = [
+    {
+      focus() {
+        throw new Error("should not focus disconnected opener");
+      },
+      isConnected: false,
+      getClientRects() {
+        return { length: 1 } as DOMRectList;
+      },
+    },
+    {
+      focus() {
+        throw new Error("should not focus hidden opener");
+      },
+      isConnected: true,
+      getClientRects() {
+        return { length: 0 } as DOMRectList;
+      },
+    },
+    {
+      focus() {
+        throw new Error("should not focus disabled opener");
+      },
+      isConnected: true,
+      disabled: true,
+      getClientRects() {
+        return { length: 1 } as DOMRectList;
+      },
+    },
+    visibleOpener,
+  ] as unknown as NodeListOf<HTMLButtonElement>;
+
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      querySelectorAll() {
+        return matches;
+      },
+    } as Pick<Document, "querySelectorAll">,
+  });
+
+  try {
+    assert.equal(findVisibleWorkspacePanelOpener(), visibleOpener);
+  } finally {
+    if (originalDocument === undefined) {
+      Reflect.deleteProperty(globalThis, "document");
+    } else {
+      Object.defineProperty(globalThis, "document", {
+        configurable: true,
+        value: originalDocument,
+      });
+    }
+  }
+});
+
+test("focusVisibleWorkspacePanelOpenerIfNeeded repairs missing focus by targeting the visible workspace opener", () => {
+  const focusCalls: FocusOptions[] = [];
+  const visibleOpener = {
+    focus(options?: FocusOptions) {
+      focusCalls.push(options ?? {});
+    },
+    isConnected: true,
+    getClientRects() {
+      return { length: 1 } as DOMRectList;
+    },
+  } as unknown as HTMLButtonElement;
+  const body = { nodeName: "BODY" } as unknown as HTMLBodyElement;
+  const originalDocument = globalThis.document;
+
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      activeElement: body,
+      body,
+      querySelectorAll() {
+        return [visibleOpener] as unknown as NodeListOf<HTMLButtonElement>;
+      },
+    } as Pick<Document, "activeElement" | "body" | "querySelectorAll">,
+  });
+
+  try {
+    assert.equal(focusVisibleWorkspacePanelOpenerIfNeeded(), true);
+    assert.equal(focusVisibleWorkspacePanelOpenerIfNeeded(null), true);
+    assert.deepEqual(focusCalls, [{ preventScroll: true }, { preventScroll: true }]);
+  } finally {
+    if (originalDocument === undefined) {
+      Reflect.deleteProperty(globalThis, "document");
+    } else {
+      Object.defineProperty(globalThis, "document", {
+        configurable: true,
+        value: originalDocument,
+      });
+    }
+  }
+});
+
+test("focusVisibleWorkspacePanelOpenerIfNeeded leaves valid restored focus alone", () => {
+  let queryCount = 0;
+  const activeTrigger = {
+    focus() {
+      throw new Error("should not override a valid trigger focus target");
+    },
+    isConnected: true,
+  } as unknown as HTMLButtonElement;
+  const body = { nodeName: "BODY" } as unknown as HTMLBodyElement;
+  const originalDocument = globalThis.document;
+
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      activeElement: activeTrigger,
+      body,
+      querySelectorAll() {
+        queryCount += 1;
+        return [] as unknown as NodeListOf<HTMLButtonElement>;
+      },
+    } as Pick<Document, "activeElement" | "body" | "querySelectorAll">,
+  });
+
+  try {
+    assert.equal(focusVisibleWorkspacePanelOpenerIfNeeded(), false);
+    assert.equal(queryCount, 0);
+  } finally {
+    if (originalDocument === undefined) {
+      Reflect.deleteProperty(globalThis, "document");
+    } else {
+      Object.defineProperty(globalThis, "document", {
+        configurable: true,
+        value: originalDocument,
+      });
+    }
+  }
+});
+
+test("controlled dashboard dialogs capture and restore the active opener through Radix autofocus hooks", () => {
+  const source = readFileSync(new URL("./DashboardDialogs.tsx", import.meta.url), "utf8");
+
+  assert.equal(source.match(/captureDialogOpener\(openerRef\);/g)?.length, 3);
+  assert.equal(source.match(/restoreDialogOpener\(openerRef, event\)/g)?.length, 3);
+  assert.match(source, /<Dialog\.Content[\s\S]*onOpenAutoFocus=\{\(\) => \{\s*captureDialogOpener\(openerRef\);/);
+  assert.match(source, /<Dialog\.Content[\s\S]*onCloseAutoFocus=\{\(event\) => \{\s*if \(restoreDialogOpener\(openerRef, event\)\) return;\s*const workspacePanelOpener = findVisibleWorkspacePanelOpener\(\);\s*if \(!workspacePanelOpener\) return;\s*event\.preventDefault\(\);\s*workspacePanelOpener\.focus\(\{ preventScroll: true \}\);/);
+  assert.equal(source.match(/findVisibleWorkspacePanelOpener\(\);/g)?.length, 1);
+});
+
+test("new workspace dialog and nested folder picker stay mounted so Radix close autofocus can restore focus", () => {
+  const dashboardClientSource = readFileSync(
+    new URL("../DashboardClient.tsx", import.meta.url),
+    "utf8",
+  );
+  const dashboardDialogsSource = readFileSync(
+    new URL("./DashboardDialogs.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    dashboardClientSource,
+    /<NewWorkspaceDialog\s+open=\{newWorkspaceOpen\}\s+onClose=\{handleCloseNewWorkspaceDialog\}/,
+  );
+  assert.doesNotMatch(
+    dashboardClientSource,
+    /\{newWorkspaceOpen \? \(\s*<NewWorkspaceDialog/,
+  );
+  const newWorkspaceDialogBlock = dashboardDialogsSource.match(
+    /export function NewWorkspaceDialog[\s\S]*?\n}\n\nfunction FolderPickerDialog/,
+  );
+
+  assert.ok(newWorkspaceDialogBlock, "expected to isolate the NewWorkspaceDialog source block");
+  assert.doesNotMatch(
+    newWorkspaceDialogBlock[0],
+    /if \(!open\) return null;/,
+  );
+  assert.match(
+    newWorkspaceDialogBlock[0],
+    /<Dialog\.Root open=\{open\} onOpenChange=\{handleDialogOpenChange\}>/,
+  );
+  const folderPickerDialogBlock = dashboardDialogsSource.match(
+    /function FolderPickerDialog\([\s\S]*?\n}\n\nexport function SettingsDialog/,
+  );
+
+  assert.ok(folderPickerDialogBlock, "expected to isolate the FolderPickerDialog source block");
+  assert.doesNotMatch(
+    folderPickerDialogBlock[0],
+    /if \(!open\) return null;/,
+  );
+  assert.match(
+    folderPickerDialogBlock[0],
+    /<Dialog\.Root\s+open=\{open\}\s+onOpenChange=\{\(nextOpen\) => \{/,
+  );
+});
+
+test("settings dialog stays mounted in dashboard client so Radix close autofocus can run", () => {
+  const dashboardClientSource = readFileSync(
+    new URL("../DashboardClient.tsx", import.meta.url),
+    "utf8",
+  );
+  const dashboardDialogsSource = readFileSync(
+    new URL("./DashboardDialogs.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    dashboardClientSource,
+    /<SettingsDialog\s+open=\{preferencesDialogOpen\}\s+mode=\{onboardingRequired \? "onboarding" : "settings"\}/,
+  );
+  assert.doesNotMatch(
+    dashboardClientSource,
+    /\{preferencesDialogOpen \|\| onboardingRequired \? \(\s*<SettingsDialog/,
+  );
+  const settingsDialogBlock = dashboardDialogsSource.match(
+    /export function SettingsDialog[\s\S]*$/,
+  );
+
+  assert.ok(settingsDialogBlock, "expected to isolate the SettingsDialog source block");
+  assert.doesNotMatch(
+    settingsDialogBlock[0],
+    /if \(!open\) return null;/,
+  );
+  assert.match(
+    settingsDialogBlock[0],
+    /<Dialog\.Root open=\{open\} onOpenChange=\{handleDialogOpenChange\}>/,
+  );
+});
+
+test("dashboard client repairs mobile body focus after the new workspace dialog closes", () => {
+  const source = readFileSync(
+    new URL("../DashboardClient.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(source, /const previousNewWorkspaceOpenRef = useRef\(newWorkspaceOpen\);/);
+  assert.match(source, /const wasNewWorkspaceOpen = previousNewWorkspaceOpenRef\.current;/);
+  assert.match(source, /previousNewWorkspaceOpenRef\.current = newWorkspaceOpen;/);
+  assert.match(source, /if \(!wasNewWorkspaceOpen \|\| newWorkspaceOpen \|\| typeof window === "undefined"\) \{/);
+  assert.match(source, /window\.requestAnimationFrame\(\(\) => \{\s*focusVisibleWorkspacePanelOpenerIfNeeded\(\);\s*}\)/);
+});

--- a/packages/web/src/features/dashboard/components/dialogFocusRestore.ts
+++ b/packages/web/src/features/dashboard/components/dialogFocusRestore.ts
@@ -1,0 +1,76 @@
+import type { MutableRefObject } from "react";
+
+type DialogAutoFocusEvent = {
+  preventDefault: () => void;
+};
+
+type FocusableTarget = Pick<HTMLElement, "focus" | "isConnected"> & {
+  disabled?: boolean;
+};
+
+function isFocusableTarget(value: unknown): value is FocusableTarget {
+  return !!value && typeof value === "object" && typeof (value as { focus?: unknown }).focus === "function";
+}
+
+export function captureDialogAutoFocusTarget(activeElement: Element | null): HTMLElement | null {
+  return isFocusableTarget(activeElement) ? (activeElement as HTMLElement) : null;
+}
+
+export function restoreDialogAutoFocusTarget(
+  opener: HTMLElement | null,
+  event: DialogAutoFocusEvent,
+): boolean {
+  if (!isFocusableTarget(opener) || opener.isConnected === false || opener.disabled === true) {
+    return false;
+  }
+  event.preventDefault();
+  opener.focus({ preventScroll: true });
+  return true;
+}
+
+export function captureDialogOpener(openerRef: MutableRefObject<HTMLElement | null>): void {
+  if (typeof document === "undefined") return;
+  openerRef.current = captureDialogAutoFocusTarget(document.activeElement);
+}
+
+export function restoreDialogOpener(
+  openerRef: MutableRefObject<HTMLElement | null>,
+  event: DialogAutoFocusEvent,
+): boolean {
+  const opener = openerRef.current;
+  openerRef.current = null;
+  return restoreDialogAutoFocusTarget(opener, event);
+}
+
+export function findVisibleWorkspacePanelOpener(): HTMLButtonElement | null {
+  if (typeof document === "undefined") return null;
+
+  for (const opener of document.querySelectorAll<HTMLButtonElement>('button[aria-label="Open workspace panel"]')) {
+    if (!isFocusableTarget(opener) || opener.isConnected === false || opener.disabled === true) {
+      continue;
+    }
+    if (typeof opener.getClientRects === "function" && opener.getClientRects().length === 0) {
+      continue;
+    }
+    return opener;
+  }
+
+  return null;
+}
+
+export function focusVisibleWorkspacePanelOpenerIfNeeded(activeElement?: Element | null): boolean {
+  if (typeof document === "undefined") return false;
+
+  const currentActiveElement = activeElement === undefined ? document.activeElement : activeElement;
+  if (currentActiveElement && currentActiveElement !== document.body) {
+    return false;
+  }
+
+  const opener = findVisibleWorkspacePanelOpener();
+  if (!opener) {
+    return false;
+  }
+
+  opener.focus({ preventScroll: true });
+  return true;
+}

--- a/packages/web/src/features/sessions/SessionPageClient.tsx
+++ b/packages/web/src/features/sessions/SessionPageClient.tsx
@@ -212,6 +212,7 @@ export default function SessionPageClient({
           onCreateWorkspace={() => {
             router.push(dashboardRootHref);
           }}
+          onCloseMobile={closeSidebarOnMobile}
         />
       ) : null}
     >


### PR DESCRIPTION
## Summary

Consolidates every valuable uncommitted local change onto current `main` without carrying obsolete Codex app-server code, superseded dispatcher fragments, or temporary task-board files. It completes the mobile viewport work, makes batched dispatcher persistence durable across shutdown and deletion, repairs mobile update-notice controls, and patches the Nano ID dependency advisory.

## User-Facing Release Notes

- Conductor's mobile workspace, notes, session, and dispatcher surfaces now stay usable around on-screen keyboards and narrow viewports.
- Dispatcher updates now write fewer redundant snapshots, retain their latest state through graceful shutdown without stalling exit, and cannot recreate deleted threads.
- Mobile update controls now meet touch-target sizing, controlled dialogs trap and restore keyboard focus, and the bundled Nano ID dependency is updated to a patched release.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Agent or integration addition / modification
- [ ] Documentation update
- [ ] Refactor / chore

## Checklist

- [x] `bun run build:frontend` passes for frontend changes
- [x] `bun run typecheck` passes for TypeScript changes
- [x] `bun run test:packages` passes for package changes
- [x] `cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` pass for Rust changes
- [x] `cd bridge-cmd && go test ./...` passes for bridge changes
- [x] No `any` types introduced without justification
- [x] No secrets or credentials committed
- [x] Security boundaries, authentication, persistence, and network behavior have regression tests when changed
- [x] User-facing release notes are filled in plain English or marked internal-only
- [x] PR title follows conventional commits (`feat:`, `fix:`, `chore:`, etc.)

## Testing

```bash
cargo fmt --all --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
cd bridge-cmd && go test ./...
bun install --frozen-lockfile
bun run typecheck
bun run test:packages
node --test scripts/*.test.mjs
bun run build:frontend
bun audit --audit-level high
```

Production browser QA passed on the exact final build with a seeded project at 1440 by 900, 390 by 844, and 844 by 390. Board, notes, the mobile workspace drawer, nested workspace/folder dialogs, settings, and update-notice controls were exercised. Dialog focus stayed trapped and returned to the opener, the public bridge shell followed visual-viewport height changes from 844 to 600 pixels, document widths matched each viewport, touch controls measured at least 44 by 44 pixels, and no browser console or page errors occurred.

## Screenshots / Demo

Validated seeded desktop board, mobile board, landscape board, mobile notes, Add Workspace dialog, mobile update notice, and workspace-drawer screenshots from the local production build. Screenshots and machine-readable QA results are retained in the Obsidian delivery folder rather than committed to the source repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved mobile usability with larger touch targets, responsive board layouts, safer dropdowns, and better scrolling.
  - Added keyboard-safe viewport handling for dialogs, terminals, sidebars, and public pages.
  - Improved dialog accessibility, focus restoration, and mobile sidebar closing behavior.
- **Bug Fixes**
  - Prevented mobile keyboard, safe-area, and nested-scrolling issues across the application.
  - Improved recovery and durability of active sessions during shutdown or restart.
- **Tests**
  - Added coverage for mobile layouts, scrolling, dropdown behavior, dialog focus, and session recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->