### PR TITLE
feat: add WebMCP challenge control surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,14 @@ It helps you:
 - reach the same local runtime from a hosted dashboard through the paired-device bridge
 - keep project state in normal local files like `conductor.yaml`, `CONDUCTOR.md`, and `.conductor/conductor.db`
 
-## Read this first, there are two ways to use Conductor
+## WebMCP challenge extension
 
-A lot of confusion comes from mixing the local app and the hosted bridge flow.
+The challenge branch adds seven bounded browser-native WebMCP tools for projects, sessions, and diffs. State changes require `confirmed: true`.
+
+- Public demo: https://app.conductross.com/webmcp
+- Technical notes: [`docs/webmcp-challenge-2026.md`](docs/webmcp-challenge-2026.md)
+
+## Read this first, there are two ways to use Conductor
 
 ### 1. Local dashboard on the same machine
 Use this when Conductor and your repos live on the same laptop or desktop.

--- a/docs/webmcp-challenge-2026.md
+++ b/docs/webmcp-challenge-2026.md
@@ -1,0 +1,86 @@
+# Conductor WebMCP Challenge Spec
+
+## Verdict
+
+Enter Conductor OSS in the 2026 WebMCP Challenge as a meaningfully extended existing product. The new work starts after the August 25, 2026 opening and will be isolated in `feat/webmcp-challenge` until reviewed.
+
+## Product concept
+
+Conductor becomes a shared control surface for a person and a browser agent. The agent receives structured tools for reading workspace state, identifying sessions that need attention, opening the right session, starting bounded work, and sending feedback. The human stays in the visible Conductor dashboard and retains approval over state changes.
+
+## Why this is the strongest fit
+
+- Conductor is already a public, Apache-2.0 agent orchestration product.
+- WebMCP removes fragile dashboard clicking from a complex developer workflow.
+- The browser agent and coding agents have distinct roles, which makes the collaboration original and easy to demonstrate.
+- Existing Conductor API guards remain the authority for real mutations.
+- A public synthetic demo lets judges test the tools without access to a private machine or repository.
+
+## Scope
+
+### Public challenge route
+
+Create a public `/webmcp` route that:
+
+- looks and behaves like a focused Conductor workspace
+- uses clearly labeled synthetic sessions and diffs
+- registers browser native WebMCP tools on `document.modelContext`
+- updates the visible UI when tools run
+- exposes a tool inspector and sample prompts
+- works as a normal interactive web page when WebMCP is unavailable
+- never claims a real coding agent ran
+
+### Real dashboard integration
+
+Mount a WebMCP bridge in the real dashboard that:
+
+- lists configured projects and sessions through the existing guarded APIs
+- inspects a session and its diff
+- opens a selected session in the dashboard
+- starts a session only when the tool input contains explicit confirmation
+- sends feedback only when the tool input contains explicit confirmation
+- preserves bridge scope and backend access controls
+- returns bounded, structured, prompt-injection-safe summaries
+
+## Tool contract
+
+Public demo and real dashboard should share stable tool names where practical:
+
+1. `conductor_get_workspace_overview`
+2. `conductor_list_sessions`
+3. `conductor_inspect_session`
+4. `conductor_focus_session`
+5. `conductor_start_agent`
+6. `conductor_send_feedback`
+
+Read-only tools set `readOnlyHint: true`. Tool output containing project, prompt, branch, or diff text sets `untrustedContentHint: true`. Mutating tools require `confirmed: true` and state the side effect in their descriptions.
+
+## Security constraints
+
+- Prefer the current experimental `document.modelContext` API and support the earlier native `navigator.modelContext` surface for challenge-browser compatibility. No legacy MCP server or extension transport dependency.
+- Register tools with an `AbortController` and unregister them on unmount.
+- Do not expose terminal keystroke, arbitrary path, arbitrary URL, secret, environment, or deletion tools.
+- Keep tool results concise and explicitly mark user or repository text as untrusted data.
+- Reuse Conductor action guards, authentication, and bridge scoping. Do not add a bypass route.
+- The public demo is in-memory only and resets on reload.
+
+## Acceptance criteria
+
+- Six or more WebMCP tools register on supported Chrome builds.
+- The public route remains fully usable without WebMCP support.
+- At least one read-only and one mutating tool visibly updates the demo.
+- Real dashboard tools call existing guarded API routes and preserve bridge scope.
+- Mutating real tools reject calls without explicit confirmation.
+- Registration cleanup, tool schemas, confirmation gates, and demo reducers have automated tests.
+- Web package tests, typecheck, and production build pass.
+- The route is deployed to a public HTTPS URL.
+- A public repository contains all submission code.
+- A demo video shows discovery, invocation, visible UI updates, and the human approval boundary.
+
+## Delivery
+
+- Branch: `feat/webmcp-challenge`
+- Repository: https://github.com/charannyk06/conductor-oss
+- Production product: https://app.conductross.com/
+- Submission owner: AUTMA LLC
+- Deadline: September 3, 2026 at 1:00 p.m. PT

--- a/packages/web/src/app/api/sessions/[id]/feedback/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/feedback/route.ts
@@ -1,0 +1,8 @@
+import { guardedSessionProxyParamRoute } from "@/lib/proxyRoutes";
+
+export const dynamic = "force-dynamic";
+
+export const POST = guardedSessionProxyParamRoute(
+  ({ id }) => `/api/sessions/${encodeURIComponent(id ?? "")}/feedback`,
+  { role: "operator", requireActionGuard: true },
+);

--- a/packages/web/src/app/webmcp/page.tsx
+++ b/packages/web/src/app/webmcp/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import { WebMcpDemoPage } from "@/features/webmcp/WebMcpDemoPage";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Conductor WebMCP Challenge Demo",
+  description: "A browser-native WebMCP control surface for inspecting and coordinating bounded AI coding-agent work with explicit human approval.",
+};
+
+export default function WebMcpPage() {
+  return <WebMcpDemoPage />;
+}

--- a/packages/web/src/features/dashboard/DashboardClient.tsx
+++ b/packages/web/src/features/dashboard/DashboardClient.tsx
@@ -95,6 +95,7 @@ import { getDefaultSessionPrimaryTab } from "@/lib/sessionKinds";
 import {
   type RuntimeAgentModelCatalog,
 } from "@/lib/runtimeAgentModelsShared";
