### PR TITLE
fix: satisfy Rust 1.98 Clippy

### DIFF
--- a/crates/conductor-core/src/paths.rs
+++ b/crates/conductor-core/src/paths.rs
@@ -329,8 +329,8 @@ fn sha256(input: &[u8]) -> [u8; 32] {
     padded.extend_from_slice(&bit_len.to_be_bytes());
 
     let mut schedule = [0u32; 64];
-    for chunk in padded.chunks_exact(64) {
-        for (index, word) in chunk.chunks_exact(4).take(16).enumerate() {
+    for chunk in padded.as_chunks::<64>().0 {
+        for (index, word) in chunk.as_chunks::<4>().0.iter().enumerate() {
             schedule[index] = u32::from_be_bytes([word[0], word[1], word[2], word[3]]);
         }
         for index in 16..64 {

--- a/crates/conductor-executors/src/agents/openclaw.rs
+++ b/crates/conductor-executors/src/agents/openclaw.rs
@@ -1395,12 +1395,7 @@ fn gateway_scope_key(url: &Url, scopes: &[String]) -> String {
 }
 
 fn platform_name() -> &'static str {
-    match env::consts::OS {
-        "macos" => "macos",
-        "windows" => "windows",
-        "linux" => "linux",
-        other => other,
-    }
+    env::consts::OS
 }
 
 fn locale_name() -> String {

--- a/crates/conductor-relay/src/relay.rs
+++ b/crates/conductor-relay/src/relay.rs
@@ -2130,7 +2130,7 @@ async fn browser_ws(
     let (bridge_key, user_id) =
         match resolve_browser_connection(&scope, &headers, query.token.as_deref()).await {
             Ok(value) => value,
-            Err(response) => return response,
+            Err(response) => return *response,
         };
 
     ws.max_message_size(MAX_WS_MESSAGE_BYTES)
@@ -2215,21 +2215,25 @@ async fn resolve_browser_connection(
     scope: &str,
     headers: &HeaderMap,
     token: Option<&str>,
-) -> Result<(String, String), Response> {
+) -> Result<(String, String), Box<Response>> {
     let Some(jwt) = resolve_token(headers, token) else {
-        return Err((
-            StatusCode::UNAUTHORIZED,
-            Json(json!({ "error": "Missing bridge relay token." })),
-        )
-            .into_response());
+        return Err(Box::new(
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({ "error": "Missing bridge relay token." })),
+            )
+                .into_response(),
+        ));
     };
 
     let Some(user_id) = decode_relay_user_id(&jwt, RELAY_JWT_SCOPE_DASHBOARD_API).ok() else {
-        return Err((
-            StatusCode::UNAUTHORIZED,
-            Json(json!({ "error": "Invalid bridge relay token." })),
-        )
-            .into_response());
+        return Err(Box::new(
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({ "error": "Invalid bridge relay token." })),
+            )
+                .into_response(),
+        ));
     };
 
     Ok((scope.trim().to_string(), user_id))


### PR DESCRIPTION
## Summary

Updates three pre-existing Rust patterns for Clippy 1.98 so the repository's warnings-denied CI gate remains green. The changes use fixed-size slice chunks, remove a redundant OS match, and box one large HTTP error response without changing behavior.

## User-Facing Release Notes

N/A - internal maintenance only

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Agent or integration addition / modification
- [ ] Documentation update
- [x] Refactor / chore

## Checklist

- [x] `cargo +1.98.0 fmt --all -- --check` passes
- [x] `cargo +1.98.0 clippy --workspace --all-targets -- -D warnings` passes
- [x] Targeted conductor-core, conductor-executors, and conductor-relay tests pass
- [x] No secrets or credentials committed
- [x] PR title follows conventional commits

## Testing

```bash
cargo +1.98.0 fmt --all -- --check
cargo +1.98.0 clippy --workspace --all-targets -- -D warnings
cargo +1.98.0 test -p conductor-core -p conductor-executors -p conductor-relay
```

Result: 256 tests passed, 3 environment-dependent tests ignored, 0 failed.