+import { useDashboardWebMcpBridge } from "@/features/webmcp/dashboardBridge";
 import {
   buildModelSelection,
   emptyModelSelection,
@@ -1420,6 +1421,14 @@ export default function DashboardClient({
     sessionsError,
     sessionsLoading,
   ]);
+
+  useDashboardWebMcpBridge({
+    bridgeId: effectiveBridgeId,
+    selectedSessionId,
+    selectedProjectId,
+    navigateDashboard,
+    refreshSessions,
+  });
 
   useEffect(() => {
     if (!selectedSessionId) {

--- a/packages/web/src/features/webmcp/WebMcpDemoPage.tsx
+++ b/packages/web/src/features/webmcp/WebMcpDemoPage.tsx
@@ -1,0 +1,733 @@
+"use client";
+
+import { useEffect, useMemo, useReducer, useRef, useState } from "react";
+import {
+  Bot,
+  CheckCircle2,
+  CircleAlert,
+  Clock3,
+  Eye,
+  FlaskConical,
+  FolderGit2,
+  ListFilter,
+  MessagesSquare,
+  Play,
+  ShieldCheck,
+  Sparkles,
+  Wrench,
+} from "lucide-react";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { PublicPageShell, PublicPanel, PublicSection } from "@/components/public/PublicPageShell";
+import { cn } from "@/lib/cn";
+import { WEBMCP_TOOL_ORDER, WEBMCP_TOOL_SPECS, type WebMcpToolName } from "@/lib/webmcpTools";
+import { createDemoWebMcpTools } from "@/features/webmcp/demoTools";
+import { createInitialDemoState, demoStateReducer, findDemoSession } from "@/features/webmcp/demoState";
+import { useWebMcpToolRegistration } from "@/features/webmcp/useWebMcpToolRegistration";
+
+type SamplePrompt = {
+  id: string;
+  label: string;
+  prompt: string;
+  toolName: WebMcpToolName;
+  configure?: () => void;
+};
+
+function statusBadgeVariant(status: string): "default" | "success" | "warning" | "error" | "info" {
+  if (status === "working" || status === "completed") return "success";
+  if (status === "needs_input") return "warning";
+  if (status === "review") return "error";
+  return "info";
+}
+
+function compatibilityBadgeVariant(supported: boolean): "success" | "warning" {
+  return supported ? "success" : "warning";
+}
+
+function readOnlyLabel(toolName: WebMcpToolName): string {
+  return WEBMCP_TOOL_SPECS[toolName].annotations?.readOnlyHint ? "Read only" : "State change";
+}
+
+function formattedToolCount(count: number): string {
+  return `${count} tool${count === 1 ? "" : "s"}`;
+}
+
+export function WebMcpDemoPage() {
+  const [state, dispatch] = useReducer(demoStateReducer, undefined, createInitialDemoState);
+  const stateRef = useRef(state);
+  const [activeToolName, setActiveToolName] = useState<WebMcpToolName>("conductor_get_workspace_overview");
+  const [projectFilter, setProjectFilter] = useState("demo-web");
+  const [sessionTarget, setSessionTarget] = useState(state.selectedSessionId);
+  const [sessionStatusFilter, setSessionStatusFilter] = useState("");
+  const [limitValue, setLimitValue] = useState("6");
+  const [promptDraft, setPromptDraft] = useState(
+    "Prepare a judge-facing walkthrough for the synthetic WebMCP demo and keep every change visible in the dashboard.",
+  );
+  const [feedbackDraft, setFeedbackDraft] = useState(
+    "Keep the confirmation boundary explicit and mention that this page uses synthetic in-memory data only.",
+  );
+  const [confirmFocus, setConfirmFocus] = useState(false);
+  const [confirmStart, setConfirmStart] = useState(false);
+  const [confirmFeedback, setConfirmFeedback] = useState(false);
+  const [runningTool, setRunningTool] = useState<WebMcpToolName | null>(null);
+  const [lastResult, setLastResult] = useState<string>("");
+
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
+  useEffect(() => {
+    setSessionTarget((current) => {
+      if (state.sessions.some((session) => session.id === current)) {
+        return current;
+      }
+      return state.selectedSessionId;
+    });
+    setProjectFilter((current) => {
+      if (state.projects.some((project) => project.id === current)) {
+        return current;
+      }
+      return state.projects[0]?.id ?? "";
+    });
+  }, [state.projects, state.selectedSessionId, state.sessions]);
+
+  const tools = useMemo(
+    () => createDemoWebMcpTools(() => stateRef.current, dispatch),
+    [dispatch],
+  );
+  const toolsByName = useMemo(
+    () => new Map(tools.map((tool) => [tool.name as WebMcpToolName, tool])),
+    [tools],
+  );
+  const compatibility = useWebMcpToolRegistration(tools);
+  const selectedSession = useMemo(
+    () => findDemoSession(state, state.selectedSessionId),
+    [state],
+  );
+
+  const runTool = async (toolName: WebMcpToolName, args: unknown) => {
+    const tool = toolsByName.get(toolName);
+    if (!tool) {
+      return;
+    }
+    setRunningTool(toolName);
+    try {
+      const output = await tool.execute(args);
+      setLastResult(output);
+    } finally {
+      setRunningTool(null);
+    }
+  };
+
+  const activeSchema = WEBMCP_TOOL_SPECS[activeToolName].inputSchema;
+  const activeTool = toolsByName.get(activeToolName) ?? null;
+
+  const samplePrompts: SamplePrompt[] = [
+    {
+      id: "sample-1",
+      label: "Overview",
+      prompt: "Get the workspace overview and summarize which synthetic session is currently focused.",
+      toolName: "conductor_get_workspace_overview",
+      configure: () => {
+        setActiveToolName("conductor_get_workspace_overview");
+        setProjectFilter("demo-web");
+        setLimitValue("6");
+      },
+    },
+    {
+      id: "sample-2",
+      label: "Inspect",
+      prompt: "Inspect `demo-session-198` and summarize the synthetic diff plus the approval boundary.",
+      toolName: "conductor_inspect_session",
+      configure: () => {
+        setActiveToolName("conductor_inspect_session");
+        setSessionTarget("demo-session-198");
+      },
+    },
+    {
+      id: "sample-3",
+      label: "Focus",
+      prompt: "Focus `demo-session-176` in the visible workspace and proceed only if `confirmed` is true.",
+      toolName: "conductor_focus_session",
+      configure: () => {
+        setActiveToolName("conductor_focus_session");
+        setSessionTarget("demo-session-176");
+        setConfirmFocus(true);
+      },
+    },
+    {
+      id: "sample-4",
+      label: "Start",
+      prompt: "Start a new synthetic session for `demo-docs` and only proceed if `confirmed` is true.",
+      toolName: "conductor_start_agent",
+      configure: () => {
+        setActiveToolName("conductor_start_agent");
+        setProjectFilter("demo-docs");
+        setPromptDraft("Draft a concise public walkthrough for the WebMCP challenge judges.");
+        setConfirmStart(true);
+      },
+    },
+  ];
+
+  const buildArgsForActiveTool = (): unknown => {
+    const limit = Number.parseInt(limitValue, 10);
+    if (activeToolName === "conductor_get_workspace_overview") {
+      return { projectId: projectFilter || undefined, sessionLimit: Number.isFinite(limit) ? limit : 6 };
+    }
+    if (activeToolName === "conductor_list_projects") {
+      return { limit: Number.isFinite(limit) ? limit : 6 };
+    }
+    if (activeToolName === "conductor_list_sessions") {
+      return {
+        projectId: projectFilter || undefined,
+        status: sessionStatusFilter || undefined,
+        limit: Number.isFinite(limit) ? limit : 6,
+      };
+    }
+    if (activeToolName === "conductor_inspect_session") {
+      return { sessionId: sessionTarget };
+    }
+    if (activeToolName === "conductor_focus_session") {
+      return { sessionId: sessionTarget, confirmed: confirmFocus };
+    }
+    if (activeToolName === "conductor_start_agent") {
+      return {
+        projectId: projectFilter,
+        prompt: promptDraft,
+        confirmed: confirmStart,
+        agent: "codex",
+      };
+    }
+    return {
+      sessionId: sessionTarget,
+      feedback: feedbackDraft,
+      confirmed: confirmFeedback,
+    };
+  };
+
+  return (
+    <PublicPageShell>
+      <div className="space-y-8">
+        <PublicSection
+          title="Browser-native WebMCP for Conductor"
+          description="This public route is a backend-free synthetic workspace built for the challenge branch. It registers browser-native tools when `document.modelContext.registerTool` is available, stays fully usable without WebMCP, and makes every visible state change explicit."
+        >
+          <div className="flex flex-wrap gap-2">
+            <Badge variant="info">Public route</Badge>
+            <Badge variant="info">Synthetic data</Badge>
+            <Badge variant={compatibilityBadgeVariant(compatibility.supported)}>
+              {compatibility.supported ? "WebMCP available" : "WebMCP unavailable"}
+            </Badge>
+            <Badge variant="outline">{formattedToolCount(tools.length)}</Badge>
+          </div>
+        </PublicSection>
+
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(340px,0.95fr)]">
+          <div className="min-w-0 space-y-6">
+            <PublicPanel className="overflow-hidden">
+              <div className="border-b border-[var(--border-soft)] px-5 py-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="space-y-1">
+                    <p className="text-[11px] uppercase tracking-[0.22em] text-[var(--text-faint)]">Compatibility</p>
+                    <h2 className="text-lg font-semibold tracking-[-0.02em] text-[var(--text-strong)]">
+                      Cross-browser status
+                    </h2>
+                  </div>
+                  <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">
+                    <Badge variant={compatibilityBadgeVariant(compatibility.supported)}>
+                      {compatibility.supported ? "Registered" : "Fallback mode"}
+                    </Badge>
+                    <Badge variant="outline">{compatibility.toolRegistrationAvailable ? "registerTool found" : "registerTool missing"}</Badge>
+                  </div>
+                </div>
+                <p className="mt-3 max-w-3xl text-sm leading-6 text-[var(--text-muted)]">
+                  {compatibility.reason}
+                </p>
+              </div>
+
+              <div className="grid gap-px bg-[var(--border-soft)] md:grid-cols-3">
+                <div className="bg-[var(--bg-panel)] px-5 py-4">
+                  <div className="flex items-center gap-2 text-[var(--text-muted)]">
+                    <ShieldCheck className="h-4 w-4" />
+                    <span className="text-[12px] uppercase tracking-[0.18em]">Guardrails</span>
+                  </div>
+                  <p className="mt-3 text-sm leading-6 text-[var(--text-normal)]">
+                    No terminal keystrokes, no secrets, no arbitrary paths, no arbitrary URLs, and no destructive actions.
+                  </p>
+                </div>
+                <div className="bg-[var(--bg-panel)] px-5 py-4">
+                  <div className="flex items-center gap-2 text-[var(--text-muted)]">
+                    <FlaskConical className="h-4 w-4" />
+                    <span className="text-[12px] uppercase tracking-[0.18em]">Synthetic scope</span>
+                  </div>
+                  <p className="mt-3 text-sm leading-6 text-[var(--text-normal)]">
+                    Every project, session, prompt, and diff on this page is synthetic and resets on reload.
+                  </p>
+                </div>
+                <div className="bg-[var(--bg-panel)] px-5 py-4">
+                  <div className="flex items-center gap-2 text-[var(--text-muted)]">
+                    <CheckCircle2 className="h-4 w-4" />
+                    <span className="text-[12px] uppercase tracking-[0.18em]">Approval boundary</span>
+                  </div>
+                  <p className="mt-3 text-sm leading-6 text-[var(--text-normal)]">
+                    Mutating tools require `confirmed: true`, even in the synthetic demo.
+                  </p>
+                </div>
+              </div>
+            </PublicPanel>
+
+            <PublicPanel className="overflow-hidden">
+              <div className="border-b border-[var(--border-soft)] px-5 py-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <p className="text-[11px] uppercase tracking-[0.22em] text-[var(--text-faint)]">Workspace</p>
+                    <h2 className="text-lg font-semibold tracking-[-0.02em] text-[var(--text-strong)]">
+                      {state.workspaceName}
+                    </h2>
+                  </div>
+                  <Badge variant="outline" className="max-w-full whitespace-normal text-left">{state.workspaceLabel}</Badge>
+                </div>
+              </div>
+
+              <div className="grid gap-6 p-5 xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
+                <div className="space-y-4">
+                  <div className="space-y-3">
+                    <div className="flex items-center gap-2 text-sm font-medium text-[var(--text-normal)]">
+                      <FolderGit2 className="h-4 w-4 text-[var(--vk-orange)]" />
+                      Synthetic projects
+                    </div>
+                    <div className="grid gap-3">
+                      {state.projects.map((project) => (
+                        <div
+                          key={project.id}
+                          className={cn(
+                            "rounded-[var(--radius-md)] border px-4 py-3",
+                            project.id === projectFilter
+                              ? "border-[var(--vk-orange)] bg-[color:color-mix(in_srgb,var(--vk-orange)_12%,var(--bg-panel))]"
+                              : "border-[var(--border-soft)] bg-[var(--bg-shell)]",
+                          )}
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="space-y-1">
+                              <div className="flex items-center gap-2">
+                                <span className="font-medium text-[var(--text-strong)]">{project.name}</span>
+                                <Badge variant="outline">{project.syntheticLabel}</Badge>
+                              </div>
+                              <p className="text-sm leading-6 text-[var(--text-muted)]">{project.description}</p>
+                            </div>
+                            <Badge variant={project.health === "attention" ? "warning" : project.health === "working" ? "success" : "info"}>
+                              {project.health}
+                            </Badge>
+                          </div>
+                          <p className="mt-3 text-xs uppercase tracking-[0.16em] text-[var(--text-faint)]">
+                            Branch: <span className="normal-case tracking-normal text-[var(--text-normal)]">{project.branch}</span>
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="space-y-3">
+                    <div className="flex items-center gap-2 text-sm font-medium text-[var(--text-normal)]">
+                      <Clock3 className="h-4 w-4 text-[var(--vk-orange)]" />
+                      Recent tool activity
+                    </div>
+                    <div className="grid gap-2">
+                      {state.toolRuns.length === 0 ? (
+                        <div className="rounded-[var(--radius-md)] border border-dashed border-[var(--border-soft)] px-4 py-4 text-sm leading-6 text-[var(--text-muted)]">
+                          Run a tool from the inspector or through WebMCP to log visible activity here.
+                        </div>
+                      ) : (
+                        state.toolRuns.map((run) => (
+                          <div key={run.id} className="rounded-[var(--radius-md)] border border-[var(--border-soft)] bg-[var(--bg-shell)] px-4 py-3">
+                            <div className="flex items-start justify-between gap-3">
+                              <div>
+                                <p className="font-medium text-[var(--text-strong)]">{run.toolName}</p>
+                                <p className="mt-1 text-sm leading-6 text-[var(--text-muted)]">{run.summary}</p>
+                              </div>
+                              <Badge variant={run.changedState ? "warning" : "outline"}>
+                                {run.changedState ? "State changed" : "Read"}
+                              </Badge>
+                            </div>
+                            <p className="mt-2 text-xs leading-5 text-[var(--text-faint)]">{run.outputPreview}</p>
+                          </div>
+                        ))
+                      )}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="space-y-4">
+                  <div className="space-y-3">
+                    <div className="flex items-center gap-2 text-sm font-medium text-[var(--text-normal)]">
+                      <MessagesSquare className="h-4 w-4 text-[var(--vk-orange)]" />
+                      Synthetic sessions
+                    </div>
+                    <div className="grid gap-2">
+                      {state.sessions.map((session) => {
+                        const active = session.id === state.selectedSessionId;
+                        return (
+                          <button
+                            key={session.id}
+                            type="button"
+                            onClick={() => dispatch({
+                              type: "focus-session",
+                              sessionId: session.id,
+                              timestamp: new Date().toISOString(),
+                            })}
+                            className={cn(
+                              "w-full rounded-[var(--radius-md)] border px-4 py-3 text-left transition-colors",
+                              active
+                                ? "border-[var(--vk-orange)] bg-[color:color-mix(in_srgb,var(--vk-orange)_10%,var(--bg-panel))]"
+                                : "border-[var(--border-soft)] bg-[var(--bg-shell)] hover:bg-[var(--bg-panel)]",
+                            )}
+                          >
+                            <div className="flex items-start justify-between gap-3">
+                              <div className="min-w-0">
+                                <div className="flex flex-wrap items-center gap-2">
+                                  <span className="truncate font-medium text-[var(--text-strong)]">{session.title}</span>
+                                  <Badge variant="outline">{session.syntheticLabel}</Badge>
+                                </div>
+                                <p className="mt-1 text-sm text-[var(--text-muted)]">
+                                  {session.id} · {session.projectId} · {session.agent}
+                                </p>
+                              </div>
+                              <Badge variant={statusBadgeVariant(session.status)}>{session.status}</Badge>
+                            </div>
+                            <p className="mt-3 text-sm leading-6 text-[var(--text-normal)]">{session.summary}</p>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  {selectedSession ? (
+                    <div className="rounded-[var(--radius-md)] border border-[var(--border-soft)] bg-[var(--bg-shell)]">
+                      <div className="border-b border-[var(--border-soft)] px-4 py-3">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Eye className="h-4 w-4 text-[var(--vk-orange)]" />
+                          <span className="font-medium text-[var(--text-strong)]">Focused synthetic session</span>
+                          <Badge variant={statusBadgeVariant(selectedSession.status)}>{selectedSession.status}</Badge>
+                        </div>
+                      </div>
+                      <div className="space-y-4 px-4 py-4">
+                        <div className="grid gap-3 sm:grid-cols-2">
+                          <div className="rounded-[var(--radius-md)] border border-[var(--border-soft)] bg-[var(--bg-panel)] px-3 py-3">
+                            <p className="text-[11px] uppercase tracking-[0.18em] text-[var(--text-faint)]">Prompt</p>
+                            <p className="mt-2 text-sm leading-6 text-[var(--text-normal)]">{selectedSession.prompt}</p>
+                          </div>
+                          <div className="rounded-[var(--radius-md)] border border-[var(--border-soft)] bg-[var(--bg-panel)] px-3 py-3">
+                            <p className="text-[11px] uppercase tracking-[0.18em] text-[var(--text-faint)]">Diff summary</p>
+                            <p className="mt-2 text-sm leading-6 text-[var(--text-normal)]">{selectedSession.diffSummary}</p>
+                          </div>
+                        </div>
+
+                        <div className="rounded-[var(--radius-md)] border border-[var(--border-soft)] bg-[var(--bg-panel)] px-3 py-3">
+                          <p className="text-[11px] uppercase tracking-[0.18em] text-[var(--text-faint)]">Synthetic diff files</p>
+                          <div className="mt-3 space-y-2">
+                            {selectedSession.diffFiles.length === 0 ? (
+                              <p className="text-sm leading-6 text-[var(--text-muted)]">No diff yet for this synthetic queued session.</p>
+                            ) : (
+                              selectedSession.diffFiles.map((file) => (
+                                <div key={`${selectedSession.id}-${file.path}`} className="flex items-center justify-between gap-3 rounded-[var(--radius-sm)] border border-[var(--border-soft)] px-3 py-2">
+                                  <div className="min-w-0">
+                                    <p className="truncate font-mono text-[12px] text-[var(--text-strong)]">{file.path}</p>
+                                    <p className="text-xs text-[var(--text-faint)]">{file.status}</p>
+                                  </div>
+                                  <p className="shrink-0 text-xs text-[var(--text-muted)]">
+                                    +{file.additions} / -{file.deletions}
+                                  </p>
+                                </div>
+                              ))
+                            )}
+                          </div>
+                        </div>
+
+                        {selectedSession.lastFeedback ? (
+                          <div className="rounded-[var(--radius-md)] border border-[var(--border-soft)] bg-[var(--bg-panel)] px-3 py-3">
+                            <p className="text-[11px] uppercase tracking-[0.18em] text-[var(--text-faint)]">Last feedback</p>
+                            <p className="mt-2 text-sm leading-6 text-[var(--text-normal)]">{selectedSession.lastFeedback}</p>
+                          </div>
+                        ) : null}
+                      </div>
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+            </PublicPanel>
+
+            <PublicPanel className="overflow-hidden">
+              <div className="border-b border-[var(--border-soft)] px-5 py-4">
+                <div className="flex items-center gap-2">
+                  <Sparkles className="h-4 w-4 text-[var(--vk-orange)]" />
+                  <h2 className="text-lg font-semibold tracking-[-0.02em] text-[var(--text-strong)]">
+                    Timeline
+                  </h2>
+                </div>
+              </div>
+              <div className="space-y-3 px-5 py-4">
+                {state.timeline.map((event) => (
+                  <div key={event.id} className="rounded-[var(--radius-md)] border border-[var(--border-soft)] bg-[var(--bg-shell)] px-4 py-3">
+                    <p className="text-sm leading-6 text-[var(--text-normal)]">{event.label}</p>
+                    <p className="mt-1 text-xs text-[var(--text-faint)]">{event.timestamp}</p>
+                  </div>
+                ))}
+              </div>
+            </PublicPanel>
+          </div>
+
+          <div className="min-w-0 space-y-6">
+            <PublicPanel className="overflow-hidden">
+              <div className="border-b border-[var(--border-soft)] px-5 py-4">
+                <div className="flex items-center gap-2">
+                  <Wrench className="h-4 w-4 text-[var(--vk-orange)]" />
+                  <h2 className="text-lg font-semibold tracking-[-0.02em] text-[var(--text-strong)]">Tool inspector</h2>
+                </div>
+                <p className="mt-2 text-sm leading-6 text-[var(--text-muted)]">
+                  Every tool below uses the same browser-native registration metadata as the real dashboard bridge.
+                </p>
+              </div>
+
+              <div className="grid gap-px bg-[var(--border-soft)]">
+                <div className="bg-[var(--bg-panel)] p-3">
+                  <div className="grid gap-2">
+                    {WEBMCP_TOOL_ORDER.map((toolName) => {
+                      const spec = WEBMCP_TOOL_SPECS[toolName];
+                      const active = toolName === activeToolName;
+                      return (
+                        <button
+                          key={toolName}
+                          type="button"
+                          onClick={() => setActiveToolName(toolName)}
+                          className={cn(
+                            "w-full rounded-[var(--radius-md)] border px-3 py-3 text-left transition-colors",
+                            active
+                              ? "border-[var(--vk-orange)] bg-[color:color-mix(in_srgb,var(--vk-orange)_10%,var(--bg-shell))]"
+                              : "border-[var(--border-soft)] bg-[var(--bg-shell)] hover:bg-[var(--bg-panel-2)]",
+                          )}
+                        >
+                          <p className="break-words font-mono text-[12px] font-medium leading-5 text-[var(--text-strong)]">{toolName}</p>
+                          <div className="mt-2 flex flex-wrap gap-2">
+                            <Badge variant={spec.annotations?.readOnlyHint ? "outline" : "warning"}>
+                              {readOnlyLabel(toolName)}
+                            </Badge>
+                            {spec.annotations?.untrustedContentHint ? (
+                              <Badge variant="info">Untrusted content</Badge>
+                            ) : null}
+                          </div>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                <div className="space-y-4 bg-[var(--bg-panel)] p-5">
+                  <div className="grid gap-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge variant={WEBMCP_TOOL_SPECS[activeToolName].annotations?.readOnlyHint ? "outline" : "warning"}>
+                        {readOnlyLabel(activeToolName)}
+                      </Badge>
+                      {WEBMCP_TOOL_SPECS[activeToolName].annotations?.untrustedContentHint ? (
+                        <Badge variant="info">Returns untrusted content</Badge>
+                      ) : null}
+                    </div>
+                    <h3 className="break-words font-mono text-[13px] font-semibold leading-5 text-[var(--text-strong)]">{activeToolName}</h3>
+                    <p className="text-sm leading-6 text-[var(--text-muted)]">
+                      {WEBMCP_TOOL_SPECS[activeToolName].description}
+                    </p>
+                  </div>
+
+                  <div className="space-y-3 rounded-[var(--radius-md)] border border-[var(--border-soft)] bg-[var(--bg-shell)] px-4 py-4">
+                    <div className="flex items-center gap-2 text-sm font-medium text-[var(--text-normal)]">
+                      <ListFilter className="h-4 w-4 text-[var(--vk-orange)]" />
+                      Manual invocation
+                    </div>
+
+                    {(activeToolName === "conductor_get_workspace_overview"
+                      || activeToolName === "conductor_list_sessions"
+                      || activeToolName === "conductor_start_agent") ? (
+                      <label className="block space-y-1.5">
+                        <span className="text-xs uppercase tracking-[0.18em] text-[var(--text-faint)]">Project</span>
+                        <select
+                          value={projectFilter}
+                          onChange={(event) => setProjectFilter(event.target.value)}
+                          className="h-9 w-full rounded-[4px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] px-2 text-[14px] text-[var(--vk-text-normal)] outline-none focus:border-[var(--vk-orange)]"
+                        >
+                          {state.projects.map((project) => (
+                            <option key={project.id} value={project.id}>{project.id}</option>
+                          ))}
+                        </select>
+                      </label>
+                    ) : null}
+
+                    {(activeToolName === "conductor_get_workspace_overview"
+                      || activeToolName === "conductor_list_projects"
+                      || activeToolName === "conductor_list_sessions") ? (
+                      <label className="block space-y-1.5">
+                        <span className="text-xs uppercase tracking-[0.18em] text-[var(--text-faint)]">Limit</span>
+                        <input
+                          value={limitValue}
+                          onChange={(event) => setLimitValue(event.target.value)}
+                          className="h-9 w-full rounded-[4px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] px-2 text-[14px] text-[var(--vk-text-normal)] outline-none focus:border-[var(--vk-orange)]"
+                          inputMode="numeric"
+                        />
+                      </label>
+                    ) : null}
+
+                    {activeToolName === "conductor_list_sessions" ? (
+                      <label className="block space-y-1.5">
+                        <span className="text-xs uppercase tracking-[0.18em] text-[var(--text-faint)]">Status</span>
+                        <input
+                          value={sessionStatusFilter}
+                          onChange={(event) => setSessionStatusFilter(event.target.value)}
+                          placeholder="working, needs_input, review..."
+                          className="h-9 w-full rounded-[4px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] px-2 text-[14px] text-[var(--vk-text-normal)] outline-none focus:border-[var(--vk-orange)]"
+                        />
+                      </label>
+                    ) : null}
+
+                    {(activeToolName === "conductor_inspect_session"
+                      || activeToolName === "conductor_focus_session"
+                      || activeToolName === "conductor_send_feedback") ? (
+                      <label className="block space-y-1.5">
+                        <span className="text-xs uppercase tracking-[0.18em] text-[var(--text-faint)]">Session</span>
+                        <select
+                          value={sessionTarget}
+                          onChange={(event) => setSessionTarget(event.target.value)}
+                          className="h-9 w-full rounded-[4px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] px-2 text-[14px] text-[var(--vk-text-normal)] outline-none focus:border-[var(--vk-orange)]"
+                        >
+                          {state.sessions.map((session) => (
+                            <option key={session.id} value={session.id}>{session.id}</option>
+                          ))}
+                        </select>
+                      </label>
+                    ) : null}
+
+                    {activeToolName === "conductor_focus_session" ? (
+                      <label className="flex items-center gap-3 rounded-[var(--radius-sm)] border border-[var(--border-soft)] px-3 py-2 text-sm text-[var(--text-normal)]">
+                        <input
+                          type="checkbox"
+                          checked={confirmFocus}
+                          onChange={(event) => setConfirmFocus(event.target.checked)}
+                        />
+                        confirmed: true
+                      </label>
+                    ) : null}
+
+                    {activeToolName === "conductor_start_agent" ? (
+                      <>
+                        <label className="block space-y-1.5">
+                          <span className="text-xs uppercase tracking-[0.18em] text-[var(--text-faint)]">Prompt</span>
+                          <textarea
+                            value={promptDraft}
+                            onChange={(event) => setPromptDraft(event.target.value)}
+                            className="min-h-28 w-full rounded-[4px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] px-3 py-2 text-[14px] leading-6 text-[var(--vk-text-normal)] outline-none focus:border-[var(--vk-orange)]"
+                          />
+                        </label>
+                        <label className="flex items-center gap-3 rounded-[var(--radius-sm)] border border-[var(--border-soft)] px-3 py-2 text-sm text-[var(--text-normal)]">
+                          <input
+                            type="checkbox"
+                            checked={confirmStart}
+                            onChange={(event) => setConfirmStart(event.target.checked)}
+                          />
+                          confirmed: true
+                        </label>
+                      </>
+                    ) : null}
+
+                    {activeToolName === "conductor_send_feedback" ? (
+                      <>
+                        <label className="block space-y-1.5">
+                          <span className="text-xs uppercase tracking-[0.18em] text-[var(--text-faint)]">Feedback</span>
+                          <textarea
+                            value={feedbackDraft}
+                            onChange={(event) => setFeedbackDraft(event.target.value)}
+                            className="min-h-28 w-full rounded-[4px] border border-[var(--vk-border)] bg-[var(--vk-bg-panel)] px-3 py-2 text-[14px] leading-6 text-[var(--vk-text-normal)] outline-none focus:border-[var(--vk-orange)]"
+                          />
+                        </label>
+                        <label className="flex items-center gap-3 rounded-[var(--radius-sm)] border border-[var(--border-soft)] px-3 py-2 text-sm text-[var(--text-normal)]">
+                          <input
+                            type="checkbox"
+                            checked={confirmFeedback}
+                            onChange={(event) => setConfirmFeedback(event.target.checked)}
+                          />
+                          confirmed: true
+                        </label>
+                      </>
+                    ) : null}
+
+                    <div className="flex flex-wrap gap-2">
+                      <Button
+                        variant="primary"
+                        size="md"
+                        onClick={() => void runTool(activeToolName, buildArgsForActiveTool())}
+                        disabled={!activeTool || runningTool !== null}
+                      >
+                        {runningTool === activeToolName ? (
+                          <>
+                            <Bot className="h-4 w-4 animate-pulse" />
+                            Running
+                          </>
+                        ) : (
+                          <>
+                            <Play className="h-4 w-4" />
+                            Run tool
+                          </>
+                        )}
+                      </Button>
+                      {!compatibility.supported ? (
+                        <div className="flex items-center gap-2 rounded-[var(--radius-sm)] border border-[var(--border-soft)] px-3 py-2 text-sm text-[var(--text-muted)]">
+                          <CircleAlert className="h-4 w-4" />
+                          Manual fallback stays usable without WebMCP.
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+
+                  <div className="space-y-2 rounded-[var(--radius-md)] border border-[var(--border-soft)] bg-[var(--bg-shell)] px-4 py-4">
+                    <p className="text-sm font-medium text-[var(--text-normal)]">Input schema</p>
+                    <pre className="overflow-x-auto rounded-[var(--radius-sm)] bg-[var(--bg-panel)] p-3 text-[12px] leading-6 text-[var(--text-muted)]">
+                      {JSON.stringify(activeSchema, null, 2)}
+                    </pre>
+                  </div>
+
+                  <div className="space-y-2 rounded-[var(--radius-md)] border border-[var(--border-soft)] bg-[var(--bg-shell)] px-4 py-4">
+                    <p className="text-sm font-medium text-[var(--text-normal)]">Last JSON result</p>
+                    <pre className="max-h-[320px] overflow-auto rounded-[var(--radius-sm)] bg-[var(--bg-panel)] p-3 text-[12px] leading-6 text-[var(--text-muted)]">
+                      {lastResult || "Run a tool to inspect its JSON string output."}
+                    </pre>
+                  </div>
+                </div>
+              </div>
+            </PublicPanel>
+
+            <PublicPanel className="overflow-hidden">
+              <div className="border-b border-[var(--border-soft)] px-5 py-4">
+                <div className="flex items-center gap-2">
+                  <Sparkles className="h-4 w-4 text-[var(--vk-orange)]" />
+                  <h2 className="text-lg font-semibold tracking-[-0.02em] text-[var(--text-strong)]">Sample prompts</h2>
+                </div>
+              </div>
+              <div className="space-y-3 px-5 py-4">
+                {samplePrompts.map((entry) => (
+                  <button
+                    key={entry.id}
+                    type="button"
+                    onClick={() => entry.configure?.()}
+                    className="w-full rounded-[var(--radius-md)] border border-[var(--border-soft)] bg-[var(--bg-shell)] px-4 py-3 text-left transition-colors hover:bg-[var(--bg-panel)]"
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <span className="font-medium text-[var(--text-strong)]">{entry.label}</span>
+                      <Badge variant="outline">{entry.toolName}</Badge>
+                    </div>
+                    <p className="mt-2 text-sm leading-6 text-[var(--text-muted)]">{entry.prompt}</p>
+                  </button>
+                ))}
+              </div>
+            </PublicPanel>
+          </div>
+        </div>
+      </div>
+    </PublicPageShell>
+  );
+}

--- a/packages/web/src/features/webmcp/dashboardBridge.test.ts
+++ b/packages/web/src/features/webmcp/dashboardBridge.test.ts
@@ -1,0 +1,268 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createDashboardWebMcpTools } from "./dashboardBridge";
+
+test("dashboard WebMCP mutation tools reject unconfirmed requests before fetch", async () => {
+  const originalFetch = global.fetch;
+  let fetchCalls = 0;
+  global.fetch = (async () => {
+    fetchCalls += 1;
+    return Response.json({ ok: true });
+  }) as typeof fetch;
+
+  try {
+    const tools = createDashboardWebMcpTools({
+      getBridgeId: () => "bridge-demo",
+      getSelection: () => ({ selectedProjectId: "demo-web", selectedSessionId: "session-1" }),
+      navigateDashboard: () => {},
+      refreshSessions: async () => {},
+    });
+    const focusTool = tools.find((tool) => tool.name === "conductor_focus_session");
+    const startTool = tools.find((tool) => tool.name === "conductor_start_agent");
+    const feedbackTool = tools.find((tool) => tool.name === "conductor_send_feedback");
+    assert.ok(focusTool);
+    assert.ok(startTool);
+    assert.ok(feedbackTool);
+
+    const focusResult = JSON.parse(await focusTool!.execute({
+      sessionId: "session-1",
+      confirmed: false,
+    })) as { requiresConfirmation?: boolean };
+    const startResult = JSON.parse(await startTool!.execute({
+      projectId: "demo-web",
+      prompt: "Unsafe without confirmation",
+      confirmed: false,
+    })) as { requiresConfirmation?: boolean };
+    const feedbackResult = JSON.parse(await feedbackTool!.execute({
+      sessionId: "session-1",
+      feedback: "Unsafe without confirmation",
+      confirmed: false,
+    })) as { requiresConfirmation?: boolean };
+
+    assert.equal(focusResult.requiresConfirmation, true);
+    assert.equal(startResult.requiresConfirmation, true);
+    assert.equal(feedbackResult.requiresConfirmation, true);
+    assert.equal(fetchCalls, 0);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("dashboard WebMCP preserves bridge scope and forwards execution cancellation", async () => {
+  const originalFetch = global.fetch;
+  const controller = new AbortController();
+  let requestUrl = "";
+  let requestSignal: AbortSignal | null | undefined;
+  let navigatedBridgeId: string | null | undefined;
+
+  global.fetch = (async (input, init) => {
+    requestUrl = String(input);
+    requestSignal = init?.signal;
+    return Response.json({
+      id: "bridge:remote-7:session-42",
+      projectId: "demo-web",
+      status: "working",
+      activity: "active",
+      agent: "codex",
+      branch: "feat/webmcp",
+      summary: "Remote synthetic summary",
+      createdAt: "2026-08-25T20:00:00.000Z",
+      lastActivityAt: "2026-08-25T20:10:00.000Z",
+      metadata: {},
+    });
+  }) as typeof fetch;
+
+  try {
+    const tools = createDashboardWebMcpTools({
+      getBridgeId: () => null,
+      getSelection: () => ({ selectedProjectId: null, selectedSessionId: null }),
+      navigateDashboard: (updates) => {
+        navigatedBridgeId = updates.bridgeId;
+      },
+      refreshSessions: async () => {},
+      requestHumanConfirmation: async () => true,
+    });
+    const focusTool = tools.find((tool) => tool.name === "conductor_focus_session");
+    assert.ok(focusTool);
+
+    const result = JSON.parse(await focusTool!.execute({
+      sessionId: "bridge:remote-7:session-42",
+      confirmed: true,
+    }, { signal: controller.signal })) as { bridgeScope?: string };
+
+    assert.equal(result.bridgeScope, "remote-7");
+    assert.equal(navigatedBridgeId, "remote-7");
+    assert.match(requestUrl, /bridgeId=remote-7/);
+    assert.equal(requestSignal, controller.signal);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("dashboard WebMCP read tools unwrap the live sessions response envelope", async () => {
+  const originalFetch = global.fetch;
+  const seenUrls: string[] = [];
+  global.fetch = (async (input) => {
+    const url = String(input);
+    seenUrls.push(url);
+    if (url.startsWith("/api/projects")) {
+      return Response.json([{
+        id: "project-1",
+        name: "Project One",
+        path: "/private/should-not-leak",
+        defaultExecutor: "codex",
+        maxSessions: 5,
+      }]);
+    }
+    if (url.startsWith("/api/sessions")) {
+      return Response.json({
+        sessions: [{
+          id: "session-1",
+          projectId: "project-1",
+          status: "working",
+          activity: "active",
+          agent: "codex",
+          branch: "feat/webmcp",
+          summary: "A bounded session summary.",
+          createdAt: "2026-08-25T21:00:00.000Z",
+          lastActivityAt: "2026-08-25T21:05:00.000Z",
+          metadata: {},
+        }],
+        stats: { totalSessions: 1 },
+      });
+    }
+    return Response.json({ error: "Unexpected test URL" }, { status: 404 });
+  }) as typeof fetch;
+
+  try {
+    const tools = createDashboardWebMcpTools({
+      getBridgeId: () => "bridge-demo",
+      getSelection: () => ({ selectedProjectId: "project-1", selectedSessionId: "session-1" }),
+      navigateDashboard: () => {},
+      refreshSessions: async () => {},
+    });
+    const overviewTool = tools.find((tool) => tool.name === "conductor_get_workspace_overview");
+    const sessionsTool = tools.find((tool) => tool.name === "conductor_list_sessions");
+    assert.ok(overviewTool);
+    assert.ok(sessionsTool);
+
+    const overview = JSON.parse(await overviewTool!.execute({ projectId: "project-1" })) as {
+      projects?: unknown[];
+      sessions?: unknown[];
+    };
+    const listed = JSON.parse(await sessionsTool!.execute({ projectId: "project-1" })) as {
+      sessions?: unknown[];
+    };
+
+    assert.equal(overview.projects?.length, 1);
+    assert.equal(overview.sessions?.length, 1);
+    assert.equal(listed.sessions?.length, 1);
+    assert.doesNotMatch(JSON.stringify(overview), /should-not-leak/);
+    assert.ok(seenUrls.every((url) => url.includes("bridgeId=bridge-demo")));
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("dashboard WebMCP rejects oversized mutation input before approval or fetch", async () => {
+  const originalFetch = global.fetch;
+  let fetchCalls = 0;
+  let approvalCalls = 0;
+  global.fetch = (async () => {
+    fetchCalls += 1;
+    return Response.json({ ok: true });
+  }) as typeof fetch;
+
+  try {
+    const tools = createDashboardWebMcpTools({
+      getBridgeId: () => null,
+      getSelection: () => ({ selectedProjectId: null, selectedSessionId: null }),
+      navigateDashboard: () => {},
+      refreshSessions: async () => {},
+      requestHumanConfirmation: async () => {
+        approvalCalls += 1;
+        return true;
+      },
+    });
+    const startTool = tools.find((tool) => tool.name === "conductor_start_agent");
+    assert.ok(startTool);
+
+    const result = JSON.parse(await startTool!.execute({
+      projectId: "demo-web",
+      prompt: "x".repeat(4_001),
+      confirmed: true,
+    })) as { error?: string };
+
+    assert.match(result.error ?? "", /prompt must be at most 4000 characters/i);
+    assert.equal(approvalCalls, 0);
+    assert.equal(fetchCalls, 0);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("dashboard WebMCP requires person approval after confirmed input", async () => {
+  const originalFetch = global.fetch;
+  let fetchCalls = 0;
+  global.fetch = (async () => {
+    fetchCalls += 1;
+    return Response.json({ ok: true });
+  }) as typeof fetch;
+
+  try {
+    const tools = createDashboardWebMcpTools({
+      getBridgeId: () => null,
+      getSelection: () => ({ selectedProjectId: null, selectedSessionId: null }),
+      navigateDashboard: () => {},
+      refreshSessions: async () => {},
+      requestHumanConfirmation: async () => false,
+    });
+    const focusTool = tools.find((tool) => tool.name === "conductor_focus_session");
+    assert.ok(focusTool);
+
+    const result = JSON.parse(await focusTool!.execute({
+      sessionId: "demo-session-176",
+      confirmed: true,
+    })) as { requiresHumanApproval?: boolean };
+
+    assert.equal(result.requiresHumanApproval, true);
+    assert.equal(fetchCalls, 0);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("dashboard WebMCP caps session lists at twelve records", async () => {
+  const originalFetch = global.fetch;
+  global.fetch = (async () => Response.json({
+    sessions: Array.from({ length: 20 }, (_, index) => ({
+      id: `session-${index}`,
+      projectId: "project-1",
+      status: "working",
+      activity: "active",
+      agent: "codex",
+      branch: "feat/webmcp",
+      summary: "A bounded session summary.",
+      createdAt: "2026-08-25T21:00:00.000Z",
+      lastActivityAt: "2026-08-25T21:05:00.000Z",
+      metadata: {},
+    })),
+    stats: { totalSessions: 20 },
+  })) as typeof fetch;
+
+  try {
+    const tools = createDashboardWebMcpTools({
+      getBridgeId: () => null,
+      getSelection: () => ({ selectedProjectId: null, selectedSessionId: null }),
+      navigateDashboard: () => {},
+      refreshSessions: async () => {},
+    });
+    const sessionsTool = tools.find((tool) => tool.name === "conductor_list_sessions");
+    assert.ok(sessionsTool);
+
+    const result = JSON.parse(await sessionsTool!.execute({ limit: 25 })) as { sessions?: unknown[] };
+    assert.equal(result.sessions?.length, 12);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});

--- a/packages/web/src/features/webmcp/dashboardBridge.test.ts
+++ b/packages/web/src/features/webmcp/dashboardBridge.test.ts
@@ -54,21 +54,24 @@ test("dashboard WebMCP preserves bridge scope and forwards execution cancellatio
   let requestUrl = "";
   let requestSignal: AbortSignal | null | undefined;
   let navigatedBridgeId: string | null | undefined;
+  let navigatedSessionId: string | null | undefined;
 
   global.fetch = (async (input, init) => {
     requestUrl = String(input);
     requestSignal = init?.signal;
     return Response.json({
-      id: "bridge:remote-7:session-42",
-      projectId: "demo-web",
-      status: "working",
-      activity: "active",
-      agent: "codex",
-      branch: "feat/webmcp",
-      summary: "Remote synthetic summary",
-      createdAt: "2026-08-25T20:00:00.000Z",
-      lastActivityAt: "2026-08-25T20:10:00.000Z",
-      metadata: {},
+      session: {
+        id: "bridge:remote-7:session-42",
+        projectId: "demo-web",
+        status: "working",
+        activity: "active",
+        agent: "codex",
+        branch: "feat/webmcp",
+        summary: "Remote synthetic summary",
+        createdAt: "2026-08-25T20:00:00.000Z",
+        lastActivityAt: "2026-08-25T20:10:00.000Z",
+        metadata: {},
+      },
     });
   }) as typeof fetch;
 
@@ -78,6 +81,7 @@ test("dashboard WebMCP preserves bridge scope and forwards execution cancellatio
       getSelection: () => ({ selectedProjectId: null, selectedSessionId: null }),
       navigateDashboard: (updates) => {
         navigatedBridgeId = updates.bridgeId;
+        navigatedSessionId = updates.sessionId;
       },
       refreshSessions: async () => {},
       requestHumanConfirmation: async () => true,
@@ -92,6 +96,7 @@ test("dashboard WebMCP preserves bridge scope and forwards execution cancellatio
 
     assert.equal(result.bridgeScope, "remote-7");
     assert.equal(navigatedBridgeId, "remote-7");
+    assert.equal(navigatedSessionId, "bridge:remote-7:session-42");
     assert.match(requestUrl, /bridgeId=remote-7/);
     assert.equal(requestSignal, controller.signal);
   } finally {
@@ -227,6 +232,37 @@ test("dashboard WebMCP requires person approval after confirmed input", async ()
 
     assert.equal(result.requiresHumanApproval, true);
     assert.equal(fetchCalls, 0);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test("dashboard WebMCP rejects invalid single-session responses before navigation", async () => {
+  const originalFetch = global.fetch;
+  let navigateCalls = 0;
+  global.fetch = (async () => Response.json({ session: { projectId: "project-1" } })) as typeof fetch;
+
+  try {
+    const tools = createDashboardWebMcpTools({
+      getBridgeId: () => null,
+      getSelection: () => ({ selectedProjectId: null, selectedSessionId: null }),
+      navigateDashboard: () => {
+        navigateCalls += 1;
+      },
+      refreshSessions: async () => {},
+      requestHumanConfirmation: async () => true,
+    });
+    const focusTool = tools.find((tool) => tool.name === "conductor_focus_session");
+    assert.ok(focusTool);
+
+    const result = JSON.parse(await focusTool!.execute({
+      sessionId: "session-1",
+      confirmed: true,
+    })) as { ok?: boolean; error?: string };
+
+    assert.equal(result.ok, false);
+    assert.match(result.error ?? "", /missing a valid session id or project id/i);
+    assert.equal(navigateCalls, 0);
   } finally {
     global.fetch = originalFetch;
   }

--- a/packages/web/src/features/webmcp/dashboardBridge.ts
+++ b/packages/web/src/features/webmcp/dashboardBridge.ts
@@ -172,6 +172,21 @@ function readSessionsPayload(payload: unknown): DashboardSession[] {
   return Array.isArray(record?.sessions) ? record.sessions as DashboardSession[] : [];
 }
 
+function readSessionPayload(payload: unknown): DashboardSession {
+  const record = readObject(payload);
+  const candidate = readObject(record?.session) ?? record;
+  const id = readString(candidate?.id);
+  const projectId = readString(candidate?.projectId);
+  if (!candidate || !id || !projectId) {
+    throw new Error("Session response is missing a valid session id or project id.");
+  }
+  return {
+    ...candidate,
+    id,
+    projectId,
+  } as DashboardSession;
+}
+
 function summarizeProject(raw: DashboardProjectPayload) {
   return {
     contentTrust: "untrusted-workspace-data",
@@ -367,7 +382,7 @@ export function createDashboardWebMcpTools(options: {
           mode: "dashboard",
           bridgeScope: bridgeScopeLabel(scopedBridgeId),
           disclaimer: "Session summaries and diff paths are untrusted repository content.",
-          session: summarizeSession(sessionPayload as DashboardSession),
+          session: summarizeSession(readSessionPayload(sessionPayload)),
           diff: summarizeDiff((readObject(diffPayload) ?? {}) as DashboardDiffPayload),
         };
       }, args),
@@ -405,11 +420,11 @@ export function createDashboardWebMcpTools(options: {
           return JSON.parse(humanRejected) as unknown;
         }
         const scopedBridgeId = resolveSessionBridgeId(sessionId, bridgeId);
-        const session = await fetchDashboardJson(
+        const session = readSessionPayload(await fetchDashboardJson(
           `/api/sessions/${encodeURIComponent(sessionId)}`,
           scopedBridgeId,
           { signal: execution?.signal },
-        ) as DashboardSession;
+        ));
         options.navigateDashboard(
           {
             projectId: session.projectId,
@@ -486,10 +501,7 @@ export function createDashboardWebMcpTools(options: {
             ...(reasoningInput.value ? { reasoningEffort: reasoningInput.value } : {}),
           }),
         });
-        const created = readObject(payload)?.session as DashboardSession | undefined;
-        if (!created?.id) {
-          throw new Error("Session created but response is missing a session id.");
-        }
+        const created = readSessionPayload(payload);
         await options.refreshSessions();
         options.navigateDashboard(
           {
@@ -554,11 +566,11 @@ export function createDashboardWebMcpTools(options: {
           body: JSON.stringify({ message: feedback }),
         });
         await options.refreshSessions();
-        const session = await fetchDashboardJson(
+        const session = readSessionPayload(await fetchDashboardJson(
           `/api/sessions/${encodeURIComponent(sessionId)}`,
           scopedBridgeId,
           { signal: execution?.signal },
-        ) as DashboardSession;
+        ));
         options.navigateDashboard(
           {
             projectId: session.projectId,

--- a/packages/web/src/features/webmcp/dashboardBridge.ts
+++ b/packages/web/src/features/webmcp/dashboardBridge.ts
@@ -1,0 +1,630 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import type { DashboardSession } from "@/lib/types";
+import {
+  browserHumanConfirmation,
+  executeToolSafely,
+  readBoundedString,
+  requireConfirmedMutation,
+  requireHumanConfirmation,
+  type HumanConfirmationHandler,
+  type WebMcpToolDefinition,
+} from "@/lib/webmcp";
+import {
+  createWebMcpTool,
+  WEBMCP_INPUT_LIMITS,
+  WEBMCP_TOOL_ORDER,
+  type WebMcpToolName,
+} from "@/lib/webmcpTools";
+import { withBridgeQuery } from "@/lib/bridgeQuery";
+import { decodeBridgeSessionId } from "@/lib/bridgeSessionIds";
+import { useWebMcpToolRegistration } from "@/features/webmcp/useWebMcpToolRegistration";
+
+type NavigateDashboardUpdates = {
+  projectId?: string | null;
+  sessionId?: string | null;
+  workspaceView?: "direct" | "board" | "notes" | null;
+  tab?: "overview" | "dispatcher" | "diff" | "preview" | "terminal" | null;
+  bridgeId?: string | null;
+};
+
+type NavigateDashboard = (
+  updates: NavigateDashboardUpdates,
+  mode?: "push" | "replace",
+) => void;
+
+type UseDashboardWebMcpBridgeOptions = {
+  bridgeId: string | null;
+  selectedSessionId: string | null;
+  selectedProjectId: string | null;
+  navigateDashboard: NavigateDashboard;
+  refreshSessions: () => Promise<void>;
+};
+
+type DashboardProjectPayload = {
+  id?: unknown;
+  name?: unknown;
+  default_executor?: unknown;
+  defaultExecutor?: unknown;
+  max_sessions?: unknown;
+  maxSessions?: unknown;
+};
+
+type DashboardDiffFilePayload = {
+  path?: unknown;
+  status?: unknown;
+  additions?: unknown;
+  deletions?: unknown;
+};
+
+type DashboardDiffPayload = {
+  hasDiff?: unknown;
+  generatedAt?: unknown;
+  source?: unknown;
+  truncated?: unknown;
+  branch?: unknown;
+  defaultBranch?: unknown;
+  files?: unknown;
+  sections?: unknown;
+};
+
+type WorkspaceOverviewArgs = {
+  projectId?: string;
+  sessionLimit?: number;
+};
+
+type ListProjectsArgs = {
+  limit?: number;
+};
+
+type ListSessionsArgs = {
+  projectId?: string;
+  status?: string;
+  limit?: number;
+};
+
+type InspectSessionArgs = {
+  sessionId: string;
+};
+
+type FocusSessionArgs = {
+  sessionId: string;
+  confirmed: boolean;
+};
+
+type StartAgentArgs = {
+  projectId: string;
+  prompt: string;
+  confirmed: boolean;
+  agent?: string;
+  model?: string;
+  reasoningEffort?: string;
+};
+
+type SendFeedbackArgs = {
+  sessionId: string;
+  feedback: string;
+  confirmed: boolean;
+};
+
+function readString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function readNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  return null;
+}
+
+function inputError(tool: WebMcpToolName, error: string) {
+  return {
+    ok: false,
+    tool,
+    error,
+  };
+}
+
+function truncate(text: string | null | undefined, maxLength: number): string | null {
+  const value = readString(text);
+  if (!value) {
+    return null;
+  }
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, Math.max(0, maxLength - 1))}…`;
+}
+
+function normalizeLimit(value: number | undefined, fallback: number, max: number): number {
+  if (!Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(1, Math.min(max, Math.floor(value ?? fallback)));
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function bridgeScopeLabel(bridgeId: string | null | undefined): string {
+  return readString(bridgeId) ?? "local";
+}
+
+function resolveSessionBridgeId(sessionId: string, fallbackBridgeId: string | null): string | null {
+  return decodeBridgeSessionId(sessionId)?.bridgeId ?? fallbackBridgeId;
+}
+
+function readSessionsPayload(payload: unknown): DashboardSession[] {
+  if (Array.isArray(payload)) {
+    return payload as DashboardSession[];
+  }
+  const record = readObject(payload);
+  return Array.isArray(record?.sessions) ? record.sessions as DashboardSession[] : [];
+}
+
+function summarizeProject(raw: DashboardProjectPayload) {
+  return {
+    contentTrust: "untrusted-workspace-data",
+    id: readString(raw.id) ?? "unknown-project",
+    name: readString(raw.name) ?? "Unnamed project",
+    defaultExecutor: readString(raw.defaultExecutor) ?? readString(raw.default_executor),
+    maxSessions: readNumber(raw.maxSessions) ?? readNumber(raw.max_sessions),
+  };
+}
+
+function summarizeSession(session: DashboardSession) {
+  return {
+    contentTrust: "untrusted-workspace-data",
+    id: session.id,
+    projectId: session.projectId,
+    status: session.status,
+    activity: session.activity,
+    agent: readString(session.agent) ?? null,
+    branch: readString(session.branch) ?? null,
+    summary: truncate(session.summary, 220),
+    createdAt: session.createdAt,
+    lastActivityAt: session.lastActivityAt,
+    taskId: readString(session.metadata?.taskId),
+    sessionKind: readString(session.metadata?.sessionKind),
+  };
+}
+
+function summarizeDiff(diff: DashboardDiffPayload) {
+  const files = Array.isArray(diff.files) ? diff.files : [];
+  return {
+    contentTrust: "untrusted-repository-data",
+    hasDiff: diff.hasDiff === true,
+    source: readString(diff.source),
+    generatedAt: readString(diff.generatedAt),
+    branch: readString(diff.branch),
+    defaultBranch: readString(diff.defaultBranch),
+    truncated: diff.truncated === true,
+    fileCount: files.length,
+    files: files.slice(0, 12).map((entry) => {
+      const file = readObject(entry) as DashboardDiffFilePayload | null;
+      return {
+        path: readString(file?.path),
+        status: readString(file?.status),
+        additions: readNumber(file?.additions),
+        deletions: readNumber(file?.deletions),
+      };
+    }),
+    sectionCounts: (() => {
+      const sections = readObject(diff.sections);
+      if (!sections) {
+        return null;
+      }
+      const count = (value: unknown) => (Array.isArray(value) ? value.length : 0);
+      return {
+        againstBase: count(sections.againstBase),
+        staged: count(sections.staged),
+        unstaged: count(sections.unstaged),
+        untracked: count(sections.untracked),
+      };
+    })(),
+  };
+}
+
+async function parseJsonResponse(response: Response): Promise<unknown> {
+  return await response.json().catch(() => null);
+}
+
+async function fetchDashboardJson(
+  path: string,
+  bridgeId: string | null | undefined,
+  init?: RequestInit,
+): Promise<unknown> {
+  const response = await fetch(withBridgeQuery(path, bridgeId), init);
+  const payload = await parseJsonResponse(response);
+  if (!response.ok) {
+    const body = readObject(payload);
+    throw new Error(
+      readString(body?.error)
+      ?? readString(body?.reason)
+      ?? `Request failed: ${response.status}`,
+    );
+  }
+  return payload;
+}
+
+export function createDashboardWebMcpTools(options: {
+  getBridgeId: () => string | null;
+  getSelection: () => { selectedProjectId: string | null; selectedSessionId: string | null };
+  navigateDashboard: NavigateDashboard;
+  refreshSessions: () => Promise<void>;
+  requestHumanConfirmation?: HumanConfirmationHandler;
+}): WebMcpToolDefinition[] {
+  const requestHumanConfirmation = options.requestHumanConfirmation ?? browserHumanConfirmation;
+  const tools = {
+    conductor_get_workspace_overview: createWebMcpTool<WorkspaceOverviewArgs>(
+      "conductor_get_workspace_overview",
+      (args, execution) => executeToolSafely("conductor_get_workspace_overview", async () => {
+        const bridgeId = options.getBridgeId();
+        const projectInput = readBoundedString(args?.projectId, "projectId", WEBMCP_INPUT_LIMITS.id);
+        if (projectInput.error) {
+          return inputError("conductor_get_workspace_overview", projectInput.error);
+        }
+        const [projectsPayload, sessionsPayload] = await Promise.all([
+          fetchDashboardJson("/api/projects", bridgeId, { signal: execution?.signal }),
+          fetchDashboardJson("/api/sessions", bridgeId, { signal: execution?.signal }),
+        ]);
+        const projectId = projectInput.value;
+        const sessionLimit = normalizeLimit(args?.sessionLimit, 6, 12);
+        const projects = Array.isArray(projectsPayload) ? projectsPayload : [];
+        const sessions = readSessionsPayload(sessionsPayload);
+        const filteredSessions = sessions
+          .filter((session) => !projectId || session.projectId === projectId)
+          .slice(0, sessionLimit)
+          .map(summarizeSession);
+        const selection = options.getSelection();
+        return {
+          ok: true,
+          mode: "dashboard",
+          bridgeScope: bridgeScopeLabel(bridgeId),
+          focusedSessionId: selection.selectedSessionId,
+          selectedProjectId: selection.selectedProjectId,
+          projects: projects.slice(0, 12).map((entry) => summarizeProject(readObject(entry) as DashboardProjectPayload ?? {})),
+          sessions: filteredSessions,
+        };
+      }, args),
+    ),
+    conductor_list_projects: createWebMcpTool<ListProjectsArgs>(
+      "conductor_list_projects",
+      (args, execution) => executeToolSafely("conductor_list_projects", async () => {
+        const bridgeId = options.getBridgeId();
+        const payload = await fetchDashboardJson("/api/projects", bridgeId, { signal: execution?.signal });
+        const limit = normalizeLimit(args?.limit, 12, 25);
+        const projects = Array.isArray(payload) ? payload : [];
+        return {
+          ok: true,
+          mode: "dashboard",
+          bridgeScope: bridgeScopeLabel(bridgeId),
+          projects: projects
+            .slice(0, limit)
+            .map((entry) => summarizeProject(readObject(entry) as DashboardProjectPayload ?? {})),
+        };
+      }, args),
+    ),
+    conductor_list_sessions: createWebMcpTool<ListSessionsArgs>(
+      "conductor_list_sessions",
+      (args, execution) => executeToolSafely("conductor_list_sessions", async () => {
+        const bridgeId = options.getBridgeId();
+        const limit = normalizeLimit(args?.limit, 10, 12);
+        const projectInput = readBoundedString(args?.projectId, "projectId", WEBMCP_INPUT_LIMITS.id);
+        const statusInput = readBoundedString(args?.status, "status", WEBMCP_INPUT_LIMITS.status);
+        if (projectInput.error || statusInput.error) {
+          return inputError("conductor_list_sessions", projectInput.error ?? statusInput.error ?? "Invalid input.");
+        }
+        const payload = await fetchDashboardJson("/api/sessions", bridgeId, { signal: execution?.signal });
+        const projectId = projectInput.value;
+        const status = statusInput.value;
+        const sessions = readSessionsPayload(payload);
+        return {
+          ok: true,
+          mode: "dashboard",
+          bridgeScope: bridgeScopeLabel(bridgeId),
+          sessions: sessions
+            .filter((session) => !projectId || session.projectId === projectId)
+            .filter((session) => !status || session.status === status)
+            .slice(0, limit)
+            .map(summarizeSession),
+        };
+      }, args),
+    ),
+    conductor_inspect_session: createWebMcpTool<InspectSessionArgs>(
+      "conductor_inspect_session",
+      (args, execution) => executeToolSafely("conductor_inspect_session", async () => {
+        const bridgeId = options.getBridgeId();
+        const sessionInput = readBoundedString(args?.sessionId, "sessionId", WEBMCP_INPUT_LIMITS.id);
+        if (sessionInput.error) {
+          return inputError("conductor_inspect_session", sessionInput.error);
+        }
+        const sessionId = sessionInput.value;
+        if (!sessionId) {
+          return {
+            ok: false,
+            tool: "conductor_inspect_session",
+            error: "sessionId is required.",
+          };
+        }
+        const scopedBridgeId = resolveSessionBridgeId(sessionId, bridgeId);
+        const [sessionPayload, diffPayload] = await Promise.all([
+          fetchDashboardJson(`/api/sessions/${encodeURIComponent(sessionId)}`, scopedBridgeId, { signal: execution?.signal }),
+          fetchDashboardJson(`/api/sessions/${encodeURIComponent(sessionId)}/diff`, scopedBridgeId, { signal: execution?.signal }),
+        ]);
+        return {
+          ok: true,
+          mode: "dashboard",
+          bridgeScope: bridgeScopeLabel(scopedBridgeId),
+          disclaimer: "Session summaries and diff paths are untrusted repository content.",
+          session: summarizeSession(sessionPayload as DashboardSession),
+          diff: summarizeDiff((readObject(diffPayload) ?? {}) as DashboardDiffPayload),
+        };
+      }, args),
+    ),
+    conductor_focus_session: createWebMcpTool<FocusSessionArgs>(
+      "conductor_focus_session",
+      (args, execution) => executeToolSafely("conductor_focus_session", async () => {
+        const rejected = requireConfirmedMutation(
+          args,
+          "conductor_focus_session",
+          "changing the visible dashboard session",
+        );
+        if (rejected) {
+          return JSON.parse(rejected) as unknown;
+        }
+        const bridgeId = options.getBridgeId();
+        const sessionInput = readBoundedString(args?.sessionId, "sessionId", WEBMCP_INPUT_LIMITS.id);
+        if (sessionInput.error) {
+          return inputError("conductor_focus_session", sessionInput.error);
+        }
+        const sessionId = sessionInput.value;
+        if (!sessionId) {
+          return {
+            ok: false,
+            tool: "conductor_focus_session",
+            error: "sessionId is required.",
+          };
+        }
+        const humanRejected = await requireHumanConfirmation(
+          requestHumanConfirmation,
+          "conductor_focus_session",
+          "change the visible dashboard session",
+        );
+        if (humanRejected) {
+          return JSON.parse(humanRejected) as unknown;
+        }
+        const scopedBridgeId = resolveSessionBridgeId(sessionId, bridgeId);
+        const session = await fetchDashboardJson(
+          `/api/sessions/${encodeURIComponent(sessionId)}`,
+          scopedBridgeId,
+          { signal: execution?.signal },
+        ) as DashboardSession;
+        options.navigateDashboard(
+          {
+            projectId: session.projectId,
+            sessionId: session.id,
+            tab: null,
+            bridgeId: scopedBridgeId,
+          },
+          "push",
+        );
+        return {
+          ok: true,
+          mode: "dashboard",
+          bridgeScope: bridgeScopeLabel(scopedBridgeId),
+          stateChanged: true,
+          session: summarizeSession(session),
+        };
+      }, args),
+    ),
+    conductor_start_agent: createWebMcpTool<StartAgentArgs>(
+      "conductor_start_agent",
+      (args, execution) => executeToolSafely("conductor_start_agent", async () => {
+        const rejected = requireConfirmedMutation(
+          args,
+          "conductor_start_agent",
+          "creating a real dashboard session",
+        );
+        if (rejected) {
+          return JSON.parse(rejected) as unknown;
+        }
+        const bridgeId = options.getBridgeId();
+        const projectInput = readBoundedString(args?.projectId, "projectId", WEBMCP_INPUT_LIMITS.id);
+        const promptInput = readBoundedString(args?.prompt, "prompt", WEBMCP_INPUT_LIMITS.prompt);
+        const agentInput = readBoundedString(args?.agent, "agent", WEBMCP_INPUT_LIMITS.agent);
+        const modelInput = readBoundedString(args?.model, "model", WEBMCP_INPUT_LIMITS.model);
+        const reasoningInput = readBoundedString(
+          args?.reasoningEffort,
+          "reasoningEffort",
+          WEBMCP_INPUT_LIMITS.reasoningEffort,
+        );
+        const validationError = projectInput.error
+          ?? promptInput.error
+          ?? agentInput.error
+          ?? modelInput.error
+          ?? reasoningInput.error;
+        if (validationError) {
+          return inputError("conductor_start_agent", validationError);
+        }
+        const projectId = projectInput.value;
+        const prompt = promptInput.value;
+        if (!projectId || !prompt) {
+          return {
+            ok: false,
+            tool: "conductor_start_agent",
+            error: "projectId and prompt are required.",
+          };
+        }
+        const humanRejected = await requireHumanConfirmation(
+          requestHumanConfirmation,
+          "conductor_start_agent",
+          "create a real dashboard session",
+        );
+        if (humanRejected) {
+          return JSON.parse(humanRejected) as unknown;
+        }
+        const payload = await fetchDashboardJson("/api/sessions", bridgeId, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          signal: execution?.signal,
+          body: JSON.stringify({
+            projectId,
+            prompt,
+            ...(agentInput.value ? { agent: agentInput.value } : {}),
+            ...(modelInput.value ? { model: modelInput.value } : {}),
+            ...(reasoningInput.value ? { reasoningEffort: reasoningInput.value } : {}),
+          }),
+        });
+        const created = readObject(payload)?.session as DashboardSession | undefined;
+        if (!created?.id) {
+          throw new Error("Session created but response is missing a session id.");
+        }
+        await options.refreshSessions();
+        options.navigateDashboard(
+          {
+            projectId: created.projectId,
+            sessionId: created.id,
+            tab: null,
+            bridgeId,
+          },
+          "push",
+        );
+        return {
+          ok: true,
+          mode: "dashboard",
+          bridgeScope: bridgeScopeLabel(bridgeId),
+          stateChanged: true,
+          session: summarizeSession(created),
+        };
+      }, args),
+    ),
+    conductor_send_feedback: createWebMcpTool<SendFeedbackArgs>(
+      "conductor_send_feedback",
+      (args, execution) => executeToolSafely("conductor_send_feedback", async () => {
+        const rejected = requireConfirmedMutation(
+          args,
+          "conductor_send_feedback",
+          "sending real session feedback",
+        );
+        if (rejected) {
+          return JSON.parse(rejected) as unknown;
+        }
+        const bridgeId = options.getBridgeId();
+        const sessionInput = readBoundedString(args?.sessionId, "sessionId", WEBMCP_INPUT_LIMITS.id);
+        const feedbackInput = readBoundedString(args?.feedback, "feedback", WEBMCP_INPUT_LIMITS.feedback);
+        if (sessionInput.error || feedbackInput.error) {
+          return inputError(
+            "conductor_send_feedback",
+            sessionInput.error ?? feedbackInput.error ?? "Invalid input.",
+          );
+        }
+        const sessionId = sessionInput.value;
+        const feedback = feedbackInput.value;
+        if (!sessionId || !feedback) {
+          return {
+            ok: false,
+            tool: "conductor_send_feedback",
+            error: "sessionId and feedback are required.",
+          };
+        }
+        const humanRejected = await requireHumanConfirmation(
+          requestHumanConfirmation,
+          "conductor_send_feedback",
+          "send real session feedback",
+        );
+        if (humanRejected) {
+          return JSON.parse(humanRejected) as unknown;
+        }
+        const scopedBridgeId = resolveSessionBridgeId(sessionId, bridgeId);
+        await fetchDashboardJson(`/api/sessions/${encodeURIComponent(sessionId)}/feedback`, scopedBridgeId, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          signal: execution?.signal,
+          body: JSON.stringify({ message: feedback }),
+        });
+        await options.refreshSessions();
+        const session = await fetchDashboardJson(
+          `/api/sessions/${encodeURIComponent(sessionId)}`,
+          scopedBridgeId,
+          { signal: execution?.signal },
+        ) as DashboardSession;
+        options.navigateDashboard(
+          {
+            projectId: session.projectId,
+            sessionId: session.id,
+            tab: null,
+            bridgeId: scopedBridgeId,
+          },
+          "push",
+        );
+        return {
+          ok: true,
+          mode: "dashboard",
+          bridgeScope: bridgeScopeLabel(scopedBridgeId),
+          stateChanged: true,
+          session: summarizeSession(session),
+        };
+      }, args),
+    ),
+  } as const;
+
+  return WEBMCP_TOOL_ORDER.map((toolName) => tools[toolName]);
+}
+
+export function useDashboardWebMcpBridge({
+  bridgeId,
+  selectedSessionId,
+  selectedProjectId,
+  navigateDashboard,
+  refreshSessions,
+}: UseDashboardWebMcpBridgeOptions): void {
+  const bridgeIdRef = useRef<string | null>(bridgeId);
+  const selectionRef = useRef({
+    selectedProjectId,
+    selectedSessionId,
+  });
+  const navigateRef = useRef(navigateDashboard);
+  const refreshSessionsRef = useRef(refreshSessions);
+
+  useEffect(() => {
+    bridgeIdRef.current = bridgeId;
+  }, [bridgeId]);
+
+  useEffect(() => {
+    selectionRef.current = {
+      selectedProjectId,
+      selectedSessionId,
+    };
+  }, [selectedProjectId, selectedSessionId]);
+
+  useEffect(() => {
+    navigateRef.current = navigateDashboard;
+  }, [navigateDashboard]);
+
+  useEffect(() => {
+    refreshSessionsRef.current = refreshSessions;
+  }, [refreshSessions]);
+
+  const tools = useMemo(
+    () => createDashboardWebMcpTools({
+      getBridgeId: () => bridgeIdRef.current,
+      getSelection: () => selectionRef.current,
+      navigateDashboard: (updates, mode) => navigateRef.current(updates, mode),
+      refreshSessions: () => refreshSessionsRef.current(),
+    }),
+    [],
+  );
+
+  useWebMcpToolRegistration(tools);
+}

--- a/packages/web/src/features/webmcp/demoState.test.ts
+++ b/packages/web/src/features/webmcp/demoState.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createInitialDemoState, demoStateReducer } from "./demoState";
+
+test("demo reducer focuses a synthetic session", () => {
+  const initial = createInitialDemoState();
+  const next = demoStateReducer(initial, {
+    type: "focus-session",
+    sessionId: "demo-session-176",
+    timestamp: "2026-08-25T14:00:00.000Z",
+  });
+
+  assert.equal(next.selectedSessionId, "demo-session-176");
+  assert.match(next.timeline[0]?.label ?? "", /Focused synthetic session demo-session-176/i);
+});
+
+test("demo reducer queues a new synthetic session and selects it", () => {
+  const initial = createInitialDemoState();
+  const next = demoStateReducer(initial, {
+    type: "start-agent",
+    timestamp: "2026-08-25T14:05:00.000Z",
+    projectId: "demo-docs",
+    prompt: "Draft the public walkthrough.",
+    agent: "codex",
+  });
+
+  assert.equal(next.sessions[0]?.projectId, "demo-docs");
+  assert.equal(next.sessions[0]?.status, "queued");
+  assert.equal(next.selectedSessionId, next.sessions[0]?.id);
+  assert.equal(next.nextSyntheticSessionNumber, initial.nextSyntheticSessionNumber + 1);
+});
+
+test("demo reducer sends feedback and returns the session to working", () => {
+  const initial = createInitialDemoState();
+  const next = demoStateReducer(initial, {
+    type: "send-feedback",
+    timestamp: "2026-08-25T14:08:00.000Z",
+    sessionId: "demo-session-198",
+    feedback: "Make the approval boundary explicit.",
+  });
+
+  const updated = next.sessions.find((session) => session.id === "demo-session-198");
+  assert.equal(updated?.status, "working");
+  assert.equal(updated?.lastFeedback, "Make the approval boundary explicit.");
+  assert.equal(next.selectedSessionId, "demo-session-198");
+});

--- a/packages/web/src/features/webmcp/demoState.test.ts
+++ b/packages/web/src/features/webmcp/demoState.test.ts
@@ -44,3 +44,19 @@ test("demo reducer sends feedback and returns the session to working", () => {
   assert.equal(updated?.lastFeedback, "Make the approval boundary explicit.");
   assert.equal(next.selectedSessionId, "demo-session-198");
 });
+
+test("demo reducer keeps timeline ids unique for same-millisecond events", () => {
+  const timestamp = "2026-08-25T14:10:00.000Z";
+  const first = demoStateReducer(createInitialDemoState(), {
+    type: "focus-session",
+    sessionId: "demo-session-176",
+    timestamp,
+  });
+  const second = demoStateReducer(first, {
+    type: "focus-session",
+    sessionId: "demo-session-198",
+    timestamp,
+  });
+
+  assert.notEqual(second.timeline[0]?.id, second.timeline[1]?.id);
+});

--- a/packages/web/src/features/webmcp/demoState.ts
+++ b/packages/web/src/features/webmcp/demoState.ts
@@ -1,0 +1,321 @@
+import type { WebMcpToolName } from "@/lib/webmcpTools";
+
+export type DemoSessionStatus = "working" | "needs_input" | "review" | "queued" | "completed";
+
+export type DemoDiffFile = {
+  path: string;
+  status: "modified" | "added" | "deleted";
+  additions: number;
+  deletions: number;
+};
+
+export type DemoProject = {
+  id: string;
+  name: string;
+  description: string;
+  branch: string;
+  syntheticLabel: string;
+  health: "working" | "attention" | "ready";
+};
+
+export type DemoSession = {
+  id: string;
+  projectId: string;
+  projectName: string;
+  title: string;
+  status: DemoSessionStatus;
+  agent: string;
+  branch: string;
+  summary: string;
+  prompt: string;
+  lastFeedback: string | null;
+  syntheticLabel: string;
+  diffSummary: string;
+  diffFiles: DemoDiffFile[];
+  updatedAt: string;
+};
+
+export type DemoToolRun = {
+  id: string;
+  toolName: WebMcpToolName;
+  changedState: boolean;
+  summary: string;
+  outputPreview: string;
+  timestamp: string;
+};
+
+export type DemoTimelineEvent = {
+  id: string;
+  label: string;
+  timestamp: string;
+};
+
+export type DemoState = {
+  workspaceName: string;
+  workspaceLabel: string;
+  projects: DemoProject[];
+  sessions: DemoSession[];
+  selectedSessionId: string;
+  timeline: DemoTimelineEvent[];
+  toolRuns: DemoToolRun[];
+  nextSyntheticSessionNumber: number;
+};
+
+export type DemoStateAction =
+  | {
+    type: "focus-session";
+    sessionId: string;
+    timestamp: string;
+  }
+  | {
+    type: "start-agent";
+    timestamp: string;
+    projectId: string;
+    prompt: string;
+    agent?: string | null;
+  }
+  | {
+    type: "send-feedback";
+    timestamp: string;
+    sessionId: string;
+    feedback: string;
+  }
+  | {
+    type: "record-tool-run";
+    run: DemoToolRun;
+  };
+
+function createTimelineEvent(label: string, timestamp: string, suffix: string): DemoTimelineEvent {
+  return {
+    id: `${suffix}-${timestamp}`,
+    label,
+    timestamp,
+  };
+}
+
+function truncate(text: string, maxLength: number): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= maxLength) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, Math.max(0, maxLength - 1))}…`;
+}
+
+export function createInitialDemoState(): DemoState {
+  return {
+    workspaceName: "Conductor WebMCP Demo",
+    workspaceLabel: "Synthetic data only. In-memory state resets on reload.",
+    projects: [
+      {
+        id: "demo-web",
+        name: "demo-web",
+        description: "Synthetic public landing route polish pass.",
+        branch: "feat/webmcp-demo",
+        syntheticLabel: "Synthetic project",
+        health: "working",
+      },
+      {
+        id: "demo-core",
+        name: "demo-core",
+        description: "Synthetic reducer and schema hardening.",
+        branch: "feat/tool-safety",
+        syntheticLabel: "Synthetic project",
+        health: "attention",
+      },
+      {
+        id: "demo-docs",
+        name: "demo-docs",
+        description: "Synthetic walkthrough and submission prep.",
+        branch: "docs/webmcp-judge-flow",
+        syntheticLabel: "Synthetic project",
+        health: "ready",
+      },
+    ],
+    sessions: [
+      {
+        id: "demo-session-204",
+        projectId: "demo-web",
+        projectName: "demo-web",
+        title: "Synthetic dashboard polish",
+        status: "working",
+        agent: "codex",
+        branch: "feat/webmcp-demo",
+        summary: "Synthetic UI polish pass is updating the public challenge route layout and samples.",
+        prompt: "Polish the synthetic `/webmcp` route and make every tool effect visible in the UI.",
+        lastFeedback: null,
+        syntheticLabel: "Synthetic session",
+        diffSummary: "Header layout tightened, inspector panels aligned, mobile spacing reduced.",
+        diffFiles: [
+          { path: "packages/web/src/app/webmcp/page.tsx", status: "modified", additions: 84, deletions: 11 },
+          { path: "packages/web/src/features/webmcp/WebMcpDemoPage.tsx", status: "modified", additions: 129, deletions: 18 },
+        ],
+        updatedAt: "2026-08-25T13:42:00.000Z",
+      },
+      {
+        id: "demo-session-198",
+        projectId: "demo-core",
+        projectName: "demo-core",
+        title: "Synthetic confirmation gate review",
+        status: "needs_input",
+        agent: "claude-code",
+        branch: "feat/tool-safety",
+        summary: "Synthetic session is waiting for explicit approval before sending operator feedback.",
+        prompt: "Verify `confirmed: true` is required before any state-changing tool executes.",
+        lastFeedback: "Please keep the guard error concise and structured.",
+        syntheticLabel: "Synthetic session",
+        diffSummary: "Confirmation helpers added, mutation paths now return structured rejection payloads.",
+        diffFiles: [
+          { path: "packages/web/src/lib/webmcp.ts", status: "modified", additions: 41, deletions: 3 },
+          { path: "packages/web/src/lib/webmcpTools.ts", status: "modified", additions: 77, deletions: 0 },
+        ],
+        updatedAt: "2026-08-25T13:31:00.000Z",
+      },
+      {
+        id: "demo-session-176",
+        projectId: "demo-docs",
+        projectName: "demo-docs",
+        title: "Synthetic judge walkthrough",
+        status: "review",
+        agent: "gemini",
+        branch: "docs/webmcp-judge-flow",
+        summary: "Synthetic walkthrough draft is staged for review with clearly labeled fake diffs.",
+        prompt: "Prepare judge-facing prompts and explain that this page uses synthetic in-memory data only.",
+        lastFeedback: null,
+        syntheticLabel: "Synthetic session",
+        diffSummary: "Prompt suggestions added, compatibility copy tightened, callout language clarified.",
+        diffFiles: [
+          { path: "docs/webmcp-challenge-2026.md", status: "modified", additions: 14, deletions: 2 },
+          { path: "packages/web/src/features/webmcp/demoState.ts", status: "added", additions: 205, deletions: 0 },
+        ],
+        updatedAt: "2026-08-25T12:58:00.000Z",
+      },
+    ],
+    selectedSessionId: "demo-session-204",
+    timeline: [
+      createTimelineEvent("Synthetic workspace loaded for the August 25, 2026 challenge branch.", "2026-08-25T13:40:00.000Z", "init"),
+      createTimelineEvent("Browser tools can inspect or mutate only this in-memory demo state.", "2026-08-25T13:41:30.000Z", "init"),
+    ],
+    toolRuns: [],
+    nextSyntheticSessionNumber: 205,
+  };
+}
+
+function prependTimeline(state: DemoState, event: DemoTimelineEvent): DemoTimelineEvent[] {
+  return [event, ...state.timeline].slice(0, 12);
+}
+
+function prependToolRun(state: DemoState, run: DemoToolRun): DemoToolRun[] {
+  return [run, ...state.toolRuns].slice(0, 12);
+}
+
+export function findDemoSession(state: DemoState, sessionId: string): DemoSession | null {
+  return state.sessions.find((session) => session.id === sessionId) ?? null;
+}
+
+export function findDemoProject(state: DemoState, projectId: string): DemoProject | null {
+  return state.projects.find((project) => project.id === projectId) ?? null;
+}
+
+export function demoStateReducer(state: DemoState, action: DemoStateAction): DemoState {
+  if (action.type === "focus-session") {
+    const session = findDemoSession(state, action.sessionId);
+    if (!session) {
+      return state;
+    }
+    return {
+      ...state,
+      selectedSessionId: session.id,
+      timeline: prependTimeline(
+        state,
+        createTimelineEvent(
+          `Focused synthetic session ${session.id} in the workspace preview.`,
+          action.timestamp,
+          "focus",
+        ),
+      ),
+    };
+  }
+
+  if (action.type === "start-agent") {
+    const project = findDemoProject(state, action.projectId);
+    if (!project) {
+      return state;
+    }
+
+    const nextId = `demo-session-${state.nextSyntheticSessionNumber}`;
+    const trimmedPrompt = truncate(action.prompt, 160);
+    const nextSession: DemoSession = {
+      id: nextId,
+      projectId: project.id,
+      projectName: project.name,
+      title: "Synthetic queued session",
+      status: "queued",
+      agent: action.agent?.trim() || "codex",
+      branch: project.branch,
+      summary: "Synthetic session was queued from the public WebMCP demo and no real agent was launched.",
+      prompt: trimmedPrompt,
+      lastFeedback: null,
+      syntheticLabel: "Synthetic session",
+      diffSummary: "No diff yet. This is a synthetic pending launch state.",
+      diffFiles: [],
+      updatedAt: action.timestamp,
+    };
+
+    return {
+      ...state,
+      sessions: [nextSession, ...state.sessions],
+      selectedSessionId: nextId,
+      timeline: prependTimeline(
+        state,
+        createTimelineEvent(
+          `Queued synthetic session ${nextId} for ${project.id}.`,
+          action.timestamp,
+          "spawn",
+        ),
+      ),
+      nextSyntheticSessionNumber: state.nextSyntheticSessionNumber + 1,
+    };
+  }
+
+  if (action.type === "send-feedback") {
+    const session = findDemoSession(state, action.sessionId);
+    if (!session) {
+      return state;
+    }
+    const nextSessions = state.sessions.map((entry) => {
+      if (entry.id !== action.sessionId) {
+        return entry;
+      }
+      return {
+        ...entry,
+        status: "working" as DemoSessionStatus,
+        summary: "Synthetic follow-up feedback was accepted and the session returned to working status.",
+        lastFeedback: truncate(action.feedback, 160),
+        updatedAt: action.timestamp,
+      };
+    });
+
+    return {
+      ...state,
+      sessions: nextSessions,
+      selectedSessionId: action.sessionId,
+      timeline: prependTimeline(
+        state,
+        createTimelineEvent(
+          `Sent synthetic feedback to ${action.sessionId}.`,
+          action.timestamp,
+          "feedback",
+        ),
+      ),
+    };
+  }
+
+  if (action.type === "record-tool-run") {
+    return {
+      ...state,
+      toolRuns: prependToolRun(state, action.run),
+    };
+  }
+
+  return state;
+}

--- a/packages/web/src/features/webmcp/demoState.ts
+++ b/packages/web/src/features/webmcp/demoState.ts
@@ -85,9 +85,12 @@ export type DemoStateAction =
     run: DemoToolRun;
   };
 
+let nextTimelineEventSequence = 0;
+
 function createTimelineEvent(label: string, timestamp: string, suffix: string): DemoTimelineEvent {
+  nextTimelineEventSequence += 1;
   return {
-    id: `${suffix}-${timestamp}`,
+    id: `${suffix}-${timestamp}-${nextTimelineEventSequence}`,
     label,
     timestamp,
   };

--- a/packages/web/src/features/webmcp/demoTools.test.ts
+++ b/packages/web/src/features/webmcp/demoTools.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createInitialDemoState, demoStateReducer, type DemoStateAction } from "./demoState";
+import { createDemoWebMcpTools } from "./demoTools";
+
+test("demo WebMCP tools reject malformed inputs deterministically", async () => {
+  let state = createInitialDemoState();
+  const tools = createDemoWebMcpTools(
+    () => state,
+    (action: DemoStateAction) => {
+      state = demoStateReducer(state, action);
+    },
+  );
+
+  const inspectTool = tools.find((tool) => tool.name === "conductor_inspect_session");
+  const startTool = tools.find((tool) => tool.name === "conductor_start_agent");
+  const feedbackTool = tools.find((tool) => tool.name === "conductor_send_feedback");
+  assert.ok(inspectTool);
+  assert.ok(startTool);
+  assert.ok(feedbackTool);
+
+  const inspectResult = JSON.parse(await inspectTool!.execute(undefined as never)) as { error?: string };
+  const startResult = JSON.parse(await startTool!.execute({ confirmed: true } as never)) as { error?: string };
+  const feedbackResult = JSON.parse(await feedbackTool!.execute({ confirmed: true } as never)) as { error?: string };
+
+  assert.equal(inspectResult.error, "sessionId is required.");
+  assert.equal(startResult.error, "projectId and prompt are required.");
+  assert.equal(feedbackResult.error, "sessionId and feedback are required.");
+});
+
+test("demo focus tool requires confirmation before visible state changes", async () => {
+  let state = createInitialDemoState();
+  const initialSessionId = state.selectedSessionId;
+  const tools = createDemoWebMcpTools(
+    () => state,
+    (action: DemoStateAction) => {
+      state = demoStateReducer(state, action);
+    },
+  );
+  const focusTool = tools.find((tool) => tool.name === "conductor_focus_session");
+  assert.ok(focusTool);
+
+  const result = JSON.parse(await focusTool!.execute({
+    sessionId: "demo-session-176",
+    confirmed: false,
+  })) as { requiresConfirmation?: boolean };
+
+  assert.equal(result.requiresConfirmation, true);
+  assert.equal(state.selectedSessionId, initialSessionId);
+});
+
+test("demo tool activity ids stay unique for same-millisecond WebMCP calls", async () => {
+  let state = createInitialDemoState();
+  const runIds: string[] = [];
+  const tools = createDemoWebMcpTools(
+    () => state,
+    (action: DemoStateAction) => {
+      if (action.type === "record-tool-run") {
+        runIds.push(action.run.id);
+      }
+      state = demoStateReducer(state, action);
+    },
+    async () => true,
+  );
+  const focusTool = tools.find((tool) => tool.name === "conductor_focus_session");
+  assert.ok(focusTool);
+
+  const originalNow = Date.now;
+  Date.now = () => 123456789;
+  try {
+    await focusTool!.execute({ sessionId: "demo-session-176", confirmed: false });
+    await focusTool!.execute({ sessionId: "demo-session-176", confirmed: true });
+  } finally {
+    Date.now = originalNow;
+  }
+
+  assert.equal(runIds.length, 2);
+  assert.equal(new Set(runIds).size, 2);
+});
+
+test("demo WebMCP rejects oversized mutation input before approval or state change", async () => {
+  let state = createInitialDemoState();
+  const initialCount = state.sessions.length;
+  let approvalCalls = 0;
+  const tools = createDemoWebMcpTools(
+    () => state,
+    (action: DemoStateAction) => {
+      state = demoStateReducer(state, action);
+    },
+    async () => {
+      approvalCalls += 1;
+      return true;
+    },
+  );
+  const startTool = tools.find((tool) => tool.name === "conductor_start_agent");
+  assert.ok(startTool);
+
+  const result = JSON.parse(await startTool!.execute({
+    projectId: "demo-web",
+    prompt: "x".repeat(4_001),
+    confirmed: true,
+  })) as { error?: string };
+
+  assert.match(result.error ?? "", /prompt must be at most 4000 characters/i);
+  assert.equal(approvalCalls, 0);
+  assert.equal(state.sessions.length, initialCount);
+});

--- a/packages/web/src/features/webmcp/demoTools.ts
+++ b/packages/web/src/features/webmcp/demoTools.ts
@@ -1,0 +1,499 @@
+import {
+  browserHumanConfirmation,
+  executeToolSafely,
+  readBoundedString,
+  requireConfirmedMutation,
+  requireHumanConfirmation,
+  type HumanConfirmationHandler,
+  type WebMcpToolDefinition,
+} from "@/lib/webmcp";
+import {
+  createWebMcpTool,
+  WEBMCP_INPUT_LIMITS,
+  WEBMCP_TOOL_ORDER,
+  type WebMcpToolName,
+} from "@/lib/webmcpTools";
+import {
+  demoStateReducer,
+  findDemoProject,
+  findDemoSession,
+  type DemoSession,
+  type DemoState,
+  type DemoStateAction,
+} from "@/features/webmcp/demoState";
+
+type DemoDispatch = (action: DemoStateAction) => void;
+
+type StateReader = () => DemoState;
+
+let nextToolRunId = 0;
+
+function createToolRunId(toolName: WebMcpToolName): string {
+  nextToolRunId += 1;
+  return `${toolName}-${Date.now()}-${nextToolRunId}`;
+}
+
+type WorkspaceOverviewArgs = {
+  projectId?: string;
+  sessionLimit?: number;
+};
+
+type ListProjectsArgs = {
+  limit?: number;
+};
+
+type ListSessionsArgs = {
+  projectId?: string;
+  status?: string;
+  limit?: number;
+};
+
+type InspectSessionArgs = {
+  sessionId: string;
+};
+
+type FocusSessionArgs = {
+  sessionId: string;
+  confirmed: boolean;
+};
+
+type StartAgentArgs = {
+  projectId: string;
+  prompt: string;
+  confirmed: boolean;
+  agent?: string;
+  model?: string;
+  reasoningEffort?: string;
+};
+
+type SendFeedbackArgs = {
+  sessionId: string;
+  feedback: string;
+  confirmed: boolean;
+};
+
+function nowIsoString(): string {
+  return new Date().toISOString();
+}
+
+function inputError(tool: WebMcpToolName, error: string) {
+  return {
+    ok: false,
+    tool,
+    error,
+  };
+}
+
+function truncate(text: string, maxLength: number): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= maxLength) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, Math.max(0, maxLength - 1))}…`;
+}
+
+function limitNumber(value: number | undefined, fallback: number, max: number): number {
+  if (!Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(1, Math.min(max, Math.floor(value ?? fallback)));
+}
+
+function summarizeSession(session: DemoSession) {
+  return {
+    contentTrust: "untrusted-synthetic-demo-data",
+    id: session.id,
+    projectId: session.projectId,
+    projectName: session.projectName,
+    title: session.title,
+    status: session.status,
+    agent: session.agent,
+    branch: session.branch,
+    summary: truncate(session.summary, 160),
+    prompt: truncate(session.prompt, 220),
+    lastFeedback: session.lastFeedback,
+    updatedAt: session.updatedAt,
+    syntheticLabel: session.syntheticLabel,
+  };
+}
+
+function summarizeToolOutput(output: unknown): string {
+  return truncate(JSON.stringify(output), 220);
+}
+
+function recordRun(
+  dispatch: DemoDispatch,
+  toolName: WebMcpToolName,
+  summary: string,
+  output: unknown,
+  changedState: boolean,
+): void {
+  dispatch({
+    type: "record-tool-run",
+    run: {
+      id: createToolRunId(toolName),
+      toolName,
+      changedState,
+      summary,
+      outputPreview: summarizeToolOutput(output),
+      timestamp: nowIsoString(),
+    },
+  });
+}
+
+function missingSessionPayload(sessionId: string) {
+  return {
+    ok: false,
+    mode: "synthetic-demo",
+    error: `Synthetic session ${sessionId} was not found.`,
+  };
+}
+
+function missingProjectPayload(projectId: string) {
+  return {
+    ok: false,
+    mode: "synthetic-demo",
+    error: `Synthetic project ${projectId} was not found.`,
+  };
+}
+
+export function createDemoWebMcpTools(
+  getState: StateReader,
+  dispatch: DemoDispatch,
+  requestHumanConfirmation: HumanConfirmationHandler = browserHumanConfirmation,
+): WebMcpToolDefinition[] {
+  const toolsByName: Record<WebMcpToolName, WebMcpToolDefinition> = {
+    conductor_get_workspace_overview: createWebMcpTool<WorkspaceOverviewArgs>(
+      "conductor_get_workspace_overview",
+      (args) => executeToolSafely("conductor_get_workspace_overview", () => {
+        const state = getState();
+        const projectInput = readBoundedString(args?.projectId, "projectId", WEBMCP_INPUT_LIMITS.id);
+        if (projectInput.error) {
+          return inputError("conductor_get_workspace_overview", projectInput.error);
+        }
+        const limit = limitNumber(args?.sessionLimit, 4, 12);
+        const sessions = state.sessions
+          .filter((session) => !projectInput.value || session.projectId === projectInput.value)
+          .slice(0, limit)
+          .map(summarizeSession);
+        const selectedSession = findDemoSession(state, state.selectedSessionId);
+        const payload = {
+          ok: true,
+          mode: "synthetic-demo",
+          disclaimer: "Synthetic workspace only. No real agent session has run.",
+          workspace: {
+            name: state.workspaceName,
+            label: state.workspaceLabel,
+            projectCount: state.projects.length,
+            sessionCount: state.sessions.length,
+            focusedSessionId: selectedSession?.id ?? null,
+          },
+          sessions,
+        };
+        recordRun(dispatch, "conductor_get_workspace_overview", "Read synthetic workspace overview.", payload, false);
+        return payload;
+      }, args),
+    ),
+    conductor_list_projects: createWebMcpTool<ListProjectsArgs>(
+      "conductor_list_projects",
+      (args) => executeToolSafely("conductor_list_projects", () => {
+        const state = getState();
+        const limit = limitNumber(args?.limit, state.projects.length, 25);
+        const payload = {
+          ok: true,
+          mode: "synthetic-demo",
+          projects: state.projects.slice(0, limit).map((project) => ({
+            contentTrust: "untrusted-synthetic-demo-data",
+            id: project.id,
+            name: project.name,
+            description: project.description,
+            branch: project.branch,
+            health: project.health,
+            syntheticLabel: project.syntheticLabel,
+          })),
+        };
+        recordRun(dispatch, "conductor_list_projects", "Listed synthetic projects.", payload, false);
+        return payload;
+      }, args),
+    ),
+    conductor_list_sessions: createWebMcpTool<ListSessionsArgs>(
+      "conductor_list_sessions",
+      (args) => executeToolSafely("conductor_list_sessions", () => {
+        const state = getState();
+        const projectInput = readBoundedString(args?.projectId, "projectId", WEBMCP_INPUT_LIMITS.id);
+        const statusInput = readBoundedString(args?.status, "status", WEBMCP_INPUT_LIMITS.status);
+        if (projectInput.error || statusInput.error) {
+          return inputError("conductor_list_sessions", projectInput.error ?? statusInput.error ?? "Invalid input.");
+        }
+        const limit = limitNumber(args?.limit, 8, 12);
+        const sessions = state.sessions
+          .filter((session) => !projectInput.value || session.projectId === projectInput.value)
+          .filter((session) => !statusInput.value || session.status === statusInput.value)
+          .slice(0, limit)
+          .map((session) => ({
+            ...summarizeSession(session),
+            diffFilesChanged: session.diffFiles.length,
+          }));
+        const payload = {
+          ok: true,
+          mode: "synthetic-demo",
+          sessions,
+        };
+        recordRun(dispatch, "conductor_list_sessions", "Listed synthetic sessions.", payload, false);
+        return payload;
+      }, args),
+    ),
+    conductor_inspect_session: createWebMcpTool<InspectSessionArgs>(
+      "conductor_inspect_session",
+      (args) => executeToolSafely("conductor_inspect_session", () => {
+        const sessionInput = readBoundedString(args?.sessionId, "sessionId", WEBMCP_INPUT_LIMITS.id);
+        if (sessionInput.error) {
+          return inputError("conductor_inspect_session", sessionInput.error);
+        }
+        const sessionId = sessionInput.value;
+        if (!sessionId) {
+          return {
+            ok: false,
+            tool: "conductor_inspect_session",
+            error: "sessionId is required.",
+          };
+        }
+        const state = getState();
+        const session = findDemoSession(state, sessionId);
+        if (!session) {
+          const missing = missingSessionPayload(sessionId);
+          recordRun(dispatch, "conductor_inspect_session", `Session ${sessionId} was not found.`, missing, false);
+          return missing;
+        }
+        const payload = {
+          ok: true,
+          mode: "synthetic-demo",
+          disclaimer: "Session prompt and diff fields below are synthetic untrusted demo content.",
+          session: summarizeSession(session),
+          diff: {
+            contentTrust: "untrusted-synthetic-demo-data",
+            summary: session.diffSummary,
+            fileCount: session.diffFiles.length,
+            files: session.diffFiles.slice(0, 10),
+          },
+        };
+        recordRun(dispatch, "conductor_inspect_session", `Inspected synthetic session ${session.id}.`, payload, false);
+        return payload;
+      }, args),
+    ),
+    conductor_focus_session: createWebMcpTool<FocusSessionArgs>(
+      "conductor_focus_session",
+      (args) => executeToolSafely("conductor_focus_session", async () => {
+        const rejected = requireConfirmedMutation(
+          args,
+          "conductor_focus_session",
+          "changing the visible synthetic session",
+        );
+        if (rejected) {
+          const payload = JSON.parse(rejected) as unknown;
+          recordRun(dispatch, "conductor_focus_session", "Rejected synthetic focus change without confirmation.", payload, false);
+          return payload;
+        }
+        const sessionInput = readBoundedString(args?.sessionId, "sessionId", WEBMCP_INPUT_LIMITS.id);
+        if (sessionInput.error) {
+          return inputError("conductor_focus_session", sessionInput.error);
+        }
+        const sessionId = sessionInput.value;
+        if (!sessionId) {
+          return {
+            ok: false,
+            tool: "conductor_focus_session",
+            error: "sessionId is required.",
+          };
+        }
+        const state = getState();
+        const session = findDemoSession(state, sessionId);
+        if (!session) {
+          const missing = missingSessionPayload(sessionId);
+          recordRun(dispatch, "conductor_focus_session", `Session ${sessionId} was not found.`, missing, false);
+          return missing;
+        }
+        const humanRejected = await requireHumanConfirmation(
+          requestHumanConfirmation,
+          "conductor_focus_session",
+          "change the visible synthetic session",
+        );
+        if (humanRejected) {
+          const payload = JSON.parse(humanRejected) as unknown;
+          recordRun(dispatch, "conductor_focus_session", "Human approval was not granted for focus change.", payload, false);
+          return payload;
+        }
+        const timestamp = nowIsoString();
+        dispatch({ type: "focus-session", sessionId: session.id, timestamp });
+        const payload = {
+          ok: true,
+          mode: "synthetic-demo",
+          stateChanged: true,
+          focusedSession: summarizeSession(session),
+        };
+        recordRun(dispatch, "conductor_focus_session", `Focused synthetic session ${session.id}.`, payload, true);
+        return payload;
+      }, args),
+    ),
+    conductor_start_agent: createWebMcpTool<StartAgentArgs>(
+      "conductor_start_agent",
+      (args) => executeToolSafely("conductor_start_agent", async () => {
+        const rejected = requireConfirmedMutation(
+          args,
+          "conductor_start_agent",
+          "creating a new Conductor session",
+        );
+        if (rejected) {
+          const payload = JSON.parse(rejected) as unknown;
+          recordRun(dispatch, "conductor_start_agent", "Rejected synthetic session creation without confirmation.", payload, false);
+          return payload;
+        }
+
+        const projectInput = readBoundedString(args?.projectId, "projectId", WEBMCP_INPUT_LIMITS.id);
+        const promptInput = readBoundedString(args?.prompt, "prompt", WEBMCP_INPUT_LIMITS.prompt);
+        const agentInput = readBoundedString(args?.agent, "agent", WEBMCP_INPUT_LIMITS.agent);
+        const modelInput = readBoundedString(args?.model, "model", WEBMCP_INPUT_LIMITS.model);
+        const reasoningInput = readBoundedString(
+          args?.reasoningEffort,
+          "reasoningEffort",
+          WEBMCP_INPUT_LIMITS.reasoningEffort,
+        );
+        const validationError = projectInput.error
+          ?? promptInput.error
+          ?? agentInput.error
+          ?? modelInput.error
+          ?? reasoningInput.error;
+        if (validationError) {
+          return inputError("conductor_start_agent", validationError);
+        }
+        const projectId = projectInput.value;
+        const prompt = promptInput.value;
+        if (!projectId || !prompt) {
+          return {
+            ok: false,
+            tool: "conductor_start_agent",
+            error: "projectId and prompt are required.",
+          };
+        }
+        const state = getState();
+        const project = findDemoProject(state, projectId);
+        if (!project) {
+          const missing = missingProjectPayload(projectId);
+          recordRun(dispatch, "conductor_start_agent", `Project ${projectId} was not found.`, missing, false);
+          return missing;
+        }
+        const humanRejected = await requireHumanConfirmation(
+          requestHumanConfirmation,
+          "conductor_start_agent",
+          "create a synthetic session",
+        );
+        if (humanRejected) {
+          const payload = JSON.parse(humanRejected) as unknown;
+          recordRun(dispatch, "conductor_start_agent", "Human approval was not granted for session creation.", payload, false);
+          return payload;
+        }
+
+        const timestamp = nowIsoString();
+        dispatch({
+          type: "start-agent",
+          timestamp,
+          projectId: project.id,
+          prompt,
+          agent: agentInput.value,
+        });
+        const nextState = demoStateReducer(state, {
+          type: "start-agent",
+          timestamp,
+          projectId: project.id,
+          prompt,
+          agent: agentInput.value,
+        });
+        const session = findDemoSession(nextState, nextState.selectedSessionId);
+        const payload = {
+          ok: true,
+          mode: "synthetic-demo",
+          disclaimer: "Synthetic only. No real coding agent was launched.",
+          stateChanged: true,
+          session: session ? summarizeSession(session) : null,
+        };
+        recordRun(dispatch, "conductor_start_agent", `Queued synthetic session for ${project.id}.`, payload, true);
+        return payload;
+      }, args),
+    ),
+    conductor_send_feedback: createWebMcpTool<SendFeedbackArgs>(
+      "conductor_send_feedback",
+      (args) => executeToolSafely("conductor_send_feedback", async () => {
+        const rejected = requireConfirmedMutation(
+          args,
+          "conductor_send_feedback",
+          "sending session feedback",
+        );
+        if (rejected) {
+          const payload = JSON.parse(rejected) as unknown;
+          recordRun(dispatch, "conductor_send_feedback", "Rejected synthetic feedback without confirmation.", payload, false);
+          return payload;
+        }
+
+        const sessionInput = readBoundedString(args?.sessionId, "sessionId", WEBMCP_INPUT_LIMITS.id);
+        const feedbackInput = readBoundedString(args?.feedback, "feedback", WEBMCP_INPUT_LIMITS.feedback);
+        if (sessionInput.error || feedbackInput.error) {
+          return inputError(
+            "conductor_send_feedback",
+            sessionInput.error ?? feedbackInput.error ?? "Invalid input.",
+          );
+        }
+        const sessionId = sessionInput.value;
+        const feedback = feedbackInput.value;
+        if (!sessionId || !feedback) {
+          return {
+            ok: false,
+            tool: "conductor_send_feedback",
+            error: "sessionId and feedback are required.",
+          };
+        }
+        const state = getState();
+        const session = findDemoSession(state, sessionId);
+        if (!session) {
+          const missing = missingSessionPayload(sessionId);
+          recordRun(dispatch, "conductor_send_feedback", `Session ${sessionId} was not found.`, missing, false);
+          return missing;
+        }
+        const humanRejected = await requireHumanConfirmation(
+          requestHumanConfirmation,
+          "conductor_send_feedback",
+          "send synthetic session feedback",
+        );
+        if (humanRejected) {
+          const payload = JSON.parse(humanRejected) as unknown;
+          recordRun(dispatch, "conductor_send_feedback", "Human approval was not granted for feedback.", payload, false);
+          return payload;
+        }
+        const timestamp = nowIsoString();
+        dispatch({
+          type: "send-feedback",
+          timestamp,
+          sessionId: session.id,
+          feedback,
+        });
+        const nextState = demoStateReducer(state, {
+          type: "send-feedback",
+          timestamp,
+          sessionId: session.id,
+          feedback,
+        });
+        const updated = findDemoSession(nextState, session.id);
+        const payload = {
+          ok: true,
+          mode: "synthetic-demo",
+          disclaimer: "Synthetic only. This visible update stays in memory and resets on reload.",
+          stateChanged: true,
+          session: updated ? summarizeSession(updated) : summarizeSession(session),
+        };
+        recordRun(dispatch, "conductor_send_feedback", `Sent synthetic feedback to ${session.id}.`, payload, true);
+        return payload;
+      }, args),
+    ),
+  };
+
+  return WEBMCP_TOOL_ORDER.map((toolName) => toolsByName[toolName]);
+}

--- a/packages/web/src/features/webmcp/useWebMcpToolRegistration.ts
+++ b/packages/web/src/features/webmcp/useWebMcpToolRegistration.ts
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  detectWebMcpCompatibility,
+  registerWebMcpTools,
+  type WebMcpCompatibility,
+  type WebMcpToolDefinition,
+} from "@/lib/webmcp";
+
+const UNSUPPORTED_COMPATIBILITY: WebMcpCompatibility = {
+  supported: false,
+  reason: "WebMCP compatibility has not been checked yet.",
+  toolRegistrationAvailable: false,
+  modelContext: null,
+};
+
+export function useWebMcpToolRegistration(tools: WebMcpToolDefinition[]): WebMcpCompatibility {
+  const [compatibility, setCompatibility] = useState<WebMcpCompatibility>(UNSUPPORTED_COMPATIBILITY);
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      setCompatibility({
+        supported: false,
+        reason: "Document context is unavailable.",
+        toolRegistrationAvailable: false,
+        modelContext: null,
+      });
+      return undefined;
+    }
+
+    let stopped = false;
+    let registrationInFlight = false;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let disposeRegistration: (() => void) | null = null;
+
+    const updateCompatibility = (next: WebMcpCompatibility) => {
+      setCompatibility((current) => (
+        current.supported === next.supported
+        && current.reason === next.reason
+        && current.toolRegistrationAvailable === next.toolRegistrationAvailable
+        && current.modelContext === next.modelContext
+          ? current
+          : next
+      ));
+    };
+
+    const scheduleRetry = () => {
+      if (!stopped) {
+        retryTimer = setTimeout(() => void attemptRegistration(), 1_000);
+      }
+    };
+
+    const attemptRegistration = async () => {
+      if (stopped || registrationInFlight || disposeRegistration) {
+        return;
+      }
+      const nextCompatibility = detectWebMcpCompatibility(document, navigator);
+      if (!nextCompatibility.supported || !nextCompatibility.modelContext) {
+        updateCompatibility(nextCompatibility);
+        scheduleRetry();
+        return;
+      }
+
+      registrationInFlight = true;
+      updateCompatibility({
+        ...nextCompatibility,
+        supported: false,
+        reason: "Registering browser-native WebMCP tools.",
+      });
+      try {
+        const dispose = await registerWebMcpTools(nextCompatibility.modelContext, tools);
+        if (stopped) {
+          dispose();
+          return;
+        }
+        disposeRegistration = dispose;
+        updateCompatibility(nextCompatibility);
+      } catch (error) {
+        if (!stopped) {
+          updateCompatibility({
+            supported: false,
+            reason: `WebMCP registration failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+            toolRegistrationAvailable: true,
+            modelContext: nextCompatibility.modelContext,
+          });
+          scheduleRetry();
+        }
+      } finally {
+        registrationInFlight = false;
+      }
+    };
+
+    void attemptRegistration();
+
+    return () => {
+      stopped = true;
+      if (retryTimer) {
+        clearTimeout(retryTimer);
+      }
+      disposeRegistration?.();
+    };
+  }, [tools]);
+
+  return compatibility;
+}

--- a/packages/web/src/lib/webmcp.test.ts
+++ b/packages/web/src/lib/webmcp.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  detectWebMcpCompatibility,
+  readBoundedString,
+  registerWebMcpTools,
+} from "./webmcp";
+
+test("detectWebMcpCompatibility reports missing browser support cleanly", () => {
+  const compatibility = detectWebMcpCompatibility(undefined);
+  assert.equal(compatibility.supported, false);
+  assert.equal(compatibility.modelContext, null);
+  assert.match(compatibility.reason, /Document context is unavailable/i);
+});
+
+test("detectWebMcpCompatibility prefers document and supports the legacy navigator surface", () => {
+  const documentContext = { registerTool() {} };
+  const navigatorContext = { registerTool() {} };
+
+  const preferred = detectWebMcpCompatibility(
+    { modelContext: documentContext },
+    { modelContext: navigatorContext },
+  );
+  const fallback = detectWebMcpCompatibility(
+    {},
+    { modelContext: navigatorContext },
+  );
+
+  assert.equal(preferred.modelContext, documentContext);
+  assert.equal(fallback.supported, true);
+  assert.equal(fallback.modelContext, navigatorContext);
+});
+
+test("registerWebMcpTools waits for every registration and cleanup aborts them", async () => {
+  const registrations: AbortSignal[] = [];
+  const toolNames: string[] = [];
+
+  const dispose = await registerWebMcpTools(
+    {
+      registerTool(tool, options) {
+        toolNames.push(tool.name);
+        registrations.push(options?.signal ?? new AbortController().signal);
+      },
+    },
+    [
+      {
+        name: "tool-a",
+        description: "A",
+        inputSchema: { type: "object", properties: {}, additionalProperties: false },
+        execute: () => "{}",
+      },
+      {
+        name: "tool-b",
+        description: "B",
+        inputSchema: { type: "object", properties: {}, additionalProperties: false },
+        execute: () => "{}",
+      },
+    ],
+  );
+
+  assert.deepEqual(toolNames, ["tool-a", "tool-b"]);
+  assert.equal(registrations.length, 2);
+  assert.equal(registrations[0], registrations[1]);
+  assert.equal(registrations[0]?.aborted, false);
+
+  dispose();
+
+  assert.equal(registrations[0]?.aborted, true);
+});
+
+test("registerWebMcpTools rejects and aborts when one registration fails", async () => {
+  let signal: AbortSignal | undefined;
+  await assert.rejects(
+    registerWebMcpTools(
+      {
+        registerTool(_tool, options) {
+          signal = options?.signal;
+          return Promise.reject(new Error("registration denied"));
+        },
+      },
+      [{
+        name: "tool-a",
+        description: "A",
+        inputSchema: { type: "object", properties: {}, additionalProperties: false },
+        execute: () => "{}",
+      }],
+    ),
+    /registration denied/,
+  );
+  assert.equal(signal?.aborted, true);
+});
+
+test("readBoundedString trims valid input and rejects oversized input", () => {
+  assert.deepEqual(readBoundedString("  valid  ", "prompt", 8), {
+    value: "valid",
+    error: null,
+  });
+  assert.deepEqual(readBoundedString("123456789", "prompt", 8), {
+    value: null,
+    error: "prompt must be at most 8 characters.",
+  });
+});

--- a/packages/web/src/lib/webmcp.ts
+++ b/packages/web/src/lib/webmcp.ts
@@ -1,0 +1,222 @@
+export type JsonSchema = {
+  type?: string;
+  description?: string;
+  properties?: Record<string, JsonSchema>;
+  required?: string[];
+  additionalProperties?: boolean;
+  enum?: string[];
+  minLength?: number;
+  maxLength?: number;
+  minimum?: number;
+  maximum?: number;
+  items?: JsonSchema;
+};
+
+export type WebMcpToolAnnotations = {
+  readOnlyHint?: boolean;
+  untrustedContentHint?: boolean;
+};
+
+export type WebMcpExecutionContext = {
+  signal?: AbortSignal;
+};
+
+export type WebMcpToolDefinition<TArgs = unknown> = {
+  name: string;
+  description: string;
+  inputSchema: JsonSchema;
+  annotations?: WebMcpToolAnnotations;
+  execute(args: TArgs, context?: WebMcpExecutionContext): Promise<string> | string;
+};
+
+export type WebMcpRegistrationOptions = {
+  signal?: AbortSignal;
+};
+
+export type WebMcpModelContext = {
+  registerTool: (
+    tool: WebMcpToolDefinition,
+    options?: WebMcpRegistrationOptions,
+  ) => void | Promise<void>;
+};
+
+export type WebMcpCompatibility = {
+  supported: boolean;
+  reason: string;
+  toolRegistrationAvailable: boolean;
+  modelContext: WebMcpModelContext | null;
+};
+
+declare global {
+  interface Document {
+    modelContext?: WebMcpModelContext;
+  }
+
+  interface Navigator {
+    modelContext?: WebMcpModelContext;
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Unknown error";
+}
+
+export function jsonToolResult(payload: unknown): string {
+  return JSON.stringify(payload, null, 2);
+}
+
+export type BoundedStringResult = {
+  value: string | null;
+  error: string | null;
+};
+
+export function readBoundedString(
+  value: unknown,
+  fieldName: string,
+  maxLength: number,
+): BoundedStringResult {
+  if (typeof value !== "string") {
+    return { value: null, error: null };
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return { value: null, error: null };
+  }
+  if (trimmed.length > maxLength) {
+    return {
+      value: null,
+      error: `${fieldName} must be at most ${maxLength} characters.`,
+    };
+  }
+  return { value: trimmed, error: null };
+}
+
+export function detectWebMcpCompatibility(
+  doc?: Pick<Document, "modelContext">,
+  nav?: Pick<Navigator, "modelContext">,
+): WebMcpCompatibility {
+  if (!doc) {
+    return {
+      supported: false,
+      reason: "Document context is unavailable.",
+      toolRegistrationAvailable: false,
+      modelContext: null,
+    };
+  }
+
+  const modelContext = doc.modelContext ?? nav?.modelContext;
+  if (!modelContext) {
+    return {
+      supported: false,
+      reason: "document.modelContext and legacy navigator.modelContext are unavailable in this browser build.",
+      toolRegistrationAvailable: false,
+      modelContext: null,
+    };
+  }
+
+  if (typeof modelContext.registerTool !== "function") {
+    return {
+      supported: false,
+      reason: "document.modelContext.registerTool is unavailable in this browser build.",
+      toolRegistrationAvailable: false,
+      modelContext: null,
+    };
+  }
+
+  return {
+    supported: true,
+    reason: "Browser-native WebMCP tool registration is available.",
+    toolRegistrationAvailable: true,
+    modelContext,
+  };
+}
+
+export async function registerWebMcpTools(
+  modelContext: WebMcpModelContext,
+  tools: WebMcpToolDefinition[],
+): Promise<() => void> {
+  const controller = new AbortController();
+  try {
+    await Promise.all(tools.map((tool) => modelContext.registerTool(tool, { signal: controller.signal })));
+  } catch (error) {
+    controller.abort(error);
+    throw error;
+  }
+
+  return () => {
+    controller.abort(new Error("WebMCP tool registration disposed."));
+  };
+}
+
+export function confirmedMutationRejected(
+  toolName: string,
+  effect: string,
+): string {
+  return jsonToolResult({
+    ok: false,
+    tool: toolName,
+    error: `Rejected because ${effect} requires confirmed: true.`,
+    requiresConfirmation: true,
+  });
+}
+
+export function requireConfirmedMutation(
+  args: { confirmed?: boolean } | null | undefined,
+  toolName: string,
+  effect: string,
+): string | null {
+  if (args?.confirmed === true) {
+    return null;
+  }
+  return confirmedMutationRejected(toolName, effect);
+}
+
+export type HumanConfirmationRequest = {
+  toolName: string;
+  effect: string;
+};
+
+export type HumanConfirmationHandler = (
+  request: HumanConfirmationRequest,
+) => boolean | Promise<boolean>;
+
+export function browserHumanConfirmation(request: HumanConfirmationRequest): boolean {
+  if (typeof globalThis.confirm !== "function") {
+    return false;
+  }
+  return globalThis.confirm(
+    `Conductor WebMCP wants to ${request.effect}. Approve this one action?`,
+  );
+}
+
+export async function requireHumanConfirmation(
+  handler: HumanConfirmationHandler,
+  toolName: string,
+  effect: string,
+): Promise<string | null> {
+  if (await handler({ toolName, effect })) {
+    return null;
+  }
+  return jsonToolResult({
+    ok: false,
+    tool: toolName,
+    error: `Rejected because a person did not approve ${effect}.`,
+    requiresHumanApproval: true,
+  });
+}
+
+export async function executeToolSafely<TArgs>(
+  toolName: string,
+  handler: (args: TArgs) => Promise<unknown> | unknown,
+  args: TArgs,
+): Promise<string> {
+  try {
+    return jsonToolResult(await handler(args));
+  } catch (error) {
+    return jsonToolResult({
+      ok: false,
+      tool: toolName,
+      error: errorMessage(error),
+    });
+  }
+}

--- a/packages/web/src/lib/webmcpTools.test.ts
+++ b/packages/web/src/lib/webmcpTools.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { requireConfirmedMutation } from "./webmcp";
+import { WEBMCP_TOOL_ORDER, WEBMCP_TOOL_SPECS } from "./webmcpTools";
+
+test("WebMCP tool catalog keeps the required shared tool names in a stable order", () => {
+  assert.deepEqual(WEBMCP_TOOL_ORDER, [
+    "conductor_get_workspace_overview",
+    "conductor_list_projects",
+    "conductor_list_sessions",
+    "conductor_inspect_session",
+    "conductor_focus_session",
+    "conductor_start_agent",
+    "conductor_send_feedback",
+  ]);
+});
+
+test("read-only tools advertise readOnlyHint and bounded schemas", () => {
+  for (const toolName of [
+    "conductor_get_workspace_overview",
+    "conductor_list_projects",
+    "conductor_list_sessions",
+    "conductor_inspect_session",
+  ] as const) {
+    const spec = WEBMCP_TOOL_SPECS[toolName];
+    assert.equal(spec.annotations?.readOnlyHint, true);
+    assert.equal(spec.inputSchema.type, "object");
+    assert.equal(spec.inputSchema.additionalProperties, false);
+  }
+});
+
+test("mutating tool schemas require confirmed and keep additionalProperties disabled", () => {
+  for (const toolName of ["conductor_focus_session", "conductor_start_agent", "conductor_send_feedback"] as const) {
+    const spec = WEBMCP_TOOL_SPECS[toolName];
+    assert.equal(spec.inputSchema.type, "object");
+    assert.equal(spec.inputSchema.additionalProperties, false);
+    assert.ok(spec.inputSchema.required?.includes("confirmed"));
+  }
+  assert.equal(WEBMCP_TOOL_SPECS.conductor_list_sessions.inputSchema.properties?.limit?.maximum, 12);
+  assert.equal(WEBMCP_TOOL_SPECS.conductor_start_agent.inputSchema.properties?.prompt?.maxLength, 4_000);
+  assert.equal(WEBMCP_TOOL_SPECS.conductor_send_feedback.inputSchema.properties?.feedback?.maxLength, 4_000);
+});
+
+test("requireConfirmedMutation returns a structured JSON rejection", () => {
+  const rejected = requireConfirmedMutation(
+    { confirmed: false },
+    "conductor_start_agent",
+    "creating a real dashboard session",
+  );
+  assert.ok(rejected);
+  const payload = JSON.parse(rejected ?? "{}") as {
+    ok?: boolean;
+    tool?: string;
+    requiresConfirmation?: boolean;
+    error?: string;
+  };
+  assert.equal(payload.ok, false);
+  assert.equal(payload.tool, "conductor_start_agent");
+  assert.equal(payload.requiresConfirmation, true);
+  assert.match(payload.error ?? "", /confirmed: true/);
+});

--- a/packages/web/src/lib/webmcpTools.ts
+++ b/packages/web/src/lib/webmcpTools.ts
@@ -1,0 +1,181 @@
+import type { JsonSchema, WebMcpToolAnnotations, WebMcpToolDefinition } from "@/lib/webmcp";
+
+export type WebMcpToolName =
+  | "conductor_get_workspace_overview"
+  | "conductor_list_projects"
+  | "conductor_list_sessions"
+  | "conductor_inspect_session"
+  | "conductor_focus_session"
+  | "conductor_start_agent"
+  | "conductor_send_feedback";
+
+type WebMcpToolSpec = {
+  name: WebMcpToolName;
+  description: string;
+  inputSchema: JsonSchema;
+  annotations?: WebMcpToolAnnotations;
+};
+
+const EMPTY_OBJECT_SCHEMA: JsonSchema = {
+  type: "object",
+  properties: {},
+  required: [],
+  additionalProperties: false,
+};
+
+const OPTIONAL_LIMIT_SCHEMA: JsonSchema = {
+  type: "integer",
+  minimum: 1,
+  maximum: 25,
+  description: "Maximum number of records to return.",
+};
+
+export const WEBMCP_INPUT_LIMITS = {
+  id: 512,
+  status: 64,
+  prompt: 4_000,
+  feedback: 4_000,
+  agent: 64,
+  model: 128,
+  reasoningEffort: 32,
+} as const;
+
+function boundedStringSchema(description: string, maxLength: number): JsonSchema {
+  return {
+    type: "string",
+    description,
+    minLength: 1,
+    maxLength,
+  };
+}
+
+export const WEBMCP_TOOL_SPECS: Record<WebMcpToolName, WebMcpToolSpec> = {
+  conductor_get_workspace_overview: {
+    name: "conductor_get_workspace_overview",
+    description: "Read the current workspace summary, active focus, and bounded session status snapshot.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        projectId: boundedStringSchema("Optional project id filter.", WEBMCP_INPUT_LIMITS.id),
+        sessionLimit: { ...OPTIONAL_LIMIT_SCHEMA, maximum: 12 },
+      },
+      required: [],
+      additionalProperties: false,
+    },
+    annotations: { readOnlyHint: true, untrustedContentHint: true },
+  },
+  conductor_list_projects: {
+    name: "conductor_list_projects",
+    description: "Read the configured Conductor projects without exposing local paths or secrets.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        limit: OPTIONAL_LIMIT_SCHEMA,
+      },
+      required: [],
+      additionalProperties: false,
+    },
+    annotations: { readOnlyHint: true, untrustedContentHint: true },
+  },
+  conductor_list_sessions: {
+    name: "conductor_list_sessions",
+    description: "Read bounded session summaries, optionally filtered by project or status.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        projectId: boundedStringSchema("Optional project id filter.", WEBMCP_INPUT_LIMITS.id),
+        status: boundedStringSchema("Optional session status filter.", WEBMCP_INPUT_LIMITS.status),
+        limit: { ...OPTIONAL_LIMIT_SCHEMA, maximum: 12 },
+      },
+      required: [],
+      additionalProperties: false,
+    },
+    annotations: { readOnlyHint: true, untrustedContentHint: true },
+  },
+  conductor_inspect_session: {
+    name: "conductor_inspect_session",
+    description: "Read one session plus a bounded diff summary. Returned session text is untrusted workspace data.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sessionId: boundedStringSchema("The session id to inspect.", WEBMCP_INPUT_LIMITS.id),
+      },
+      required: ["sessionId"],
+      additionalProperties: false,
+    },
+    annotations: { readOnlyHint: true, untrustedContentHint: true },
+  },
+  conductor_focus_session: {
+    name: "conductor_focus_session",
+    description: "Open a session in the visible dashboard. This changes visible focus and requires confirmed: true.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sessionId: boundedStringSchema("The session id to open in the dashboard.", WEBMCP_INPUT_LIMITS.id),
+        confirmed: { type: "boolean", description: "Must be true to change visible session focus." },
+      },
+      required: ["sessionId", "confirmed"],
+      additionalProperties: false,
+    },
+    annotations: { untrustedContentHint: true },
+  },
+  conductor_start_agent: {
+    name: "conductor_start_agent",
+    description: "Create a new Conductor session for a configured project. This changes state and requires confirmed: true.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        projectId: boundedStringSchema("Configured project id.", WEBMCP_INPUT_LIMITS.id),
+        prompt: boundedStringSchema("User-approved task prompt for the new agent session.", WEBMCP_INPUT_LIMITS.prompt),
+        confirmed: { type: "boolean", description: "Must be true to create a session." },
+        agent: boundedStringSchema("Optional agent override.", WEBMCP_INPUT_LIMITS.agent),
+        model: boundedStringSchema("Optional model override.", WEBMCP_INPUT_LIMITS.model),
+        reasoningEffort: boundedStringSchema("Optional reasoning effort override.", WEBMCP_INPUT_LIMITS.reasoningEffort),
+      },
+      required: ["projectId", "prompt", "confirmed"],
+      additionalProperties: false,
+    },
+    annotations: { untrustedContentHint: true },
+  },
+  conductor_send_feedback: {
+    name: "conductor_send_feedback",
+    description: "Send follow-up feedback into an existing session. This changes state and requires confirmed: true.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sessionId: boundedStringSchema("Target session id.", WEBMCP_INPUT_LIMITS.id),
+        feedback: boundedStringSchema("Human-approved feedback message.", WEBMCP_INPUT_LIMITS.feedback),
+        confirmed: { type: "boolean", description: "Must be true to send feedback." },
+      },
+      required: ["sessionId", "feedback", "confirmed"],
+      additionalProperties: false,
+    },
+    annotations: { untrustedContentHint: true },
+  },
+};
+
+export const WEBMCP_TOOL_ORDER: WebMcpToolName[] = [
+  "conductor_get_workspace_overview",
+  "conductor_list_projects",
+  "conductor_list_sessions",
+  "conductor_inspect_session",
+  "conductor_focus_session",
+  "conductor_start_agent",
+  "conductor_send_feedback",
+];
+
+export const EMPTY_WEBMCP_SCHEMA = EMPTY_OBJECT_SCHEMA;
+
+export function createWebMcpTool<TArgs>(
+  name: WebMcpToolName,
+  execute: WebMcpToolDefinition<TArgs>["execute"],
+): WebMcpToolDefinition<TArgs> {
+  const spec = WEBMCP_TOOL_SPECS[name];
+  return {
+    name: spec.name,
+    description: spec.description,
+    inputSchema: spec.inputSchema,
+    annotations: spec.annotations,
+    execute,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a browser-native WebMCP extension to Conductor OSS with seven bounded tools for projects, sessions, diffs, visible focus, agent starts, and feedback. It also adds a public synthetic `/webmcp` demo so judges can discover and invoke the tools without private repositories, local runtimes, or credentials.

## User-Facing Release Notes

- You can now expose Conductor projects, sessions, and bounded diff summaries to browser agents through seven browser-native WebMCP tools.
- State-changing WebMCP actions now require both `confirmed: true` and a separate browser-level human approval.
- A public synthetic `/webmcp` workspace demonstrates discovery, invocation, fallback behavior, and visible tool activity without touching real agent sessions.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Agent or integration addition / modification
- [x] Documentation update
- [ ] Breaking change
- [ ] Refactor / chore

## Checklist

- [x] `bun run build:frontend` passes for frontend changes
- [x] `bun run typecheck` passes for TypeScript changes
- [x] `bun run test:packages` passes for package changes
- [x] `cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` pass
- [x] No `any` types introduced
- [x] No secrets or credentials committed
- [x] Security boundaries, authentication, persistence, and network behavior have regression tests when changed
- [x] User-facing release notes are filled in plain English
- [x] PR title follows conventional commits

## Testing

```bash
bun run build:frontend
bun run typecheck
bun run test:packages
cargo fmt --all -- --check
cargo test --workspace
cargo clippy --workspace --all-targets -- -D warnings
```

Verified in a real browser at desktop and 390 px mobile widths. Simulated the current `document.modelContext.registerTool` surface and confirmed all seven tools register with live abort signals. Invoked a read-only overview tool, verified an unconfirmed mutation is rejected, and approved a focus mutation that visibly updated the synthetic workspace. The page also remains fully usable in fallback mode when WebMCP is unavailable.

## Screenshots / Demo

- Challenge route: `/webmcp`
- Public deployment and demo video will be added after the preview deployment is available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a WebMCP demo for exploring projects, sessions, diffs, timelines, and tool activity.
  * Added browser-native tools for workspace inspection, session management, agent startup, and feedback.
  * Added dashboard integration with session navigation and refresh support.
  * Added confirmation safeguards for actions that change state.
  * Added a protected session feedback endpoint.
* **Documentation**
  * Added WebMCP challenge specifications, usage guidance, demo links, and technical notes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->